### PR TITLE
Add demo recording pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ test-results/
 .env
 packages/docs/.vitepress/cache/
 packages/docs/.vitepress/dist/
+docs/.vitepress/cache/
+demos/output/

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,148 @@
+# Demo Recording Pipeline
+
+Automated recording of OpenPencil user scenarios with fake cursor, text annotations, and FFmpeg post-production.
+
+## Prerequisites
+
+- [Playwright](https://playwright.dev/) — already installed with the project
+- [FFmpeg](https://ffmpeg.org/) — for video conversion
+
+```bash
+# Install ffmpeg
+brew install ffmpeg        # macOS
+sudo apt install ffmpeg    # Ubuntu/Debian
+
+# Verify
+ffmpeg -version
+```
+
+## Recording
+
+Start the dev server first, then record a scenario:
+
+```bash
+# Terminal 1: start dev server
+bun run dev
+
+# Terminal 2: record a scenario
+bun demo:record create-shapes
+bun demo:record layers-panel
+bun demo:record color-picker
+```
+
+The browser opens in headed mode, runs the scenario with fake cursor + annotations, and saves a `.webm` file to `demos/output/recordings/`.
+
+### Dry-run mode
+
+Debug cursor movements and annotations without recording video:
+
+```bash
+bun demo:record create-shapes --dry-run
+```
+
+## Converting
+
+Convert a recorded `.webm` to MP4 and GIF:
+
+```bash
+bun demo:convert demos/output/recordings/<file>.webm create-shapes
+```
+
+Output goes to `demos/output/final/`:
+- `create-shapes.mp4` — H.264, suitable for embedding
+- `create-shapes.gif` — 640px wide, optimized palette
+
+### Duration guidelines
+
+- **GIF**: keep scenarios under 30 seconds (file size target: <5MB)
+- **MP4**: keep under 2 minutes for documentation, shorter for social media
+
+## Creating Scenarios
+
+Each scenario is a TypeScript file in `demos/scenarios/` that exports a `DemoScenario`:
+
+```typescript
+import type { DemoScenario } from '../scripts/record'
+
+const scenario: DemoScenario = {
+  name: 'My Feature Demo',
+
+  async run(r) {
+    // Show annotation, then draw a shape
+    await r.annotate('Press R for Rectangle tool')
+    await r.selectTool('rectangle')
+    await r.clearAnnotation()
+
+    await r.annotate('Click and drag to draw')
+    await r.drawRect(200, 150, 300, 200)
+    await r.clearAnnotation()
+
+    // Zoom in to see detail
+    await r.zoomIn(2)
+
+    // Click with ripple effect
+    await r.clickCanvas(350, 250, { showRipple: true })
+
+    // Annotation at top (useful when demonstrating bottom UI)
+    await r.annotate('Properties panel shows fill options', 'top')
+    await r.sleep(1500)
+    await r.clearAnnotation()
+
+    // Zoom to fit before ending
+    await r.zoomToFit()
+  },
+}
+
+export default scenario
+```
+
+### DemoRecorder API
+
+| Method | Description |
+|--------|-------------|
+| `annotate(text, position?)` | Show annotation (`'bottom'` or `'top'`) |
+| `clearAnnotation()` | Hide current annotation |
+| `drawRect(x, y, w, h, annotation?)` | Draw rectangle with optional annotation |
+| `drawEllipse(x, y, w, h, annotation?)` | Draw ellipse with optional annotation |
+| `selectTool(tool, annotation?)` | Switch tool (`'select'`, `'rectangle'`, `'ellipse'`, `'text'`, `'pen'`, `'frame'`, `'hand'`) |
+| `clickCanvas(x, y, options?)` | Click on canvas coordinates with fake cursor |
+| `clickLocator(locator, options?)` | Click on Playwright locator with fake cursor |
+| `drag(fromX, fromY, toX, toY)` | Drag on canvas with fake cursor |
+| `pressKey(key)` | Press keyboard key |
+| `type(text, delay?)` | Type text character by character |
+| `zoomIn(factor?)` | Smooth zoom in (default 1.5x) |
+| `zoomOut(factor?)` | Smooth zoom out (default 1.5x) |
+| `smoothZoom(targetZoom, durationMs?)` | Zoom to exact level with animation |
+| `zoomToFit()` | Fit all content in view |
+| `sleep(ms)` | Pause for timing |
+
+Click options: `{ showRipple: true }` adds a visual ripple effect at click point.
+
+## Troubleshooting
+
+### ffmpeg not found
+
+Install via package manager (see Prerequisites). The convert script checks for ffmpeg and shows installation commands if missing.
+
+### GIF >5MB
+
+The convert script fails if GIF exceeds 5MB. To fix:
+- **Shorten the scenario** — keep under 30 seconds
+- **Edit `convert.sh`** — reduce `fps=15` to `fps=10`, or `scale=640` to `scale=480`
+- **Crop** — add FFmpeg crop filter to remove empty space
+
+### CanvasKit rendering issues
+
+Demos run in headed mode with real GPU by default. If you see rendering artifacts:
+- Ensure your GPU drivers are up to date
+- Try with `--enable-unsafe-swiftshader` in browser launch args (software rendering, slower)
+
+### Cleanup
+
+Recorded `.webm` files accumulate in `demos/output/recordings/`. Delete after converting:
+
+```bash
+rm -rf demos/output/recordings/*
+```
+
+The `demos/output/` directory is gitignored.

--- a/demos/scenarios/color-picker.ts
+++ b/demos/scenarios/color-picker.ts
@@ -1,0 +1,54 @@
+import type { DemoScenario } from '../scripts/record'
+
+const scenario: DemoScenario = {
+  name: 'Color Picker',
+
+  async run(r) {
+    await r.annotate('Draw a rectangle to work with')
+    await r.sleep(800)
+    await r.drawRect(300, 200, 250, 200)
+    await r.clearAnnotation()
+
+    await r.sleep(800)
+
+    await r.annotate('Select the shape')
+    await r.sleep(500)
+    await r.selectTool('select')
+    await r.clickCanvas(425, 300, { showRipple: true })
+    await r.clearAnnotation()
+
+    await r.sleep(800)
+
+    const fillSwatch = r.page.locator('.size-5.shrink-0.cursor-pointer.rounded.border').first()
+
+    if ((await fillSwatch.count()) > 0) {
+      await r.annotate('Click the fill color swatch to open Color Picker')
+      await r.sleep(800)
+      await r.clickLocator(fillSwatch, { showRipple: true })
+      await r.sleep(500)
+      await r.clearAnnotation()
+
+      await r.sleep(800)
+
+      const hexInput = r.page.locator('input[maxlength="6"]').first()
+
+      if ((await hexInput.count()) > 0) {
+        await r.annotate('Type a hex color value')
+        await r.sleep(800)
+        await r.clickLocator(hexInput, { showRipple: true })
+        await hexInput.fill('4285F4')
+        await hexInput.dispatchEvent('change')
+        await r.sleep(500)
+        await r.clearAnnotation()
+      }
+    } else {
+      await r.annotate('Color picker opens from the properties panel')
+      await r.sleep(2000)
+      await r.clearAnnotation()
+    }
+
+    await r.sleep(1500)
+  },
+}
+
+export default scenario

--- a/demos/scenarios/create-shapes.ts
+++ b/demos/scenarios/create-shapes.ts
@@ -1,0 +1,48 @@
+import type { DemoScenario } from '../scripts/record'
+
+const scenario: DemoScenario = {
+  name: 'Create Shapes',
+
+  async run(r) {
+    await r.annotate('Press R to select the Rectangle tool')
+    await r.sleep(1000)
+    await r.selectTool('rectangle')
+    await r.clearAnnotation()
+
+    await r.annotate('Click and drag to draw a rectangle')
+    await r.sleep(500)
+    await r.drawRect(200, 150, 300, 200)
+    await r.sleep(500)
+    await r.clearAnnotation()
+
+    await r.sleep(800)
+
+    await r.annotate('Press O to select the Ellipse tool')
+    await r.sleep(1000)
+    await r.selectTool('ellipse')
+    await r.clearAnnotation()
+
+    await r.annotate('Click and drag to draw an ellipse')
+    await r.sleep(500)
+    await r.drawEllipse(600, 150, 250, 200)
+    await r.sleep(500)
+    await r.clearAnnotation()
+
+    await r.sleep(800)
+
+    await r.annotate('Press V to switch to Select tool')
+    await r.sleep(1000)
+    await r.selectTool('select')
+    await r.clearAnnotation()
+
+    await r.annotate('Click and drag to move a shape')
+    await r.sleep(500)
+    await r.drag(350, 250, 350, 400)
+    await r.sleep(500)
+    await r.clearAnnotation()
+
+    await r.sleep(1500)
+  },
+}
+
+export default scenario

--- a/demos/scenarios/layers-panel.ts
+++ b/demos/scenarios/layers-panel.ts
@@ -1,0 +1,49 @@
+import type { DemoScenario } from '../scripts/record'
+
+const scenario: DemoScenario = {
+  name: 'Layers Panel',
+
+  async run(r) {
+    await r.annotate('Draw some shapes to populate the layers panel')
+    await r.sleep(800)
+    await r.drawRect(200, 200, 200, 150)
+    await r.drawEllipse(500, 200, 180, 180)
+    await r.clearAnnotation()
+
+    await r.sleep(800)
+
+    await r.annotate('Layers panel shows all created objects')
+    await r.sleep(2000)
+    await r.clearAnnotation()
+
+    await r.sleep(500)
+
+    const layerRow = r.page.locator('[data-node-id]').first()
+
+    await r.annotate('Click a layer to select it')
+    await r.sleep(800)
+    await r.clickLocator(layerRow, { showRipple: true })
+    await r.sleep(800)
+    await r.clearAnnotation()
+
+    await r.sleep(800)
+
+    await r.annotate('Select a shape and press Backspace to delete')
+    await r.sleep(800)
+    await r.clickCanvas(300, 275)
+    await r.sleep(300)
+    await r.pressKey('Backspace')
+    await r.clearAnnotation()
+
+    await r.sleep(500)
+
+    await r.annotate('Press ⌘+Z to undo')
+    await r.sleep(800)
+    await r.canvas.undo()
+    await r.clearAnnotation()
+
+    await r.sleep(1500)
+  },
+}
+
+export default scenario

--- a/demos/scripts/annotations.ts
+++ b/demos/scripts/annotations.ts
@@ -1,0 +1,211 @@
+import type { Page, Locator } from '@playwright/test'
+
+const CURSOR_ID = 'demo-cursor'
+const RIPPLE_ID = 'demo-ripple'
+const ANNOTATION_ID = 'demo-annotation'
+const TRANSITION_MS = 400
+
+function sleep(ms: number) {
+  return new Promise<void>((r) => setTimeout(r, ms))
+}
+
+export async function ensureCursor(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ id, ms }) => {
+      if (document.getElementById(id)) return
+      const cursor = document.createElement('div')
+      cursor.id = id
+      cursor.innerHTML = `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M5 3L19 12L12 13L9 20L5 3Z" fill="white" stroke="black" stroke-width="1.5" stroke-linejoin="round"/>
+    </svg>`
+      Object.assign(cursor.style, {
+        position: 'fixed',
+        top: '0px',
+        left: '0px',
+        width: '24px',
+        height: '24px',
+        zIndex: '999999',
+        pointerEvents: 'none',
+        transition: `top ${ms}ms ease, left ${ms}ms ease`,
+        filter: 'drop-shadow(0 2px 4px rgba(0,0,0,0.3))',
+      })
+      document.body.appendChild(cursor)
+
+      document.addEventListener('mousemove', (e) => {
+        cursor.style.transition = 'none'
+        cursor.style.top = `${e.clientY}px`
+        cursor.style.left = `${e.clientX}px`
+      })
+    },
+    { id: CURSOR_ID, ms: TRANSITION_MS },
+  )
+}
+
+export async function moveCursorTo(page: Page, x: number, y: number): Promise<void> {
+  await ensureCursor(page)
+  await page.evaluate(
+    ({ id, x, y, ms }) => {
+      const cursor = document.getElementById(id)
+      if (cursor) {
+        cursor.style.transition = `top ${ms}ms ease, left ${ms}ms ease`
+        cursor.style.top = `${y}px`
+        cursor.style.left = `${x}px`
+      }
+    },
+    { id: CURSOR_ID, x, y, ms: TRANSITION_MS },
+  )
+  await sleep(TRANSITION_MS + 50)
+}
+
+export interface DemoClickOptions {
+  showRipple?: boolean
+}
+
+export async function demoClick(
+  page: Page,
+  locator: Locator,
+  options: DemoClickOptions = {},
+): Promise<void> {
+  const box = await locator.boundingBox()
+  if (box) {
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+    await moveCursorTo(page, cx, cy)
+
+    if (options.showRipple) {
+      await showRipple(page, cx, cy)
+    }
+  }
+  await locator.click()
+}
+
+export async function demoClickXY(
+  page: Page,
+  x: number,
+  y: number,
+  options: DemoClickOptions = {},
+): Promise<void> {
+  await moveCursorTo(page, x, y)
+
+  if (options.showRipple) {
+    await showRipple(page, x, y)
+  }
+
+  await page.mouse.click(x, y)
+}
+
+async function showRipple(page: Page, x: number, y: number): Promise<void> {
+  await page.evaluate(
+    ({ id, x, y }) => {
+      const existing = document.getElementById(id)
+      if (existing) existing.remove()
+
+      const ripple = document.createElement('div')
+      ripple.id = id
+      Object.assign(ripple.style, {
+        position: 'fixed',
+        top: `${y - 15}px`,
+        left: `${x - 15}px`,
+        width: '30px',
+        height: '30px',
+        borderRadius: '50%',
+        background: 'rgba(66, 133, 244, 0.4)',
+        zIndex: '999998',
+        pointerEvents: 'none',
+        animation: 'demo-ripple-anim 600ms ease-out forwards',
+      })
+
+      if (!document.getElementById('demo-ripple-style')) {
+        const style = document.createElement('style')
+        style.id = 'demo-ripple-style'
+        style.textContent = `
+          @keyframes demo-ripple-anim {
+            0% { transform: scale(0.5); opacity: 1; }
+            100% { transform: scale(2); opacity: 0; }
+          }
+        `
+        document.head.appendChild(style)
+      }
+
+      document.body.appendChild(ripple)
+      setTimeout(() => ripple.remove(), 600)
+    },
+    { id: RIPPLE_ID, x, y },
+  )
+}
+
+export async function hideCursor(page: Page): Promise<void> {
+  await page.evaluate((id) => {
+    const cursor = document.getElementById(id)
+    if (cursor) cursor.style.display = 'none'
+  }, CURSOR_ID)
+}
+
+export type AnnotationPosition = 'top' | 'bottom'
+
+export async function showAnnotation(
+  page: Page,
+  text: string,
+  position: AnnotationPosition = 'top',
+): Promise<void> {
+  await page.evaluate(
+    ({ id, text, position, ms }) => {
+      if (!document.getElementById('demo-fira-font')) {
+        const link = document.createElement('link')
+        link.id = 'demo-fira-font'
+        link.rel = 'stylesheet'
+        link.href = 'https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;500&display=swap'
+        document.head.appendChild(link)
+      }
+
+      if (!document.getElementById('demo-annotation-style')) {
+        const style = document.createElement('style')
+        style.id = 'demo-annotation-style'
+        style.textContent = `
+          @keyframes demo-fade-in { from { opacity: 0; transform: translateX(-50%) translateY(8px); } to { opacity: 1; transform: translateX(-50%) translateY(0); } }
+          @keyframes demo-fade-out { from { opacity: 1; transform: translateX(-50%) translateY(0); } to { opacity: 0; transform: translateX(-50%) translateY(8px); } }
+        `
+        document.head.appendChild(style)
+      }
+
+      const existing = document.getElementById(id)
+      if (existing) existing.remove()
+
+      const el = document.createElement('div')
+      el.id = id
+      el.textContent = text
+      Object.assign(el.style, {
+        position: 'fixed',
+        [position === 'top' ? 'top' : 'bottom']: '32px',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        background: 'rgba(15, 15, 15, 0.88)',
+        color: '#ffffff',
+        fontFamily: "'Fira Sans', sans-serif",
+        fontSize: '18px',
+        fontWeight: '500',
+        padding: '12px 24px',
+        borderRadius: '8px',
+        zIndex: '999998',
+        pointerEvents: 'none',
+        animation: `demo-fade-in ${ms}ms ease forwards`,
+        whiteSpace: 'nowrap',
+      })
+      document.body.appendChild(el)
+    },
+    { id: ANNOTATION_ID, text, position, ms: TRANSITION_MS },
+  )
+}
+
+export async function hideAnnotation(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ id, ms }) => {
+      const el = document.getElementById(id)
+      if (!el) return
+      el.style.animation = `demo-fade-out ${ms}ms ease forwards`
+      setTimeout(() => el.remove(), ms)
+    },
+    { id: ANNOTATION_ID, ms: TRANSITION_MS },
+  )
+  await sleep(TRANSITION_MS)
+}

--- a/demos/scripts/convert.sh
+++ b/demos/scripts/convert.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_DIR="$SCRIPT_DIR/../output/final"
+MAX_GIF_SIZE=$((5 * 1024 * 1024))
+
+if ! which ffmpeg > /dev/null 2>&1; then
+  echo "Error: ffmpeg not found"
+  echo ""
+  echo "Install ffmpeg:"
+  echo "  macOS:  brew install ffmpeg"
+  echo "  Ubuntu: sudo apt install ffmpeg"
+  echo "  Fedora: sudo dnf install ffmpeg"
+  exit 1
+fi
+
+if [ $# -lt 1 ]; then
+  echo "Usage: bash demos/scripts/convert.sh <input.webm> [output-name]"
+  echo ""
+  echo "Example: bash demos/scripts/convert.sh demos/output/recordings/abc123.webm create-shapes"
+  exit 1
+fi
+
+INPUT="$1"
+NAME="${2:-$(basename "$INPUT" .webm)}"
+MP4_OUT="$OUTPUT_DIR/$NAME.mp4"
+GIF_OUT="$OUTPUT_DIR/$NAME.gif"
+PALETTE="/tmp/demo-palette-$NAME.png"
+
+if [ ! -f "$INPUT" ]; then
+  echo "Error: input file not found: $INPUT"
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "Converting $INPUT → $MP4_OUT"
+ffmpeg -y -i "$INPUT" \
+  -c:v libx264 \
+  -pix_fmt yuv420p \
+  -crf 23 \
+  -preset medium \
+  "$MP4_OUT" 2>/dev/null
+
+echo "Generating palette for GIF..."
+ffmpeg -y -i "$MP4_OUT" \
+  -vf "fps=15,scale=640:-1:flags=lanczos" \
+  -vframes 1 \
+  -update 1 \
+  "$PALETTE" 2>/dev/null || true
+
+ffmpeg -y -i "$MP4_OUT" \
+  -vf "fps=15,scale=640:-1:flags=lanczos,palettegen=stats_mode=diff" \
+  "$PALETTE" 2>/dev/null
+
+echo "Converting → $GIF_OUT"
+ffmpeg -y -i "$MP4_OUT" -i "$PALETTE" \
+  -lavfi "fps=15,scale=640:-1:flags=lanczos[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=3" \
+  "$GIF_OUT" 2>/dev/null
+
+rm -f "$PALETTE"
+
+GIF_SIZE=$(stat -f%z "$GIF_OUT" 2>/dev/null || stat --printf="%s" "$GIF_OUT" 2>/dev/null || echo 0)
+if [ "$GIF_SIZE" -gt "$MAX_GIF_SIZE" ]; then
+  GIF_MB=$(echo "scale=1; $GIF_SIZE / 1024 / 1024" | bc)
+  echo ""
+  echo "Warning: GIF is ${GIF_MB}MB (limit: 5MB)"
+  echo ""
+  echo "Optimization suggestions:"
+  echo "  - Reduce duration: keep scenarios under 30 seconds"
+  echo "  - Lower fps: change fps=15 to fps=10 in this script"
+  echo "  - Smaller scale: change scale=640 to scale=480"
+  echo "  - Crop: add crop filter to remove empty space"
+  exit 1
+fi
+
+echo ""
+echo "Done!"
+echo "  MP4: $MP4_OUT"
+echo "  GIF: $GIF_OUT ($(du -h "$GIF_OUT" | cut -f1))"

--- a/demos/scripts/record.test.ts
+++ b/demos/scripts/record.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from 'bun:test'
+
+import { DemoRecorder, type DemoScenario } from './record'
+import { CanvasHelper } from '../../tests/helpers/canvas'
+
+describe('DemoRecorder', () => {
+  test('delegates to CanvasHelper methods', () => {
+    const recorder = Object.getOwnPropertyNames(DemoRecorder.prototype)
+    const canvasHelper = Object.getOwnPropertyNames(CanvasHelper.prototype)
+
+    const delegatedMethods = ['drawRect', 'drawEllipse', 'selectTool', 'pressKey']
+    for (const method of delegatedMethods) {
+      expect(recorder).toContain(method)
+      expect(canvasHelper).toContain(method)
+    }
+  })
+
+  test('exports DemoScenario interface', () => {
+    const scenario: DemoScenario = {
+      name: 'test',
+      run: async () => {},
+    }
+    expect(scenario.name).toBe('test')
+  })
+
+  test('CanvasHelper is not modified', async () => {
+    const canvasSource = await Bun.file('tests/helpers/canvas.ts').text()
+    expect(canvasSource).toContain('export class CanvasHelper')
+    expect(canvasSource).not.toContain('DemoRecorder')
+    expect(canvasSource).not.toContain('annotation')
+  })
+})

--- a/demos/scripts/record.ts
+++ b/demos/scripts/record.ts
@@ -1,0 +1,236 @@
+import { chromium, type Page, type BrowserContext, type Locator } from '@playwright/test'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+import { CanvasHelper } from '../../tests/helpers/canvas'
+import {
+  ensureCursor,
+  moveCursorTo,
+  demoClick,
+  demoClickXY,
+  hideCursor,
+  showAnnotation,
+  hideAnnotation,
+  type DemoClickOptions,
+  type AnnotationPosition,
+} from './annotations'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const OUTPUT_DIR = resolve(__dirname, '..', 'output', 'recordings')
+
+const VIEWPORT = { width: 1280, height: 800 }
+const SCALE = 2
+const BASE_URL = 'http://localhost:1420'
+
+function sleep(ms: number) {
+  return new Promise<void>((r) => setTimeout(r, ms))
+}
+
+export interface DemoScenario {
+  name: string
+  run(recorder: DemoRecorder): Promise<void>
+}
+
+export class DemoRecorder {
+  readonly page: Page
+  readonly canvas: CanvasHelper
+
+  constructor(page: Page) {
+    this.page = page
+    this.canvas = new CanvasHelper(page)
+  }
+
+  async init() {
+    await this.page.goto(`${BASE_URL}/?test`, { timeout: 60_000, waitUntil: 'domcontentloaded' })
+    await this.page.locator('canvas[data-ready="1"]').waitFor({ timeout: 60_000 })
+    await ensureCursor(this.page)
+    await sleep(500)
+  }
+
+  async sleep(ms: number) {
+    await sleep(ms)
+  }
+
+  async annotate(text: string, position?: AnnotationPosition) {
+    await showAnnotation(this.page, text, position)
+  }
+
+  async clearAnnotation() {
+    await hideAnnotation(this.page)
+  }
+
+  async drawRect(x: number, y: number, w: number, h: number) {
+    await this.canvas.drawRect(x, y, w, h)
+    await sleep(500)
+  }
+
+  async drawEllipse(x: number, y: number, w: number, h: number) {
+    await this.canvas.drawEllipse(x, y, w, h)
+    await sleep(500)
+  }
+
+  async selectTool(tool: Parameters<CanvasHelper['selectTool']>[0]) {
+    await this.canvas.selectTool(tool)
+    await sleep(300)
+  }
+
+  async clickCanvas(x: number, y: number, options?: DemoClickOptions) {
+    const box = await this.canvas.canvas.boundingBox()
+    if (!box) throw new Error('Canvas not found')
+    await demoClickXY(this.page, box.x + x, box.y + y, options)
+  }
+
+  async clickLocator(locator: Locator, options?: DemoClickOptions) {
+    await demoClick(this.page, locator, options)
+  }
+
+  async drag(fromX: number, fromY: number, toX: number, toY: number) {
+    const box = await this.canvas.canvas.boundingBox()
+    if (!box) throw new Error('Canvas not found')
+    await moveCursorTo(this.page, box.x + fromX, box.y + fromY)
+    await this.canvas.drag(fromX, fromY, toX, toY, 20)
+    await sleep(300)
+  }
+
+  async pressKey(key: string) {
+    await this.canvas.pressKey(key)
+    await sleep(200)
+  }
+
+  async type(text: string, delay = 60) {
+    for (const char of text) {
+      await this.page.keyboard.type(char)
+      await sleep(delay)
+    }
+  }
+
+  async smoothZoom(targetZoom: number, durationMs = 600) {
+    await this.page.evaluate(
+      ({ targetZoom, durationMs }) => {
+        return new Promise<void>((resolve) => {
+          const store = (window as any).__OPEN_PENCIL_STORE__
+          if (!store) { resolve(); return }
+
+          const startZoom = store.state.zoom
+          const startPanX = store.state.panX
+          const startPanY = store.state.panY
+          const centerX = window.innerWidth / 2
+          const centerY = window.innerHeight / 2
+          const startTime = performance.now()
+
+          function easeInOut(t: number) {
+            return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t
+          }
+
+          function step(now: number) {
+            const t = Math.min(1, (now - startTime) / durationMs)
+            const eased = easeInOut(t)
+            const zoom = startZoom + (targetZoom - startZoom) * eased
+            store.state.panX = centerX - (centerX - startPanX) * (zoom / startZoom)
+            store.state.panY = centerY - (centerY - startPanY) * (zoom / startZoom)
+            store.state.zoom = zoom
+            store.requestRepaint()
+            if (t < 1) requestAnimationFrame(step)
+            else resolve()
+          }
+          requestAnimationFrame(step)
+        })
+      },
+      { targetZoom, durationMs },
+    )
+  }
+
+  async zoomIn(factor = 1.5) {
+    const current = await this.page.evaluate(
+      () => (window as any).__OPEN_PENCIL_STORE__?.state.zoom ?? 1,
+    )
+    await this.smoothZoom(current * factor)
+  }
+
+  async zoomOut(factor = 1.5) {
+    const current = await this.page.evaluate(
+      () => (window as any).__OPEN_PENCIL_STORE__?.state.zoom ?? 1,
+    )
+    await this.smoothZoom(current / factor)
+  }
+
+  async zoomToFit() {
+    await this.page.evaluate(() => {
+      const store = (window as any).__OPEN_PENCIL_STORE__
+      if (store) store.zoomToFit()
+    })
+    await sleep(300)
+  }
+
+  async finish() {
+    await hideCursor(this.page)
+    await sleep(500)
+  }
+}
+
+const IS_MAIN =
+  import.meta.url === Bun.pathToFileURL(process.argv[1] ?? '').href ||
+  process.argv[1]?.endsWith('record.ts')
+
+async function main() {
+  const args = process.argv.slice(2)
+  const dryRun = args.includes('--dry-run')
+  const scenarioName = args.find((a) => !a.startsWith('--'))
+
+  if (!scenarioName) {
+    console.error('Usage: bun demos/scripts/record.ts <scenario-name> [--dry-run]')
+    console.error('Available scenarios: check demos/scenarios/')
+    process.exit(1)
+  }
+
+  const scenarioPath = resolve(__dirname, '..', 'scenarios', `${scenarioName}.ts`)
+  let scenarioModule: { default: DemoScenario }
+  try {
+    scenarioModule = await import(scenarioPath)
+  } catch {
+    console.error(`Scenario not found: ${scenarioPath}`)
+    process.exit(1)
+  }
+
+  const scenario = scenarioModule.default
+  console.log(`${dryRun ? '[DRY RUN] ' : ''}Recording scenario: ${scenario.name}`)
+
+  const browser = await chromium.launch({ headless: false })
+
+  let context: BrowserContext
+  if (dryRun) {
+    context = await browser.newContext({
+      viewport: VIEWPORT,
+      deviceScaleFactor: SCALE,
+    })
+  } else {
+    context = await browser.newContext({
+      viewport: VIEWPORT,
+      deviceScaleFactor: SCALE,
+      recordVideo: { dir: OUTPUT_DIR, size: VIEWPORT },
+    })
+  }
+
+  const page = await context.newPage()
+  const recorder = new DemoRecorder(page)
+
+  try {
+    await recorder.init()
+    await scenario.run(recorder)
+    await recorder.finish()
+  } catch (err) {
+    console.error('Recording failed:', err)
+    process.exit(1)
+  } finally {
+    await context.close()
+    await browser.close()
+  }
+
+  if (!dryRun) {
+    const videoPath = await page.video()?.path()
+    console.log(`Recording saved: ${videoPath}`)
+    console.log(`Convert: bash demos/scripts/convert.sh ${videoPath}`)
+  }
+}
+
+if (IS_MAIN) main()

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "open-pencil": "bun packages/cli/src/index.ts",
     "docs:dev": "bun --filter @open-pencil/docs dev",
     "docs:build": "bun --filter @open-pencil/docs build",
-    "docs:preview": "bun --filter @open-pencil/docs preview"
+    "docs:preview": "bun --filter @open-pencil/docs preview",
+    "demo:record": "bun demos/scripts/record.ts",
+    "demo:convert": "bash demos/scripts/convert.sh"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.37",


### PR DESCRIPTION
Playwright-based recording of OpenPencil user scenarios with fake SVG cursor, text annotations, and FFmpeg post-production.

- annotations.ts: fake cursor with CSS transitions, ripple effect, text annotation overlays
- record.ts: DemoRecorder wrapping CanvasHelper, --dry-run support, smooth zoom via store
- convert.sh: webm→MP4→GIF with palette optimization, size check
- 3 scenarios: create-shapes, layers-panel, color-picker
- demo:record and demo:convert package.json scripts
- README with API reference and troubleshooting