### PR TITLE
Fix macOS startup hang and recover hidden window on reopen

### DIFF
--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -17,58 +17,34 @@ static FONT_CACHE: OnceLock<Vec<FontFamily>> = OnceLock::new();
 
 fn enumerate_system_fonts() -> Vec<FontFamily> {
     let source = SystemSource::new();
-    let mut families: Vec<FontFamily> = Vec::new();
-
-    if let Ok(family_names) = source.all_families() {
-        for name in &family_names {
-            if let Ok(handle) = source.select_family_by_name(name) {
-                let styles: Vec<String> = handle
-                    .fonts()
-                    .iter()
-                    .filter_map(|f| {
-                        f.load().ok().map(|font| {
-                            let props = font.properties();
-                            let mut style = match props.weight.0 as i32 {
-                                0..=150 => "Thin",
-                                151..=250 => "ExtraLight",
-                                251..=350 => "Light",
-                                351..=450 => "Regular",
-                                451..=550 => "Medium",
-                                551..=650 => "SemiBold",
-                                651..=750 => "Bold",
-                                751..=850 => "ExtraBold",
-                                _ => "Black",
-                            }
-                            .to_string();
-                            if props.style == font_kit::properties::Style::Italic {
-                                style.push_str(" Italic");
-                            }
-                            style
-                        })
-                    })
-                    .collect();
-
-                if !styles.is_empty() {
-                    families.push(FontFamily {
-                        family: name.clone(),
-                        styles,
-                    });
-                }
-            }
-        }
-    }
+    let mut families = source
+        .all_families()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|family| FontFamily {
+            family,
+            styles: vec!["Regular".to_string()],
+        })
+        .collect::<Vec<_>>();
 
     families.sort_by(|a, b| a.family.cmp(&b.family));
     families
 }
 
 #[tauri::command]
-fn list_system_fonts() -> Vec<FontFamily> {
-    FONT_CACHE.get_or_init(enumerate_system_fonts).clone()
+async fn list_system_fonts() -> Vec<FontFamily> {
+    if let Some(cached) = FONT_CACHE.get() {
+        return cached.clone();
+    }
+
+    let families = tauri::async_runtime::spawn_blocking(enumerate_system_fonts)
+        .await
+        .unwrap_or_default();
+    let _ = FONT_CACHE.set(families.clone());
+    families
 }
 
-#[tauri::command]
-fn load_system_font(family: String, style: String) -> Result<Vec<u8>, String> {
+fn load_system_font_blocking(family: String, style: String) -> Result<Vec<u8>, String> {
     let source = SystemSource::new();
     let family_handle = source
         .select_family_by_name(&family)
@@ -116,6 +92,13 @@ fn load_system_font(family: String, style: String) -> Result<Vec<u8>, String> {
     }
 
     Err(format!("Could not load font {family} {style}"))
+}
+
+#[tauri::command]
+async fn load_system_font(family: String, style: String) -> Result<Vec<u8>, String> {
+    tauri::async_runtime::spawn_blocking(move || load_system_font_blocking(family, style))
+        .await
+        .map_err(|e| format!("Font load task failed: {e}"))?
 }
 
 #[tauri::command]
@@ -175,10 +158,22 @@ fn build_fig_file(
     Ok(result.into_inner())
 }
 
+fn show_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![build_fig_file, list_system_fonts, load_system_font])
+        .invoke_handler(tauri::generate_handler![
+            build_fig_file,
+            list_system_fonts,
+            load_system_font
+        ])
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
@@ -437,9 +432,22 @@ pub fn run() {
                 .build()?;
 
             app.set_menu(menu)?;
+            show_main_window(app.handle());
 
             Ok(())
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app, event| {
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Reopen {
+                has_visible_windows,
+                ..
+            } = event
+            {
+                if !has_visible_windows {
+                    show_main_window(app);
+                }
+            }
+        });
 }


### PR DESCRIPTION
## Human Summary
I've never worked in rust, so just a heads up. But was not able to open the MacOS app without these fixes. Feel free to close or point your clanker at this PR 

## Summary
- move `list_system_fonts` and `load_system_font` off the UI thread using `tauri::async_runtime::spawn_blocking`
- make initial font enumeration lightweight by returning family names with a default `Regular` style
- on macOS, ensure the main window is restored/focused when app is reopened with no visible windows

## Why
On macOS the app could appear frozen at launch due to synchronous system font work on startup, and could also remain running without a visible window after reopen.

## Validation
- `cargo check -q` in `desktop/`
- local debug bundle launches responsively
- reopen event restores window when no windows are visible
