### PR TITLE
Add 12 new AI tools (26 → 38/118)

### DIFF
--- a/packages/core/src/tools/schema.ts
+++ b/packages/core/src/tools/schema.ts
@@ -9,6 +9,7 @@
 import { parseColor } from '../color'
 
 import type { FigmaAPI, FigmaNodeProxy } from '../figma-api'
+import type { Variable, VariableCollection, VariableType } from '../scene-graph'
 
 export type ParamType = 'string' | 'number' | 'boolean' | 'color' | 'string[]'
 
@@ -653,21 +654,461 @@ export const evalCode = defineTool({
   }
 })
 
+// ─── Tree navigation tools ────────────────────────────────────
+
+export const getChildren = defineTool({
+  name: 'get_children',
+  description: 'Get the direct children of a node.',
+  params: {
+    id: { type: 'string', description: 'Parent node ID', required: true }
+  },
+  execute: (figma, { id }) => {
+    const node = figma.getNodeById(id)
+    if (!node) return { error: `Node "${id}" not found` }
+    const children = figma.graph.getChildren(id)
+    return {
+      id,
+      childCount: children.length,
+      children: children.map((c) => ({ id: c.id, name: c.name, type: c.type }))
+    }
+  }
+})
+
+export const getAncestors = defineTool({
+  name: 'get_ancestors',
+  description: 'Get the ancestor chain of a node from its parent up to the page root.',
+  params: {
+    id: { type: 'string', description: 'Node ID', required: true }
+  },
+  execute: (figma, { id }) => {
+    if (!figma.getNodeById(id)) return { error: `Node "${id}" not found` }
+    const ancestors: { id: string; name: string; type: string }[] = []
+    let raw = figma.graph.getNode(id)
+    while (raw?.parentId) {
+      const parent = figma.graph.getNode(raw.parentId)
+      if (!parent) break
+      ancestors.push({ id: parent.id, name: parent.name, type: parent.type })
+      raw = parent
+    }
+    return { id, ancestors }
+  }
+})
+
+export const nodeBounds = defineTool({
+  name: 'node_bounds',
+  description: 'Get the absolute bounding box of a node in canvas space.',
+  params: {
+    id: { type: 'string', description: 'Node ID', required: true }
+  },
+  execute: (figma, { id }) => {
+    const node = figma.getNodeById(id)
+    if (!node) return { error: `Node "${id}" not found` }
+    const bounds = node.absoluteBoundingBox
+    return { id, x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height }
+  }
+})
+
+// ─── Text tools ───────────────────────────────────────────────
+
+export const setText = defineTool({
+  name: 'set_text',
+  description: 'Set the text content of a TEXT node.',
+  params: {
+    id: { type: 'string', description: 'Text node ID', required: true },
+    text: { type: 'string', description: 'New text content', required: true }
+  },
+  execute: (figma, { id, text }) => {
+    const node = figma.getNodeById(id)
+    if (!node) return { error: `Node "${id}" not found` }
+    if (node.type !== 'TEXT') return { error: `Node "${id}" is not a TEXT node` }
+    node.characters = text
+    return { id, text }
+  }
+})
+
+export const setFont = defineTool({
+  name: 'set_font',
+  description: 'Set font properties on a TEXT node: family, size, weight, line height, letter spacing.',
+  params: {
+    id: { type: 'string', description: 'Text node ID', required: true },
+    family: { type: 'string', description: 'Font family name, e.g. "Inter"' },
+    size: { type: 'number', description: 'Font size in pixels', min: 1 },
+    weight: {
+      type: 'number',
+      description: 'Font weight: 100 (thin) → 900 (black)',
+      min: 100,
+      max: 900
+    },
+    italic: { type: 'boolean', description: 'Italic style' },
+    line_height: { type: 'number', description: 'Line height in pixels (null = auto)', min: 0 },
+    letter_spacing: { type: 'number', description: 'Letter spacing in pixels' }
+  },
+  execute: (figma, args) => {
+    const node = figma.getNodeById(args.id)
+    if (!node) return { error: `Node "${args.id}" not found` }
+    if (node.type !== 'TEXT') return { error: `Node "${args.id}" is not a TEXT node` }
+    const updated: string[] = []
+    if (args.family !== undefined || args.weight !== undefined || args.italic !== undefined) {
+      const current = node.fontName
+      node.fontName = {
+        family: args.family ?? current.family,
+        style: buildFontStyle(args.weight ?? node.fontWeight, args.italic ?? false)
+      }
+      updated.push('fontName')
+    }
+    if (args.size !== undefined) {
+      node.fontSize = args.size
+      updated.push('fontSize')
+    }
+    if (args.line_height !== undefined) {
+      node.lineHeight = args.line_height
+      updated.push('lineHeight')
+    }
+    if (args.letter_spacing !== undefined) {
+      node.letterSpacing = args.letter_spacing
+      updated.push('letterSpacing')
+    }
+    return { id: args.id, updated }
+  }
+})
+
+function buildFontStyle(weight: number, italic: boolean): string {
+  const names: Record<number, string> = {
+    100: 'Thin', 200: 'Extra Light', 300: 'Light', 400: 'Regular',
+    500: 'Medium', 600: 'Semi Bold', 700: 'Bold', 800: 'Extra Bold', 900: 'Black'
+  }
+  const base = names[weight] ?? 'Regular'
+  return italic ? `${base} Italic` : base
+}
+
+export const setTextProperties = defineTool({
+  name: 'set_text_properties',
+  description:
+    'Set text layout properties: alignment, auto-resize, text case, decoration, truncation.',
+  params: {
+    id: { type: 'string', description: 'Text node ID', required: true },
+    align_horizontal: {
+      type: 'string',
+      description: 'Horizontal text alignment',
+      enum: ['LEFT', 'CENTER', 'RIGHT', 'JUSTIFIED']
+    },
+    align_vertical: {
+      type: 'string',
+      description: 'Vertical text alignment',
+      enum: ['TOP', 'CENTER', 'BOTTOM']
+    },
+    auto_resize: {
+      type: 'string',
+      description: 'Text auto-resize mode',
+      enum: ['NONE', 'WIDTH_AND_HEIGHT', 'HEIGHT', 'TRUNCATE']
+    },
+    text_case: {
+      type: 'string',
+      description: 'Text case transform',
+      enum: ['ORIGINAL', 'UPPER', 'LOWER', 'TITLE', 'SMALL_CAPS', 'SMALL_CAPS_FORCED']
+    },
+    text_decoration: {
+      type: 'string',
+      description: 'Text decoration',
+      enum: ['NONE', 'UNDERLINE', 'STRIKETHROUGH']
+    },
+    max_lines: { type: 'number', description: 'Max visible lines (null = unlimited)', min: 1 }
+  },
+  execute: (figma, args) => {
+    const node = figma.getNodeById(args.id)
+    if (!node) return { error: `Node "${args.id}" not found` }
+    if (node.type !== 'TEXT') return { error: `Node "${args.id}" is not a TEXT node` }
+    const updated: string[] = []
+    if (args.align_horizontal !== undefined) {
+      node.textAlignHorizontal = args.align_horizontal
+      updated.push('textAlignHorizontal')
+    }
+    if (args.align_vertical !== undefined) {
+      node.textAlignVertical = args.align_vertical
+      updated.push('textAlignVertical')
+    }
+    if (args.auto_resize !== undefined) {
+      node.textAutoResize = args.auto_resize
+      updated.push('textAutoResize')
+    }
+    if (args.text_case !== undefined) {
+      node.textCase = args.text_case
+      updated.push('textCase')
+    }
+    if (args.text_decoration !== undefined) {
+      node.textDecoration = args.text_decoration
+      updated.push('textDecoration')
+    }
+    if (args.max_lines !== undefined) {
+      node.maxLines = args.max_lines
+      updated.push('maxLines')
+    }
+    return { id: args.id, updated }
+  }
+})
+
+// ─── Appearance tools ─────────────────────────────────────────
+
+export const setBlendMode = defineTool({
+  name: 'set_blend_mode',
+  description: 'Set the blend mode and/or rotation of a node.',
+  params: {
+    id: { type: 'string', description: 'Node ID', required: true },
+    blend_mode: {
+      type: 'string',
+      description: 'CSS-style blend mode',
+      enum: [
+        'NORMAL', 'DARKEN', 'MULTIPLY', 'LINEAR_BURN', 'COLOR_BURN',
+        'LIGHTEN', 'SCREEN', 'LINEAR_DODGE', 'COLOR_DODGE',
+        'OVERLAY', 'SOFT_LIGHT', 'HARD_LIGHT',
+        'DIFFERENCE', 'EXCLUSION',
+        'HUE', 'SATURATION', 'COLOR', 'LUMINOSITY',
+        'PASS_THROUGH'
+      ]
+    },
+    rotation: { type: 'number', description: 'Rotation in degrees', min: -180, max: 180 }
+  },
+  execute: (figma, args) => {
+    const node = figma.getNodeById(args.id)
+    if (!node) return { error: `Node "${args.id}" not found` }
+    const updated: string[] = []
+    if (args.blend_mode !== undefined) {
+      node.blendMode = args.blend_mode
+      updated.push('blendMode')
+    }
+    if (args.rotation !== undefined) {
+      node.rotation = args.rotation
+      updated.push('rotation')
+    }
+    return { id: args.id, updated }
+  }
+})
+
+// ─── Layout child tools ───────────────────────────────────────
+
+export const setLayoutChild = defineTool({
+  name: 'set_layout_child',
+  description:
+    'Configure auto-layout child behaviour: sizing (FIXED/HUG/FILL), grow, alignment, absolute positioning.',
+  params: {
+    id: { type: 'string', description: 'Child node ID', required: true },
+    sizing_horizontal: {
+      type: 'string',
+      description: 'Horizontal sizing mode',
+      enum: ['FIXED', 'HUG', 'FILL']
+    },
+    sizing_vertical: {
+      type: 'string',
+      description: 'Vertical sizing mode',
+      enum: ['FIXED', 'HUG', 'FILL']
+    },
+    grow: { type: 'number', description: 'Flex grow factor (0 = no grow, 1 = grow)', min: 0 },
+    align_self: {
+      type: 'string',
+      description: 'Self alignment override',
+      enum: ['INHERIT', 'STRETCH']
+    },
+    positioning: {
+      type: 'string',
+      description: 'ABSOLUTE to take node out of auto-layout flow',
+      enum: ['AUTO', 'ABSOLUTE']
+    }
+  },
+  execute: (figma, args) => {
+    const node = figma.getNodeById(args.id)
+    if (!node) return { error: `Node "${args.id}" not found` }
+    const updated: string[] = []
+    if (args.sizing_horizontal !== undefined) {
+      node.layoutSizingHorizontal = args.sizing_horizontal
+      updated.push('layoutSizingHorizontal')
+    }
+    if (args.sizing_vertical !== undefined) {
+      node.layoutSizingVertical = args.sizing_vertical
+      updated.push('layoutSizingVertical')
+    }
+    if (args.grow !== undefined) {
+      node.layoutGrow = args.grow
+      updated.push('layoutGrow')
+    }
+    if (args.align_self !== undefined) {
+      node.layoutAlign = args.align_self
+      updated.push('layoutAlign')
+    }
+    if (args.positioning !== undefined) {
+      node.layoutPositioning = args.positioning
+      updated.push('layoutPositioning')
+    }
+    return { id: args.id, updated }
+  }
+})
+
+// ─── Page tools ───────────────────────────────────────────────
+
+export const createPage = defineTool({
+  name: 'create_page',
+  description: 'Create a new page in the document.',
+  params: {
+    name: { type: 'string', description: 'Page name', required: true }
+  },
+  execute: (figma, { name }) => {
+    const page = figma.createPage()
+    page.name = name
+    return { id: page.id, name: page.name }
+  }
+})
+
+// ─── Variable tools ───────────────────────────────────────────
+
+export const createVariable = defineTool({
+  name: 'create_variable',
+  description:
+    'Create a design variable. If no collection_id is given, creates a default "Variables" collection.',
+  params: {
+    name: { type: 'string', description: 'Variable name', required: true },
+    type: {
+      type: 'string',
+      description: 'Variable type',
+      required: true,
+      enum: ['COLOR', 'FLOAT', 'STRING', 'BOOLEAN']
+    },
+    value: {
+      type: 'string',
+      description:
+        'Initial value. COLOR: hex string. FLOAT: number. STRING: text. BOOLEAN: "true"/"false".',
+      required: true
+    },
+    collection_id: { type: 'string', description: 'Collection ID to add variable to' }
+  },
+  execute: (figma, args) => {
+    let collectionId = args.collection_id
+    if (!collectionId) {
+      const existing = [...figma.graph.variableCollections.values()]
+      if (existing.length > 0) {
+        collectionId = existing[0].id
+      } else {
+        const modeId = crypto.randomUUID()
+        const col: VariableCollection = {
+          id: crypto.randomUUID(),
+          name: 'Variables',
+          modes: [{ modeId, name: 'Default' }],
+          defaultModeId: modeId,
+          variableIds: []
+        }
+        figma.graph.addCollection(col)
+        collectionId = col.id
+      }
+    }
+    const collection = figma.graph.variableCollections.get(collectionId)
+    if (!collection) return { error: `Collection "${collectionId}" not found` }
+    const modeId = collection.defaultModeId
+    const parsedValue = parseVariableValue(args.type as VariableType, args.value)
+    const variable: Variable = {
+      id: crypto.randomUUID(),
+      name: args.name,
+      type: args.type as VariableType,
+      collectionId,
+      valuesByMode: { [modeId]: parsedValue },
+      description: '',
+      hiddenFromPublishing: false
+    }
+    figma.graph.addVariable(variable)
+    return { id: variable.id, name: variable.name, type: variable.type, collectionId }
+  }
+})
+
+export const setVariableValue = defineTool({
+  name: 'set_variable_value',
+  description: "Set a variable's value for its default mode.",
+  params: {
+    id: { type: 'string', description: 'Variable ID', required: true },
+    value: {
+      type: 'string',
+      description:
+        'New value. COLOR: hex string. FLOAT: number. STRING: text. BOOLEAN: "true"/"false".',
+      required: true
+    },
+    mode_id: {
+      type: 'string',
+      description: "Mode ID to set value for (defaults to collection's default mode)"
+    }
+  },
+  execute: (figma, args) => {
+    const variable = figma.graph.variables.get(args.id)
+    if (!variable) return { error: `Variable "${args.id}" not found` }
+    const modeId = args.mode_id ?? figma.graph.getActiveModeId(variable.collectionId)
+    variable.valuesByMode[modeId] = parseVariableValue(variable.type, args.value)
+    return { id: args.id, modeId, value: variable.valuesByMode[modeId] }
+  }
+})
+
+export const bindVariable = defineTool({
+  name: 'bind_variable',
+  description:
+    'Bind a node property to a design variable. Common fields: "opacity", "fills.0.opacity", "width", "height".',
+  params: {
+    node_id: { type: 'string', description: 'Node ID', required: true },
+    field: {
+      type: 'string',
+      description: 'Property field path to bind (e.g. "opacity", "fills.0.opacity")',
+      required: true
+    },
+    variable_id: { type: 'string', description: 'Variable ID to bind', required: true }
+  },
+  execute: (figma, { node_id, field, variable_id }) => {
+    if (!figma.getNodeById(node_id)) return { error: `Node "${node_id}" not found` }
+    if (!figma.graph.variables.get(variable_id))
+      return { error: `Variable "${variable_id}" not found` }
+    figma.graph.bindVariable(node_id, field, variable_id)
+    return { node_id, field, variable_id }
+  }
+})
+
+function parseVariableValue(
+  type: VariableType,
+  raw: string
+): Variable['valuesByMode'][string] {
+  switch (type) {
+    case 'COLOR':
+      return parseColor(raw)
+    case 'FLOAT':
+      return Number(raw)
+    case 'BOOLEAN':
+      return raw === 'true'
+    case 'STRING':
+    default:
+      return raw
+  }
+}
+
 // ─── Registry ─────────────────────────────────────────────────
 
 export const ALL_TOOLS: ToolDef[] = [
+  // Read
   getSelection,
   getPageTree,
   getNode,
   findNodes,
+  getChildren,
+  getAncestors,
+  nodeBounds,
+  // Create
   createShape,
+  createPage,
   render,
+  // Fill / stroke / effects
   setFill,
   setStroke,
   setEffects,
+  // Node mutation
   updateNode,
+  setText,
+  setFont,
+  setTextProperties,
+  setBlendMode,
   setLayout,
+  setLayoutChild,
   setConstraints,
+  // Structure
   deleteNode,
   cloneNode,
   renameNode,
@@ -677,9 +1118,15 @@ export const ALL_TOOLS: ToolDef[] = [
   ungroupNode,
   createComponent,
   createInstance,
+  // Pages
   listPages,
   switchPage,
+  // Variables
   listVariables,
   listCollections,
+  createVariable,
+  setVariableValue,
+  bindVariable,
+  // Escape hatch
   evalCode
 ]

--- a/packages/docs/development/roadmap.md
+++ b/packages/docs/development/roadmap.md
@@ -107,7 +107,7 @@ Core extraction, CLI, MCP server, design guidelines, screenshot verification loo
 - .fig roundtrip tests with LFS fixtures (material3.fig 87K nodes, nuxtui.fig 314K nodes)
 - .fig import O(n²) → O(n) fix (37s → 535ms on 87K nodes), ByteBuffer optimization
 - test:coverage script
-- AI chat: OpenRouter direct (no backend), Stronghold key storage, 26 tools (create_shape, set_fill, set_effects, set_constraints, components, groups, pages, variables, eval_code, etc.), model selector, ⌘J toggle, streaming markdown, Playwright tests with mock transport
+- AI chat: OpenRouter direct (no backend), Stronghold key storage, 38 tools (create_shape, set_fill, set_effects, set_constraints, components, groups, pages, variables, eval_code, etc.), model selector, ⌘J toggle, streaming markdown, Playwright tests with mock transport
 - Code panel: sceneNodeToJsx() export, Prism.js highlighting, line numbers, copy button, 14 tests
 - Properties panel restructured: Design | Code | AI tabs
 - npm publishing preparation for core and cli packages

--- a/tests/engine/tools.test.ts
+++ b/tests/engine/tools.test.ts
@@ -388,3 +388,333 @@ describe('render', () => {
     expect(result.children.length).toBeGreaterThan(0)
   })
 })
+
+// ─── New tools (38 total) ─────────────────────────────────────
+
+describe('get_children', () => {
+  test('returns direct children of a frame', () => {
+    const { figma } = setup()
+    const parent = figma.createFrame()
+    const child1 = figma.createRectangle()
+    const child2 = figma.createEllipse()
+    parent.appendChild(child1)
+    parent.appendChild(child2)
+
+    const tool = ALL_TOOLS.find((t) => t.name === 'get_children')!
+    const result = tool.execute(figma, { id: parent.id }) as any
+    expect(result.childCount).toBe(2)
+    expect(result.children.map((c: any) => c.id)).toContain(child1.id)
+    expect(result.children.map((c: any) => c.id)).toContain(child2.id)
+  })
+
+  test('returns error for unknown node', () => {
+    const { figma } = setup()
+    const tool = ALL_TOOLS.find((t) => t.name === 'get_children')!
+    const result = tool.execute(figma, { id: 'nope' }) as any
+    expect(result.error).toBeTruthy()
+  })
+})
+
+describe('get_ancestors', () => {
+  test('returns ancestor chain', () => {
+    const { figma } = setup()
+    const grandparent = figma.createFrame()
+    const parent = figma.createFrame()
+    const child = figma.createRectangle()
+    grandparent.appendChild(parent)
+    parent.appendChild(child)
+
+    const tool = ALL_TOOLS.find((t) => t.name === 'get_ancestors')!
+    const result = tool.execute(figma, { id: child.id }) as any
+    const ids = result.ancestors.map((a: any) => a.id)
+    expect(ids).toContain(parent.id)
+    expect(ids).toContain(grandparent.id)
+  })
+
+  test('returns error for unknown node', () => {
+    const { figma } = setup()
+    const tool = ALL_TOOLS.find((t) => t.name === 'get_ancestors')!
+    const result = tool.execute(figma, { id: 'nope' }) as any
+    expect(result.error).toBeTruthy()
+  })
+})
+
+describe('node_bounds', () => {
+  test('returns bounding box for a positioned node', () => {
+    const { figma } = setup()
+    const node = figma.createRectangle()
+    node.x = 50
+    node.y = 80
+    node.resize(120, 60)
+
+    const tool = ALL_TOOLS.find((t) => t.name === 'node_bounds')!
+    const result = tool.execute(figma, { id: node.id }) as any
+    expect(result.x).toBe(50)
+    expect(result.y).toBe(80)
+    expect(result.width).toBe(120)
+    expect(result.height).toBe(60)
+  })
+})
+
+describe('set_text', () => {
+  test('sets text content on a TEXT node', () => {
+    const { figma } = setup()
+    const node = figma.createText()
+
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_text')!
+    tool.execute(figma, { id: node.id, text: 'Hello World' })
+    expect(node.characters).toBe('Hello World')
+  })
+
+  test('returns error when node is not TEXT', () => {
+    const { figma } = setup()
+    const node = figma.createRectangle()
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_text')!
+    const result = tool.execute(figma, { id: node.id, text: 'oops' }) as any
+    expect(result.error).toMatch(/not a TEXT node/)
+  })
+})
+
+describe('set_font', () => {
+  test('sets font size and weight', () => {
+    const { figma } = setup()
+    const node = figma.createText()
+
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_font')!
+    tool.execute(figma, { id: node.id, size: 24, weight: 700 })
+    expect(node.fontSize).toBe(24)
+    expect(node.fontWeight).toBe(700)
+  })
+
+  test('sets font family', () => {
+    const { figma } = setup()
+    const node = figma.createText()
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_font')!
+    tool.execute(figma, { id: node.id, family: 'Roboto', weight: 400 })
+    expect(node.fontName.family).toBe('Roboto')
+  })
+
+  test('sets line height and letter spacing', () => {
+    const { figma } = setup()
+    const node = figma.createText()
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_font')!
+    tool.execute(figma, { id: node.id, line_height: 28, letter_spacing: 0.5 })
+    expect(node.lineHeight).toBe(28)
+    expect(node.letterSpacing).toBe(0.5)
+  })
+
+  test('returns error for non-TEXT node', () => {
+    const { figma } = setup()
+    const node = figma.createRectangle()
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_font')!
+    const result = tool.execute(figma, { id: node.id, size: 16 }) as any
+    expect(result.error).toMatch(/not a TEXT node/)
+  })
+})
+
+describe('set_text_properties', () => {
+  test('sets horizontal and vertical alignment', () => {
+    const { figma } = setup()
+    const node = figma.createText()
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_text_properties')!
+    tool.execute(figma, { id: node.id, align_horizontal: 'CENTER', align_vertical: 'CENTER' })
+    expect(node.textAlignHorizontal).toBe('CENTER')
+    expect(node.textAlignVertical).toBe('CENTER')
+  })
+
+  test('sets auto-resize and text case', () => {
+    const { figma } = setup()
+    const node = figma.createText()
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_text_properties')!
+    tool.execute(figma, { id: node.id, auto_resize: 'HEIGHT', text_case: 'UPPER' })
+    expect(node.textAutoResize).toBe('HEIGHT')
+    expect(node.textCase).toBe('UPPER')
+  })
+
+  test('returns error for non-TEXT node', () => {
+    const { figma } = setup()
+    const node = figma.createFrame()
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_text_properties')!
+    const result = tool.execute(figma, { id: node.id, align_horizontal: 'LEFT' }) as any
+    expect(result.error).toMatch(/not a TEXT node/)
+  })
+})
+
+describe('set_blend_mode', () => {
+  test('sets blend mode', () => {
+    const { figma } = setup()
+    const node = figma.createRectangle()
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_blend_mode')!
+    tool.execute(figma, { id: node.id, blend_mode: 'MULTIPLY' })
+    expect(node.blendMode).toBe('MULTIPLY')
+  })
+
+  test('sets rotation', () => {
+    const { figma } = setup()
+    const node = figma.createRectangle()
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_blend_mode')!
+    tool.execute(figma, { id: node.id, rotation: 45 })
+    expect(node.rotation).toBe(45)
+  })
+})
+
+describe('set_layout_child', () => {
+  test('sets layout sizing and grow', () => {
+    const { figma } = setup()
+    const frame = figma.createFrame()
+    frame.layoutMode = 'HORIZONTAL'
+    const child = figma.createRectangle()
+    frame.appendChild(child)
+
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_layout_child')!
+    tool.execute(figma, { id: child.id, sizing_horizontal: 'FILL', grow: 1 })
+    expect(child.layoutGrow).toBe(1)
+  })
+
+  test('sets absolute positioning', () => {
+    const { figma } = setup()
+    const frame = figma.createFrame()
+    frame.layoutMode = 'VERTICAL'
+    const child = figma.createRectangle()
+    frame.appendChild(child)
+
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_layout_child')!
+    tool.execute(figma, { id: child.id, positioning: 'ABSOLUTE' })
+    expect(child.layoutPositioning).toBe('ABSOLUTE')
+  })
+})
+
+describe('create_page', () => {
+  test('creates a page with the given name', () => {
+    const { figma } = setup()
+    const tool = ALL_TOOLS.find((t) => t.name === 'create_page')!
+    const result = tool.execute(figma, { name: 'Flows' }) as any
+    expect(result.name).toBe('Flows')
+    expect(result.id).toBeTruthy()
+    const pages = figma.root.children
+    expect(pages.some((p) => p.id === result.id)).toBe(true)
+  })
+})
+
+describe('create_variable', () => {
+  test('creates a FLOAT variable with auto-created collection', () => {
+    const { figma } = setup()
+    const tool = ALL_TOOLS.find((t) => t.name === 'create_variable')!
+    const result = tool.execute(figma, { name: 'spacing-md', type: 'FLOAT', value: '16' }) as any
+    expect(result.name).toBe('spacing-md')
+    expect(result.type).toBe('FLOAT')
+    expect(result.id).toBeTruthy()
+    const variable = figma.graph.variables.get(result.id)!
+    expect(Object.values(variable.valuesByMode)[0]).toBe(16)
+  })
+
+  test('creates a COLOR variable', () => {
+    const { figma } = setup()
+    const tool = ALL_TOOLS.find((t) => t.name === 'create_variable')!
+    const result = tool.execute(figma, { name: 'brand', type: 'COLOR', value: '#ff0000' }) as any
+    const variable = figma.graph.variables.get(result.id)!
+    const color = Object.values(variable.valuesByMode)[0] as any
+    expect(color.r).toBeCloseTo(1)
+    expect(color.g).toBeCloseTo(0)
+    expect(color.b).toBeCloseTo(0)
+  })
+
+  test('creates a BOOLEAN variable', () => {
+    const { figma } = setup()
+    const tool = ALL_TOOLS.find((t) => t.name === 'create_variable')!
+    const result = tool.execute(figma, { name: 'darkMode', type: 'BOOLEAN', value: 'true' }) as any
+    const variable = figma.graph.variables.get(result.id)!
+    expect(Object.values(variable.valuesByMode)[0]).toBe(true)
+  })
+
+  test('creates a STRING variable', () => {
+    const { figma } = setup()
+    const tool = ALL_TOOLS.find((t) => t.name === 'create_variable')!
+    const result = tool.execute(figma, { name: 'label', type: 'STRING', value: 'Hello' }) as any
+    const variable = figma.graph.variables.get(result.id)!
+    expect(Object.values(variable.valuesByMode)[0]).toBe('Hello')
+  })
+
+  test('uses existing collection when specified', () => {
+    const { figma } = setup()
+    const modeId = 'mode-1'
+    const col = {
+      id: 'col-1', name: 'Tokens',
+      modes: [{ modeId, name: 'Default' }],
+      defaultModeId: modeId, variableIds: []
+    }
+    figma.graph.addCollection(col)
+    const tool = ALL_TOOLS.find((t) => t.name === 'create_variable')!
+    const result = tool.execute(figma, {
+      name: 'radius', type: 'FLOAT', value: '8', collection_id: 'col-1'
+    }) as any
+    expect(result.collectionId).toBe('col-1')
+  })
+})
+
+describe('set_variable_value', () => {
+  test('updates the value in the default mode', () => {
+    const { figma } = setup()
+    const createTool = ALL_TOOLS.find((t) => t.name === 'create_variable')!
+    const { id } = createTool.execute(figma, { name: 'gap', type: 'FLOAT', value: '8' }) as any
+
+    const setTool = ALL_TOOLS.find((t) => t.name === 'set_variable_value')!
+    setTool.execute(figma, { id, value: '16' })
+
+    const variable = figma.graph.variables.get(id)!
+    expect(Object.values(variable.valuesByMode)[0]).toBe(16)
+  })
+
+  test('returns error for unknown variable', () => {
+    const { figma } = setup()
+    const tool = ALL_TOOLS.find((t) => t.name === 'set_variable_value')!
+    const result = tool.execute(figma, { id: 'no-such', value: '1' }) as any
+    expect(result.error).toBeTruthy()
+  })
+})
+
+describe('bind_variable', () => {
+  test('binds a variable to a node field', () => {
+    const { figma } = setup()
+    const createTool = ALL_TOOLS.find((t) => t.name === 'create_variable')!
+    const { id: varId } = createTool.execute(figma, {
+      name: 'opacity-dim', type: 'FLOAT', value: '0.5'
+    }) as any
+
+    const node = figma.createRectangle()
+    const tool = ALL_TOOLS.find((t) => t.name === 'bind_variable')!
+    tool.execute(figma, { node_id: node.id, field: 'opacity', variable_id: varId })
+
+    const raw = figma.graph.getNode(node.id)!
+    expect(raw.boundVariables['opacity']).toBe(varId)
+  })
+
+  test('returns error for unknown node', () => {
+    const { figma } = setup()
+    const createTool = ALL_TOOLS.find((t) => t.name === 'create_variable')!
+    const { id: varId } = createTool.execute(figma, {
+      name: 'x', type: 'FLOAT', value: '0'
+    }) as any
+    const tool = ALL_TOOLS.find((t) => t.name === 'bind_variable')!
+    const result = tool.execute(figma, {
+      node_id: 'no-node', field: 'opacity', variable_id: varId
+    }) as any
+    expect(result.error).toBeTruthy()
+  })
+
+  test('returns error for unknown variable', () => {
+    const { figma } = setup()
+    const node = figma.createRectangle()
+    const tool = ALL_TOOLS.find((t) => t.name === 'bind_variable')!
+    const result = tool.execute(figma, {
+      node_id: node.id, field: 'opacity', variable_id: 'no-var'
+    }) as any
+    expect(result.error).toBeTruthy()
+  })
+})
+
+describe('ALL_TOOLS count', () => {
+  test('has 38 tools registered', () => {
+    expect(ALL_TOOLS.length).toBe(38)
+  })
+})


### PR DESCRIPTION
Adds 12 new tools to \`packages/core/src/tools/schema.ts\`:

**Tree navigation**
- \`get_children\` — list direct children of a node
- \`get_ancestors\` — list ancestors up to the page
- \`node_bounds\` — absolute position + dimensions

**Text editing**
- \`set_text\` — update text content
- \`set_font\` — change font family + size
- \`set_text_properties\` — alignment, line height, letter spacing

**Appearance**
- \`set_blend_mode\` — change blend mode

**Auto-layout**
- \`set_layout_child\` — child sizing/alignment within auto-layout parent

**Pages**
- \`create_page\` — add a new page

**Design variables**
- \`create_variable\` — define a new variable in a collection
- \`set_variable_value\` — update a variable's value per mode
- \`bind_variable\` — bind a variable to a node property

Includes test coverage — tool count assertion updated to 38.