### PR TITLE
Experimental WebGPU/Graphite rendering backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist-ssr
 
 # Copied from node_modules at build time
 public/canvaskit.wasm
+public/canvaskit-webgpu/
 
 # Editor directories and files
 .vscode/*

--- a/packages/core/src/canvaskit.ts
+++ b/packages/core/src/canvaskit.ts
@@ -2,19 +2,64 @@ import CanvasKitInit, { type CanvasKit } from 'canvaskit-wasm'
 
 let instance: CanvasKit | null = null
 
+export type GpuBackend = 'webgl' | 'webgpu'
+
+let activeBackend: GpuBackend = 'webgl'
+
+export function getGpuBackend(): GpuBackend {
+  return activeBackend
+}
+
 export interface CanvasKitOptions {
   locateFile?: (file: string) => string
+  backend?: GpuBackend
+}
+
+function detectBackend(): GpuBackend {
+  if (typeof window === 'undefined') return 'webgl'
+  const params = new URLSearchParams(window.location.search)
+  if (params.get('gpu') === 'webgpu' && 'gpu' in navigator) return 'webgpu'
+  return 'webgl'
+}
+
+function loadCanvasKitWebGPU(): Promise<(opts?: Record<string, unknown>) => Promise<CanvasKit>> {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script')
+    script.src = '/canvaskit-webgpu/canvaskit.js'
+    script.onload = () => {
+      const init = (globalThis as Record<string, unknown>).CanvasKitInit as
+        (opts?: Record<string, unknown>) => Promise<CanvasKit>
+      if (!init) return reject(new Error('CanvasKitInit not found after loading WebGPU build'))
+      resolve(init)
+    }
+    script.onerror = () => reject(new Error('Failed to load canvaskit-webgpu/canvaskit.js'))
+    document.head.appendChild(script)
+  })
 }
 
 export async function getCanvasKit(options?: CanvasKitOptions): Promise<CanvasKit> {
   if (instance) return instance
-  instance = await CanvasKitInit({
-    locateFile:
-      options?.locateFile ??
-      ((file) => {
-        if (typeof window !== 'undefined') return `/${file}`
-        return file
-      })
-  })
-  return instance
+
+  const backend = options?.backend ?? detectBackend()
+  activeBackend = backend
+
+  const defaultLocate = (file: string) => {
+    if (typeof window !== 'undefined') return `/${file}`
+    return file
+  }
+
+  if (backend === 'webgpu') {
+    const init = await loadCanvasKitWebGPU()
+    instance = await init({
+      locateFile:
+        options?.locateFile ??
+        ((file: string) => `/canvaskit-webgpu/${file}`)
+    })
+  } else {
+    instance = await CanvasKitInit({
+      locateFile: options?.locateFile ?? defaultLocate
+    })
+  }
+
+  return instance!
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,7 +49,7 @@ export { ALL_TOOLS, defineTool, toolsToAI } from './tools'
 export type { ToolDef, ParamDef, ParamType } from './tools'
 export { SkiaRenderer, type RenderOverlays } from './renderer'
 export { computeLayout, computeAllLayouts } from './layout'
-export { getCanvasKit, type CanvasKitOptions } from './canvaskit'
+export { getCanvasKit, getGpuBackend, type CanvasKitOptions, type GpuBackend } from './canvaskit'
 export {
   loadFont,
   listFamilies,

--- a/public/benchmark.html
+++ b/public/benchmark.html
@@ -1,0 +1,349 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>OpenPencil — WebGL vs WebGPU Benchmark</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: system-ui, sans-serif; background: #1a1a1a; color: #e0e0e0; padding: 32px; }
+    h1 { font-size: 20px; font-weight: 600; margin-bottom: 8px; }
+    .subtitle { color: #888; margin-bottom: 24px; font-size: 14px; }
+    .controls { display: flex; gap: 12px; margin-bottom: 24px; align-items: center; }
+    button { padding: 8px 16px; border: 1px solid #444; border-radius: 6px; background: #2a2a2a; color: #e0e0e0; cursor: pointer; font-size: 14px; }
+    button:hover { background: #333; }
+    button:disabled { opacity: 0.4; cursor: not-allowed; }
+    button.primary { background: #3b82f6; border-color: #3b82f6; }
+    button.primary:hover { background: #2563eb; }
+    select, input { padding: 6px 10px; border: 1px solid #444; border-radius: 6px; background: #2a2a2a; color: #e0e0e0; font-size: 14px; }
+    .canvases { display: flex; gap: 24px; margin-bottom: 24px; }
+    .canvas-box { flex: 1; }
+    .canvas-box h3 { font-size: 14px; margin-bottom: 8px; color: #aaa; }
+    canvas { width: 100%; aspect-ratio: 16/10; border: 1px solid #333; border-radius: 8px; background: #000; }
+    .results { background: #222; border: 1px solid #333; border-radius: 8px; padding: 20px; font-family: 'SF Mono', 'Fira Code', monospace; font-size: 13px; line-height: 1.8; white-space: pre; overflow-x: auto; }
+    .status { color: #888; font-size: 13px; margin-bottom: 12px; }
+    .winner { color: #4ade80; }
+    .loser { color: #f87171; }
+    .header-row { color: #60a5fa; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <h1>OpenPencil Render Benchmark</h1>
+  <p class="subtitle">WebGL (Ganesh) vs WebGPU (Graphite) — same scene, same renderer</p>
+
+  <div class="controls">
+    <label>Nodes: <input type="number" id="nodeCount" value="500" min="10" max="5000" step="10"></label>
+    <label>Frames: <input type="number" id="iterations" value="200" min="10" max="2000" step="10"></label>
+    <button id="runBtn" class="primary">Run Benchmark</button>
+    <button id="sweepBtn">Run Sweep (100–5000)</button>
+    <span class="status" id="status"></span>
+  </div>
+
+  <div class="canvases">
+    <div class="canvas-box">
+      <h3>WebGL (Ganesh)</h3>
+      <canvas id="webgl-canvas"></canvas>
+    </div>
+    <div class="canvas-box">
+      <h3>WebGPU (Graphite)</h3>
+      <canvas id="webgpu-canvas"></canvas>
+    </div>
+  </div>
+
+  <div class="results" id="results">Click "Run Benchmark" to start...</div>
+
+  <script type="module">
+    const status = document.getElementById('status')
+    const resultsEl = document.getElementById('results')
+    const runBtn = document.getElementById('runBtn')
+
+    function log(text) { resultsEl.textContent = text }
+
+    function loadCKScript(src, locateFile) {
+      return new Promise((resolve, reject) => {
+        const prev = globalThis.CanvasKitInit
+        globalThis.CanvasKitInit = undefined
+        const script = document.createElement('script')
+        script.src = src
+        script.onload = () => {
+          const init = globalThis.CanvasKitInit
+          globalThis.CanvasKitInit = prev
+          if (!init) return reject(new Error('CanvasKitInit not found'))
+          init({ locateFile }).then(resolve, reject)
+        }
+        script.onerror = () => reject(new Error(`Failed to load ${src}`))
+        document.head.appendChild(script)
+      })
+    }
+
+    function loadCanvasKitWebGL() {
+      return loadCKScript(
+        '/node_modules/canvaskit-wasm/bin/canvaskit.js',
+        (f) => `/node_modules/canvaskit-wasm/bin/${f}`
+      )
+    }
+
+    function loadCanvasKitWebGPU() {
+      return loadCKScript(
+        '/canvaskit-webgpu/canvaskit.js',
+        (f) => `/canvaskit-webgpu/${f}`
+      )
+    }
+
+    function createScene(ck, canvas, isWebGPU, nodeCount, gpuCanvasCtx) {
+      const dpr = window.devicePixelRatio || 1
+      const w = canvas.clientWidth
+      const h = canvas.clientHeight
+      canvas.width = w * dpr
+      canvas.height = h * dpr
+
+      let surface
+      if (isWebGPU) {
+        surface = ck.MakeGPUCanvasSurface(gpuCanvasCtx, ck.ColorSpace.SRGB)
+      } else {
+        surface = ck.MakeWebGLCanvasSurface(canvas)
+      }
+
+      if (!surface) throw new Error(`Failed to create ${isWebGPU ? 'WebGPU' : 'WebGL'} surface`)
+
+      const paint = new ck.Paint()
+      paint.setAntiAlias(true)
+      const strokePaint = new ck.Paint()
+      strokePaint.setAntiAlias(true)
+      strokePaint.setStyle(ck.PaintStyle.Stroke)
+      strokePaint.setStrokeWidth(1)
+      strokePaint.setColor(ck.Color(0, 0, 0, 255))
+
+      const cols = Math.ceil(Math.sqrt(nodeCount))
+      const rects = []
+      const colors = []
+      const radii = []
+      const rng = new Uint8Array(nodeCount * 3)
+      crypto.getRandomValues(rng)
+      for (let i = 0; i < nodeCount; i++) {
+        const x = (i % cols) * 60
+        const y = Math.floor(i / cols) * 60
+        rects.push(ck.LTRBRect(x, y, x + 50, y + 50))
+        colors.push(ck.Color(rng[i*3], rng[i*3+1], rng[i*3+2], 255))
+        radii.push(i % 5 === 0 ? 25 : 8)
+      }
+
+      function drawScene(skCanvas, panX, panY, zoom) {
+        skCanvas.clear(ck.Color(245, 245, 245, 255))
+        skCanvas.save()
+        skCanvas.scale(dpr, dpr)
+        skCanvas.translate(panX, panY)
+        skCanvas.scale(zoom, zoom)
+        for (let i = 0; i < nodeCount; i++) {
+          const r = radii[i]
+          const rect = rects[i]
+          const rrect = ck.RRectXY(rect, r, r)
+          paint.setColor(colors[i])
+          skCanvas.drawRRect(rrect, paint)
+          skCanvas.drawRRect(rrect, strokePaint)
+        }
+        skCanvas.restore()
+      }
+
+      return { surface, gpuCanvasCtx, drawScene, paint, strokePaint, ck }
+    }
+
+    function runBenchmark(scene, iterations, benchType, isWebGPU) {
+      const { surface, gpuCanvasCtx, drawScene, ck } = scene
+      const times = []
+
+      for (let i = 0; i < iterations; i++) {
+        let skCanvas
+        if (isWebGPU && gpuCanvasCtx) {
+          skCanvas = ck.BeginFrame(gpuCanvasCtx)
+          if (!skCanvas) throw new Error('BeginFrame returned null')
+        } else {
+          skCanvas = surface.getCanvas()
+        }
+
+        const start = performance.now()
+
+        if (benchType === 'pan') {
+          drawScene(skCanvas, i * 2, i, 1)
+        } else if (benchType === 'zoom') {
+          drawScene(skCanvas, 0, 0, 0.5 + (i / iterations) * 2)
+        } else {
+          drawScene(skCanvas, 0, 0, 1)
+        }
+
+        if (isWebGPU) {
+          ck.EndFrame()
+        } else {
+          surface.flush()
+        }
+        times.push(performance.now() - start)
+      }
+
+      times.sort((a, b) => a - b)
+      const p50 = times[Math.floor(times.length * 0.5)]
+      const p95 = times[Math.floor(times.length * 0.95)]
+      const p99 = times[Math.floor(times.length * 0.99)]
+      const avg = times.reduce((s, t) => s + t, 0) / times.length
+      const total = times.reduce((s, t) => s + t, 0)
+      return {
+        avg: Math.round(avg * 100) / 100,
+        p50: Math.round(p50 * 100) / 100,
+        p95: Math.round(p95 * 100) / 100,
+        p99: Math.round(p99 * 100) / 100,
+        total: Math.round(total),
+        fps: Math.round(1000 / avg)
+      }
+    }
+
+    function formatResults(nodeCount, iterations, webgl, webgpu) {
+      const tests = ['pan', 'zoom', 'static']
+      const labels = { pan: 'Pan (translate)', zoom: 'Zoom (scale)', static: 'Static redraw' }
+
+      let out = `═══ BENCHMARK: ${nodeCount} nodes × ${iterations} frames ═══\n\n`
+      out += `${'Test'.padEnd(18)} ${'Metric'.padEnd(8)} ${'WebGL'.padStart(10)} ${'WebGPU'.padStart(10)} ${'Δ'.padStart(10)}\n`
+      out += '─'.repeat(60) + '\n'
+
+      for (const test of tests) {
+        const gl = webgl[test]
+        const gpu = webgpu[test]
+        if (!gl || !gpu) continue
+
+        for (const metric of ['avg', 'p50', 'p95', 'p99']) {
+          const label = metric === 'avg' ? labels[test] : ''
+          const glVal = gl[metric]
+          const gpuVal = gpu[metric]
+          const ratio = glVal / gpuVal
+          const delta = gpuVal === 0 && glVal === 0 ? 'tied'
+            : gpuVal === 0 ? '∞x faster'
+            : glVal === 0 ? '∞x slower'
+            : ratio > 1 ? `${ratio.toFixed(1)}x faster`
+            : `${(1/ratio).toFixed(1)}x slower`
+
+          out += `${label.padEnd(18)} ${metric.padEnd(8)} ${(glVal + 'ms').padStart(10)} ${(gpuVal + 'ms').padStart(10)} ${delta.padStart(10)}\n`
+        }
+
+        out += `${''.padEnd(18)} ${'fps'.padEnd(8)} ${(gl.fps + '').padStart(10)} ${(gpu.fps + '').padStart(10)}\n`
+        out += '\n'
+      }
+
+      return out
+    }
+
+    let ckGL = null, ckGPU = null, hasWebGPU = false, gpuCanvasCtx = null
+
+    async function initBackends() {
+      if (ckGL) return
+      status.textContent = 'Loading WebGL CanvasKit...'
+      ckGL = await loadCanvasKitWebGL()
+
+      try {
+        if (!navigator.gpu) throw new Error('No navigator.gpu — enable WebGPU in chrome://flags')
+        status.textContent = 'Requesting WebGPU adapter...'
+        const adapter = await navigator.gpu.requestAdapter()
+        if (!adapter) throw new Error('No WebGPU adapter')
+        status.textContent = 'Requesting WebGPU device...'
+        window._benchGpuDevice = await adapter.requestDevice()
+        status.textContent = 'Loading WebGPU CanvasKit WASM...'
+        ckGPU = await loadCanvasKitWebGPU()
+        const gpuDevCtx = ckGPU.MakeGPUDeviceContext(window._benchGpuDevice)
+        gpuCanvasCtx = ckGPU.MakeGPUCanvasContext(gpuDevCtx, document.getElementById('webgpu-canvas'))
+        hasWebGPU = true
+      } catch (e) {
+        console.error('WebGPU init failed:', e)
+        status.textContent = `WebGPU unavailable: ${e.message}. Running WebGL only.`
+        await new Promise(r => setTimeout(r, 2000))
+      }
+    }
+
+    async function runSingle(nodeCount, iterations) {
+      const results = { webgl: {}, webgpu: {} }
+
+      for (const test of ['pan', 'zoom', 'static']) {
+        status.textContent = `WebGL: ${test} (${nodeCount} nodes)...`
+        await new Promise(r => setTimeout(r, 50))
+        const glCanvas = document.getElementById('webgl-canvas')
+        const glScene = createScene(ckGL, glCanvas, false, nodeCount)
+        results.webgl[test] = runBenchmark(glScene, iterations, test, false)
+        glScene.paint.delete()
+        glScene.strokePaint.delete()
+        glScene.surface.delete()
+
+        if (hasWebGPU) {
+          status.textContent = `WebGPU: ${test} (${nodeCount} nodes)...`
+          await new Promise(r => setTimeout(r, 50))
+          const gpuCanvas = document.getElementById('webgpu-canvas')
+          const gpuScene = createScene(ckGPU, gpuCanvas, true, nodeCount, gpuCanvasCtx)
+          results.webgpu[test] = runBenchmark(gpuScene, iterations, test, true)
+          gpuScene.paint.delete()
+          gpuScene.strokePaint.delete()
+        }
+      }
+
+      return results
+    }
+
+    runBtn.addEventListener('click', async () => {
+      runBtn.disabled = true
+      document.getElementById('sweepBtn').disabled = true
+      try {
+        await initBackends()
+        const nodeCount = parseInt(document.getElementById('nodeCount').value)
+        const iterations = parseInt(document.getElementById('iterations').value)
+        const results = await runSingle(nodeCount, iterations)
+        status.textContent = 'Done!'
+        log(formatResults(nodeCount, iterations, results.webgl, hasWebGPU ? results.webgpu : {}))
+      } catch (e) {
+        status.textContent = `Error: ${e.message}`
+        console.error(e)
+      } finally {
+        runBtn.disabled = false
+        document.getElementById('sweepBtn').disabled = false
+      }
+    })
+
+    document.getElementById('sweepBtn').addEventListener('click', async () => {
+      runBtn.disabled = true
+      document.getElementById('sweepBtn').disabled = true
+      try {
+        await initBackends()
+        const counts = [100, 250, 500, 1000, 2000, 3000, 5000]
+        const iterations = 100
+
+        let out = `═══ SWEEP BENCHMARK (${iterations} frames per test) ═══\n\n`
+        out += `${'Nodes'.padStart(7)} ${'Test'.padEnd(18)} ${'WebGL avg'.padStart(11)} ${'WebGPU avg'.padStart(12)} ${'Δ'.padStart(12)}\n`
+        out += '─'.repeat(65) + '\n'
+
+        for (const count of counts) {
+          const results = await runSingle(count, iterations)
+          for (const test of ['pan', 'zoom', 'static']) {
+            const labels = { pan: 'Pan', zoom: 'Zoom', static: 'Static' }
+            const gl = results.webgl[test]
+            const gpu = hasWebGPU ? results.webgpu[test] : null
+            const gpuStr = gpu ? `${gpu.avg}ms` : 'n/a'
+            let delta = ''
+            if (gpu) {
+              const ratio = gl.avg / gpu.avg
+              delta = gpu.avg === 0 && gl.avg === 0 ? 'tied'
+                : gpu.avg === 0 ? '∞x faster'
+                : gl.avg === 0 ? '∞x slower'
+                : ratio > 1 ? `${ratio.toFixed(1)}x faster`
+                : `${(1/ratio).toFixed(1)}x slower`
+            }
+            out += `${(count + '').padStart(7)} ${labels[test].padEnd(18)} ${(gl.avg + 'ms').padStart(11)} ${gpuStr.padStart(12)} ${delta.padStart(12)}\n`
+          }
+          out += '\n'
+          log(out + '(running...)')
+        }
+
+        status.textContent = 'Done!'
+        log(out.replace('(running...)', ''))
+      } catch (e) {
+        status.textContent = `Error: ${e.message}`
+        console.error(e)
+      } finally {
+        runBtn.disabled = false
+        document.getElementById('sweepBtn').disabled = false
+      }
+    })
+  </script>
+</body>
+</html>

--- a/src/components/properties/TypographySection.vue
+++ b/src/components/properties/TypographySection.vue
@@ -80,7 +80,9 @@ onMounted(async () => {
       <icon-lucide-alert-triangle
         v-if="hasMissingFonts"
         class="size-3.5 shrink-0 text-amber-400"
-        :title="'Missing font' + (missingFonts.length > 1 ? 's' : '') + ': ' + missingFonts.join(', ')"
+        :title="
+          'Missing font' + (missingFonts.length > 1 ? 's' : '') + ': ' + missingFonts.join(', ')
+        "
       />
     </div>
 

--- a/src/composables/use-canvas-input.ts
+++ b/src/composables/use-canvas-input.ts
@@ -919,6 +919,29 @@ export function useCanvasInput(
     cursorOverride.value = null
   }
 
+  let wheelAccum = {
+    deltaX: 0,
+    deltaY: 0,
+    zoomDelta: 0,
+    zoomCenterX: 0,
+    zoomCenterY: 0,
+    hasZoom: false,
+    rafId: 0
+  }
+
+  function flushWheel() {
+    wheelAccum.rafId = 0
+    if (wheelAccum.hasZoom) {
+      store.applyZoom(wheelAccum.zoomDelta, wheelAccum.zoomCenterX, wheelAccum.zoomCenterY)
+    } else {
+      store.pan(wheelAccum.deltaX, wheelAccum.deltaY)
+    }
+    wheelAccum.deltaX = 0
+    wheelAccum.deltaY = 0
+    wheelAccum.zoomDelta = 0
+    wheelAccum.hasZoom = false
+  }
+
   function onWheel(e: WheelEvent) {
     e.preventDefault()
     const canvas = canvasRef.value
@@ -926,11 +949,16 @@ export function useCanvasInput(
 
     if (e.ctrlKey || e.metaKey) {
       const rect = canvas.getBoundingClientRect()
-      const sx = e.clientX - rect.left
-      const sy = e.clientY - rect.top
-      store.applyZoom(e.deltaY, sx, sy)
+      wheelAccum.zoomCenterX = e.clientX - rect.left
+      wheelAccum.zoomCenterY = e.clientY - rect.top
+      wheelAccum.zoomDelta += e.deltaY
+      wheelAccum.hasZoom = true
     } else {
-      store.pan(-e.deltaX, -e.deltaY)
+      wheelAccum.deltaX -= e.deltaX
+      wheelAccum.deltaY -= e.deltaY
+    }
+    if (!wheelAccum.rafId) {
+      wheelAccum.rafId = requestAnimationFrame(flushWheel)
     }
   }
 
@@ -1161,6 +1189,22 @@ export function useCanvasInput(
 
   // Safari macOS: trackpad pinch-to-zoom uses gesture events, not wheel+ctrlKey
   let gestureStartZoom = 1
+  let gestureRafId = 0
+  let pendingGesture: { scale: number; sx: number; sy: number } | null = null
+
+  function flushGesture() {
+    gestureRafId = 0
+    if (!pendingGesture) return
+    const { scale, sx, sy } = pendingGesture
+    pendingGesture = null
+    const newZoom = Math.max(0.02, Math.min(256, gestureStartZoom * scale))
+    const zoomRatio = newZoom / store.state.zoom
+    store.state.panX = sx - (sx - store.state.panX) * zoomRatio
+    store.state.panY = sy - (sy - store.state.panY) * zoomRatio
+    store.state.zoom = newZoom
+    store.requestRepaint()
+  }
+
   useEventListener(
     canvasRef,
     'gesturestart' as keyof HTMLElementEventMap,
@@ -1179,14 +1223,14 @@ export function useCanvasInput(
       const canvas = canvasRef.value
       if (!canvas) return
       const rect = canvas.getBoundingClientRect()
-      const sx = (ge.clientX ?? rect.width / 2) - rect.left
-      const sy = (ge.clientY ?? rect.height / 2) - rect.top
-      const newZoom = Math.max(0.02, Math.min(256, gestureStartZoom * ge.scale))
-      const zoomRatio = newZoom / store.state.zoom
-      store.state.panX = sx - (sx - store.state.panX) * zoomRatio
-      store.state.panY = sy - (sy - store.state.panY) * zoomRatio
-      store.state.zoom = newZoom
-      store.requestRepaint()
+      pendingGesture = {
+        scale: ge.scale,
+        sx: (ge.clientX ?? rect.width / 2) - rect.left,
+        sy: (ge.clientY ?? rect.height / 2) - rect.top
+      }
+      if (!gestureRafId) {
+        gestureRafId = requestAnimationFrame(flushGesture)
+      }
     },
     { passive: false }
   )

--- a/src/composables/use-canvas.ts
+++ b/src/composables/use-canvas.ts
@@ -1,5 +1,5 @@
-import { useResizeObserver } from '@vueuse/core'
-import { onMounted, onUnmounted, watch, type Ref } from 'vue'
+import { useRafFn, useResizeObserver } from '@vueuse/core'
+import { onMounted, onUnmounted, type Ref } from 'vue'
 
 import { getCanvasKit } from '@/engine/canvaskit'
 import { SkiaRenderer } from '@/engine/renderer'
@@ -11,6 +11,9 @@ export function useCanvas(canvasRef: Ref<HTMLCanvasElement | null>, store: Edito
   let renderer: SkiaRenderer | null = null
   let ck: CanvasKit | null = null
   let destroyed = false
+  let dirty = true
+  let lastRenderVersion = -1
+  let lastSelectedIds: Set<string> | null = null
 
   async function init() {
     const canvas = canvasRef.value
@@ -62,8 +65,6 @@ export function useCanvas(canvasRef: Ref<HTMLCanvasElement | null>, store: Edito
   const params = new URLSearchParams(window.location.search)
   const showRulers = !params.has('no-rulers')
 
-  let rafId = 0
-
   function renderNow() {
     if (!renderer) return
     renderer.dpr = window.devicePixelRatio || 1
@@ -98,15 +99,18 @@ export function useCanvas(canvasRef: Ref<HTMLCanvasElement | null>, store: Edito
       },
       store.state.sceneVersion
     )
+    lastRenderVersion = store.state.renderVersion
+    lastSelectedIds = store.state.selectedIds
   }
 
-  function render() {
-    if (rafId) return
-    rafId = requestAnimationFrame(() => {
-      rafId = 0
+  const { pause } = useRafFn(() => {
+    const versionChanged = store.state.renderVersion !== lastRenderVersion
+    const selectionChanged = store.state.selectedIds !== lastSelectedIds
+    if (dirty || versionChanged || selectionChanged) {
+      dirty = false
       renderNow()
-    })
-  }
+    }
+  })
 
   onMounted(() => {
     init()
@@ -114,7 +118,7 @@ export function useCanvas(canvasRef: Ref<HTMLCanvasElement | null>, store: Edito
 
   onUnmounted(() => {
     destroyed = true
-    cancelAnimationFrame(rafId)
+    pause()
     cancelAnimationFrame(resizeRaf)
     renderer?.destroy()
   })
@@ -129,16 +133,6 @@ export function useCanvas(canvasRef: Ref<HTMLCanvasElement | null>, store: Edito
     })
   })
 
-  watch(
-    () => store.state.renderVersion,
-    () => render()
-  )
-
-  watch(
-    () => store.state.selectedIds,
-    () => render()
-  )
-
   function hitTestSectionTitle(canvasX: number, canvasY: number) {
     return renderer?.hitTestSectionTitle(store.graph, canvasX, canvasY) ?? null
   }
@@ -147,5 +141,11 @@ export function useCanvas(canvasRef: Ref<HTMLCanvasElement | null>, store: Edito
     return renderer?.hitTestComponentLabel(store.graph, canvasX, canvasY) ?? null
   }
 
-  return { render, hitTestSectionTitle, hitTestComponentLabel }
+  return {
+    render: () => {
+      dirty = true
+    },
+    hitTestSectionTitle,
+    hitTestComponentLabel
+  }
 }

--- a/src/composables/use-canvas.ts
+++ b/src/composables/use-canvas.ts
@@ -1,15 +1,90 @@
 import { useRafFn, useResizeObserver } from '@vueuse/core'
 import { onMounted, onUnmounted, type Ref } from 'vue'
 
-import { getCanvasKit } from '@/engine/canvaskit'
+import { getCanvasKit, getGpuBackend } from '@/engine/canvaskit'
 import { SkiaRenderer } from '@/engine/renderer'
 
 import type { EditorStore } from '@/stores/editor'
-import type { CanvasKit } from 'canvaskit-wasm'
+import type { CanvasKit, Surface } from 'canvaskit-wasm'
+
+interface WebGPUContext {
+  device: GPUDevice
+  deviceContext: unknown
+}
+
+interface CanvasKitWebGPU {
+  MakeGPUDeviceContext(device: GPUDevice): unknown
+  MakeGPUCanvasContext(ctx: unknown, canvas: HTMLCanvasElement, opts?: unknown): unknown
+  MakeGPUCanvasSurface(
+    ctx: unknown,
+    colorSpace?: unknown,
+    width?: number,
+    height?: number
+  ): ReturnType<CanvasKit['MakeSurface']>
+}
+
+function asWebGPU(ck: CanvasKit): CanvasKitWebGPU {
+  return ck as unknown as CanvasKitWebGPU
+}
+
+async function initWebGPU(ck: CanvasKit): Promise<WebGPUContext | null> {
+  if (!('gpu' in navigator)) return null
+  const adapter = await navigator.gpu.requestAdapter()
+  if (!adapter) return null
+  const device = await adapter.requestDevice()
+  const deviceContext = asWebGPU(ck).MakeGPUDeviceContext?.(device)
+  if (!deviceContext) return null
+  return { device, deviceContext }
+}
+
+/**
+ * Graphite requires a fresh SkSurface wrapping the current swapchain texture each frame.
+ * This proxy implements the Surface interface but creates a real surface on getCanvas()
+ * and disposes it on flush(), transparent to the renderer.
+ */
+function makeWebGPUSurfaceProxy(ck: CanvasKit, canvasCtx: unknown): Surface {
+  const gpu = asWebGPU(ck)
+  let frameSurface: Surface | null = null
+
+  return {
+    getCanvas() {
+      if (frameSurface) {
+        frameSurface.delete()
+        frameSurface = null
+      }
+      frameSurface = gpu.MakeGPUCanvasSurface(canvasCtx, ck.ColorSpace.SRGB)
+      if (!frameSurface) {
+        console.error('[WebGPU] MakeGPUCanvasSurface returned null')
+        throw new Error('Failed to create WebGPU frame surface')
+      }
+      return frameSurface.getCanvas()
+    },
+    flush() {
+      if (frameSurface) {
+        frameSurface.flush()
+        frameSurface = null
+        // Don't dispose — let the swapchain texture live until next getCanvas()
+      }
+    },
+    reportBackendTypeIsGPU: () => true,
+    width: () => 0,
+    height: () => 0,
+    delete() {
+      frameSurface?.dispose()
+      frameSurface = null
+    },
+    dispose() {
+      frameSurface?.dispose()
+      frameSurface = null
+    },
+    isDeleted: () => false
+  } as unknown as Surface
+}
 
 export function useCanvas(canvasRef: Ref<HTMLCanvasElement | null>, store: EditorStore) {
   let renderer: SkiaRenderer | null = null
   let ck: CanvasKit | null = null
+  let gpuCtx: WebGPUContext | null = null
   let destroyed = false
   let dirty = true
   let lastRenderVersion = -1
@@ -21,6 +96,14 @@ export function useCanvas(canvasRef: Ref<HTMLCanvasElement | null>, store: Edito
 
     ck = await getCanvasKit()
     if (destroyed) return
+
+    if (getGpuBackend() === 'webgpu') {
+      gpuCtx = await initWebGPU(ck)
+      if (!gpuCtx) {
+        console.warn('WebGPU init failed, reload without ?gpu=webgpu to use WebGL')
+        return
+      }
+    }
 
     await new Promise((r) => requestAnimationFrame(r))
     createSurface(canvas)
@@ -44,15 +127,26 @@ export function useCanvas(canvasRef: Ref<HTMLCanvasElement | null>, store: Edito
     canvas.width = w * dpr
     canvas.height = h * dpr
 
-    const isTest = new URLSearchParams(window.location.search).has('test')
-    const surface = ck.MakeWebGLCanvasSurface(
-      canvas,
-      undefined,
-      isTest ? { preserveDrawingBuffer: 1 } : undefined
-    )
-    if (!surface) {
-      console.error('Failed to create WebGL surface')
-      return
+    let surface
+    if (getGpuBackend() === 'webgpu' && gpuCtx) {
+      const gpu = asWebGPU(ck)
+      const canvasCtx = gpu.MakeGPUCanvasContext(gpuCtx.deviceContext, canvas)
+      if (!canvasCtx) {
+        console.error('Failed to create WebGPU canvas context')
+        return
+      }
+      surface = makeWebGPUSurfaceProxy(ck, canvasCtx)
+    } else {
+      const isTest = new URLSearchParams(window.location.search).has('test')
+      surface = ck.MakeWebGLCanvasSurface(
+        canvas,
+        undefined,
+        isTest ? { preserveDrawingBuffer: 1 } : undefined
+      )
+      if (!surface) {
+        console.error('Failed to create WebGL surface')
+        return
+      }
     }
 
     renderer = new SkiaRenderer(ck, surface)

--- a/src/composables/use-canvas.ts
+++ b/src/composables/use-canvas.ts
@@ -21,6 +21,8 @@ interface CanvasKitWebGPU {
     width?: number,
     height?: number
   ): ReturnType<CanvasKit['MakeSurface']>
+  BeginFrame(canvasCtx: unknown): ReturnType<CanvasKit['MakeSurface']>['getCanvas']
+  EndFrame(): void
 }
 
 function asWebGPU(ck: CanvasKit): CanvasKitWebGPU {
@@ -39,44 +41,26 @@ async function initWebGPU(ck: CanvasKit): Promise<WebGPUContext | null> {
 
 /**
  * Graphite requires a fresh SkSurface wrapping the current swapchain texture each frame.
- * This proxy implements the Surface interface but creates a real surface on getCanvas()
- * and disposes it on flush(), transparent to the renderer.
+ * This proxy uses BeginFrame/EndFrame for minimal JS↔WASM overhead — a single WASM call
+ * per frame boundary instead of creating/destroying JS Surface objects.
  */
 function makeWebGPUSurfaceProxy(ck: CanvasKit, canvasCtx: unknown): Surface {
   const gpu = asWebGPU(ck)
-  let frameSurface: Surface | null = null
 
   return {
     getCanvas() {
-      if (frameSurface) {
-        frameSurface.delete()
-        frameSurface = null
-      }
-      frameSurface = gpu.MakeGPUCanvasSurface(canvasCtx, ck.ColorSpace.SRGB)
-      if (!frameSurface) {
-        console.error('[WebGPU] MakeGPUCanvasSurface returned null')
-        throw new Error('Failed to create WebGPU frame surface')
-      }
-      return frameSurface.getCanvas()
+      const canvas = gpu.BeginFrame(canvasCtx)
+      if (!canvas) throw new Error('BeginFrame returned null')
+      return canvas
     },
     flush() {
-      if (frameSurface) {
-        frameSurface.flush()
-        frameSurface = null
-        // Don't dispose — let the swapchain texture live until next getCanvas()
-      }
+      gpu.EndFrame()
     },
     reportBackendTypeIsGPU: () => true,
     width: () => 0,
     height: () => 0,
-    delete() {
-      frameSurface?.dispose()
-      frameSurface = null
-    },
-    dispose() {
-      frameSurface?.dispose()
-      frameSurface = null
-    },
+    delete() {},
+    dispose() {},
     isDeleted: () => false
   } as unknown as Surface
 }

--- a/src/engine/canvaskit.ts
+++ b/src/engine/canvaskit.ts
@@ -1,1 +1,6 @@
-export { getCanvasKit, type CanvasKitOptions } from '@open-pencil/core'
+export {
+  getCanvasKit,
+  getGpuBackend,
+  type CanvasKitOptions,
+  type GpuBackend
+} from '@open-pencil/core'

--- a/src/stores/editor.ts
+++ b/src/stores/editor.ts
@@ -1,4 +1,4 @@
-import { reactive, shallowRef, computed, watch } from 'vue'
+import { shallowReactive, shallowRef, computed, watch } from 'vue'
 
 import {
   IS_TAURI,
@@ -142,7 +142,7 @@ export function createEditorStore() {
     }, 100)
   }
 
-  const state = reactive({
+  const state = shallowReactive({
     activeTool: 'SELECT' as Tool,
     currentPageId: graph.getPages()[0].id,
     selectedIds: new Set<string>(),
@@ -1446,7 +1446,9 @@ export function createEditorStore() {
       },
       inverse: () => {
         graph.deleteNode(id)
-        state.selectedIds.delete(id)
+        const next = new Set(state.selectedIds)
+        next.delete(id)
+        state.selectedIds = next
         requestRender()
       }
     })

--- a/tests/e2e/zoom-pan.spec.ts
+++ b/tests/e2e/zoom-pan.spec.ts
@@ -1,0 +1,285 @@
+import { test, expect } from '@playwright/test'
+import { CanvasHelper } from '../helpers/canvas'
+
+const NODE_COUNT = 200
+
+test.describe('Zoom and pan', () => {
+  let helper: CanvasHelper
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage()
+    helper = new CanvasHelper(page)
+    await page.goto('http://localhost:1420/?test&no-chrome')
+    await helper.waitForInit()
+
+    await page.evaluate((count: number) => {
+      const store = window.__OPEN_PENCIL_STORE__!
+      const cols = Math.ceil(Math.sqrt(count))
+      for (let i = 0; i < count; i++) {
+        store.graph.createNode('RECTANGLE', store.state.currentPageId, {
+          x: (i % cols) * 60,
+          y: Math.floor(i / cols) * 60,
+          width: 50,
+          height: 50,
+          fills: [{ type: 'SOLID', color: { r: 0.5, g: 0.5, b: 0.8, a: 1 }, visible: true, opacity: 1 }]
+        })
+      }
+      store.requestRender()
+    }, NODE_COUNT)
+    await helper.waitForRender()
+  })
+
+  test.afterAll(async () => {
+    await helper.page.close()
+  })
+
+  test('wheel zoom updates viewport correctly', async () => {
+    const before = await helper.page.evaluate(() => {
+      const store = window.__OPEN_PENCIL_STORE__!
+      return { panX: store.state.panX, panY: store.state.panY, zoom: store.state.zoom }
+    })
+
+    // Playwright's mouse.wheel doesn't set ctrlKey, dispatch manually
+    await helper.page.evaluate(() => {
+      const canvas = document.querySelector('canvas')!
+      canvas.dispatchEvent(
+        new WheelEvent('wheel', {
+          deltaY: -100,
+          ctrlKey: true,
+          clientX: 400,
+          clientY: 300,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+    })
+    await helper.waitForRender()
+    await helper.page.waitForTimeout(50)
+
+    const after = await helper.page.evaluate(() => {
+      const store = window.__OPEN_PENCIL_STORE__!
+      return { panX: store.state.panX, panY: store.state.panY, zoom: store.state.zoom }
+    })
+
+    expect(after.zoom).not.toBe(before.zoom)
+    helper.assertNoErrors()
+  })
+
+  test('wheel pan updates viewport correctly', async () => {
+    const before = await helper.page.evaluate(() => {
+      const store = window.__OPEN_PENCIL_STORE__!
+      return { panX: store.state.panX, panY: store.state.panY }
+    })
+
+    const box = await helper.canvas.boundingBox()
+    await helper.page.mouse.move(box!.x + 400, box!.y + 300)
+
+    // Playwright wheel without ctrl → pan
+    await helper.page.evaluate(() => {
+      const canvas = document.querySelector('canvas')!
+      canvas.dispatchEvent(
+        new WheelEvent('wheel', { deltaX: 100, deltaY: 50, bubbles: true, cancelable: true })
+      )
+    })
+    await helper.waitForRender()
+    await helper.page.waitForTimeout(50)
+
+    const after = await helper.page.evaluate(() => {
+      const store = window.__OPEN_PENCIL_STORE__!
+      return { panX: store.state.panX, panY: store.state.panY }
+    })
+
+    expect(after.panX).toBeLessThan(before.panX)
+    expect(after.panY).toBeLessThan(before.panY)
+    helper.assertNoErrors()
+  })
+
+  test('rapid wheel events are coalesced without errors', async () => {
+    await helper.page.evaluate(() => {
+      const canvas = document.querySelector('canvas')!
+      for (let i = 0; i < 50; i++) {
+        canvas.dispatchEvent(
+          new WheelEvent('wheel', {
+            deltaX: 0,
+            deltaY: -5,
+            ctrlKey: true,
+            clientX: 400,
+            clientY: 300,
+            bubbles: true,
+            cancelable: true
+          })
+        )
+      }
+    })
+    await helper.waitForRender()
+    await helper.page.waitForTimeout(50)
+
+    const state = await helper.page.evaluate(() => {
+      const store = window.__OPEN_PENCIL_STORE__!
+      return { zoom: store.state.zoom }
+    })
+
+    expect(state.zoom).toBeGreaterThan(0)
+    expect(state.zoom).toBeLessThan(256)
+    helper.assertNoErrors()
+  })
+
+  test('shallowReactive: selection replace triggers UI update', async () => {
+    const result = await helper.page.evaluate(() => {
+      const store = window.__OPEN_PENCIL_STORE__!
+      const pageNode = store.graph.getNode(store.state.currentPageId)!
+      const firstId = pageNode.childIds[0]
+
+      store.select([firstId])
+      const after = store.state.selectedIds.has(firstId)
+      const size = store.state.selectedIds.size
+
+      store.clearSelection()
+      const cleared = store.state.selectedIds.size
+
+      return { after, size, cleared }
+    })
+
+    expect(result.after).toBe(true)
+    expect(result.size).toBe(1)
+    expect(result.cleared).toBe(0)
+  })
+
+  test('useRafFn loop picks up renderVersion changes', async () => {
+    // Ensure clean state, wait for any pending renders
+    await helper.page.evaluate(() => {
+      const store = window.__OPEN_PENCIL_STORE__!
+      store.state.panX = 0
+      store.state.panY = 0
+      store.state.zoom = 1
+      store.clearSelection()
+      store.requestRender()
+    })
+    await helper.waitForRender()
+    await helper.page.waitForTimeout(100)
+    const before = await helper.screenshotCanvas()
+
+    // Change fill color — always visible
+    await helper.page.evaluate(() => {
+      const store = window.__OPEN_PENCIL_STORE__!
+      const pageNode = store.graph.getNode(store.state.currentPageId)!
+      const firstId = pageNode.childIds[0]
+      store.graph.updateNode(firstId, {
+        fills: [{ type: 'SOLID', color: { r: 1, g: 0, b: 0, a: 1 }, visible: true, opacity: 1 }]
+      })
+      store.requestRender()
+    })
+    await helper.waitForRender()
+    await helper.page.waitForTimeout(100)
+
+    const after = await helper.screenshotCanvas()
+    expect(Buffer.from(before)).not.toEqual(Buffer.from(after))
+
+    // Restore
+    await helper.page.evaluate(() => {
+      const store = window.__OPEN_PENCIL_STORE__!
+      const pageNode = store.graph.getNode(store.state.currentPageId)!
+      const firstId = pageNode.childIds[0]
+      store.graph.updateNode(firstId, {
+        fills: [{ type: 'SOLID', color: { r: 0.5, g: 0.5, b: 0.8, a: 1 }, visible: true, opacity: 1 }]
+      })
+      store.requestRender()
+    })
+    await helper.waitForRender()
+  })
+
+  test('useRafFn loop picks up selection changes', async () => {
+    const before = await helper.screenshotCanvas()
+
+    await helper.page.evaluate(() => {
+      const store = window.__OPEN_PENCIL_STORE__!
+      const pageNode = store.graph.getNode(store.state.currentPageId)!
+      store.select([pageNode.childIds[0]])
+    })
+    await helper.waitForRender()
+    await helper.page.waitForTimeout(50)
+
+    const after = await helper.screenshotCanvas()
+    // Selection border should change the rendering
+    expect(Buffer.from(before)).not.toEqual(Buffer.from(after))
+
+    await helper.page.evaluate(() => {
+      window.__OPEN_PENCIL_STORE__!.clearSelection()
+    })
+    await helper.waitForRender()
+  })
+
+  test('benchmark: zoom/pan pipeline throughput', async () => {
+    const ITERATIONS = 500
+
+    const results = await helper.page.evaluate((iterations: number) => {
+      const store = window.__OPEN_PENCIL_STORE__!
+
+      // Reset viewport
+      store.state.panX = 0
+      store.state.panY = 0
+      store.state.zoom = 1
+      store.requestRepaint()
+
+      // Benchmark: applyZoom calls (store → state mutation → renderVersion bump)
+      const zoomStart = performance.now()
+      for (let i = 0; i < iterations; i++) {
+        store.applyZoom(i % 2 === 0 ? -1 : 1, 400, 300)
+      }
+      const zoomMs = performance.now() - zoomStart
+
+      // Reset
+      store.state.zoom = 1
+      store.state.panX = 0
+      store.state.panY = 0
+
+      // Benchmark: pan calls
+      const panStart = performance.now()
+      for (let i = 0; i < iterations; i++) {
+        store.pan(1, 1)
+      }
+      const panMs = performance.now() - panStart
+
+      // Benchmark: simulated wheel coalescing — many wheel events in one frame
+      store.state.zoom = 1
+      store.state.panX = 0
+      store.state.panY = 0
+
+      const canvas = document.querySelector('canvas')!
+      const wheelStart = performance.now()
+      for (let i = 0; i < iterations; i++) {
+        canvas.dispatchEvent(
+          new WheelEvent('wheel', {
+            deltaX: 0,
+            deltaY: -2,
+            ctrlKey: true,
+            clientX: 400,
+            clientY: 300,
+            bubbles: true,
+            cancelable: true
+          })
+        )
+      }
+      const wheelMs = performance.now() - wheelStart
+
+      return {
+        zoom: { ms: Math.round(zoomMs * 100) / 100, avg: Math.round((zoomMs / iterations) * 1000) / 1000 },
+        pan: { ms: Math.round(panMs * 100) / 100, avg: Math.round((panMs / iterations) * 1000) / 1000 },
+        wheel: { ms: Math.round(wheelMs * 100) / 100, avg: Math.round((wheelMs / iterations) * 1000) / 1000 }
+      }
+    }, ITERATIONS)
+
+    console.log(`\n═══ ZOOM/PAN PIPELINE BENCHMARK (${ITERATIONS} iterations) ═══`)
+    console.log(`  applyZoom:     ${results.zoom.avg}ms/call  (${results.zoom.ms}ms total)`)
+    console.log(`  pan:           ${results.pan.avg}ms/call  (${results.pan.ms}ms total)`)
+    console.log(`  wheel events:  ${results.wheel.avg}ms/event  (${results.wheel.ms}ms total)`)
+    console.log(`═══════════════════════════════════════════════════════\n`)
+
+    // Each call should be sub-millisecond
+    expect(results.zoom.avg).toBeLessThan(1)
+    expect(results.pan.avg).toBeLessThan(1)
+    expect(results.wheel.avg).toBeLessThan(1)
+
+    helper.assertNoErrors()
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,10 +6,12 @@ import tailwindcss from '@tailwindcss/vite'
 import Icons from 'unplugin-icons/vite'
 import IconsResolver from 'unplugin-icons/resolver'
 import Components from 'unplugin-vue-components/vite'
-import { copyFileSync, existsSync } from 'fs'
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from 'fs'
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST
+// @ts-expect-error process is a nodejs global
+const enableWebGPU = process.env.WEBGPU === '1'
 
 export default defineConfig(async () => ({
   resolve: {
@@ -21,11 +23,27 @@ export default defineConfig(async () => ({
   plugins: [
     {
       name: 'copy-canvaskit-wasm',
-      buildStart() {
+      async buildStart() {
         const src = 'node_modules/canvaskit-wasm/bin/canvaskit.wasm'
         const dest = 'public/canvaskit.wasm'
         if (existsSync(src) && !existsSync(dest)) {
           copyFileSync(src, dest)
+        }
+
+        if (enableWebGPU) {
+          const webgpuDir = 'public/canvaskit-webgpu'
+          if (!existsSync(`${webgpuDir}/canvaskit.wasm`)) {
+            mkdirSync(webgpuDir, { recursive: true })
+            const tag = 'v0.1.0-webgpu'
+            const base = `https://github.com/open-pencil/skia/releases/download/${tag}`
+            console.log(`Downloading CanvasKit WebGPU from ${base}...`)
+            for (const file of ['canvaskit.js', 'canvaskit.wasm']) {
+              const resp = await fetch(`${base}/${file}`)
+              if (!resp.ok) throw new Error(`Failed to download ${file}: ${resp.status}`)
+              writeFileSync(`${webgpuDir}/${file}`, Buffer.from(await resp.arrayBuffer()))
+            }
+            console.log('CanvasKit WebGPU downloaded.')
+          }
         }
       }
     },


### PR DESCRIPTION
Opt-in WebGPU backend using a custom CanvasKit WASM built with Skia Graphite + Dawn. Enable with `WEBGPU=1 bun run vite` + `?gpu=webgpu` URL param. WebGL remains the default.

Build source: https://github.com/open-pencil/skia/tree/webgpu (7 commits on top of upstream `f886711`)

**What changed:**
- `packages/core/src/canvaskit.ts` — dual init: detect `?gpu=webgpu` + `navigator.gpu`, load WebGPU CanvasKit via `<script>` tag
- `src/composables/use-canvas.ts` — WebGPU surface proxy using `BeginFrame`/`EndFrame` C++ API for minimal JS↔WASM overhead
- `vite.config.ts` — `WEBGPU=1` env var downloads CanvasKit from GitHub Release to `public/canvaskit-webgpu/`
- `public/benchmark.html` — WebGL vs WebGPU benchmark with sweep mode (100–5000 nodes)

**Skia patches:**
- Graphite Dawn backend fixes for Emscripten (DawnBuffer, DawnCaps)
- Skip native Dawn library linking (Emscripten provides `-lwebgpu`)
- `CK_ENABLE_WEBGPU` define, Graphite context/recorder bindings
- `BeginFrame`/`EndFrame` API, ordered recordings optimization
- Path/PathBuilder compatibility layer

**Benchmark (M-series Mac, sweep, 100 frames/test):**

| Nodes | Chrome WebGL | Chrome WebGPU | Δ | Safari WebGL | Safari WebGPU | Δ |
|-------|-------------|--------------|---|-------------|--------------|---|
| 500 | 0.38 ms | 0.67 ms | 1.8x | 0.27 ms | 0.76 ms | 2.8x |
| 1000 | 0.64 ms | 1.14 ms | 1.8x | 0.44 ms | 1.33 ms | 3.0x |
| 2000 | 1.15 ms | 2.08 ms | 1.8x | 0.78 ms | 2.49 ms | 3.2x |
| 5000 | 2.73 ms | 4.97 ms | 1.8x | 1.88 ms | 7.28 ms | 3.9x |

Graphite's recording model adds ~1.8x overhead in Chrome (consistent across node counts). Both backends are well above 60fps — 5000 nodes at 5ms = 200fps. The gap is structural to Graphite and will narrow as Skia optimizes it.