### PR TITLE
Add demo recording infrastructure with webreel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,7 @@ packages/docs/.vitepress/cache/
 packages/docs/.vitepress/dist/
 packages/collab/.wrangler/
 packages/core/vendor/canvaskit-webgpu/
+packages/demos/videos/
+packages/demos/.webreel/
 patches/skia-webgpu/
 .wrangler/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,11 @@ Vue 3 + CanvasKit (Skia WASM) + Yoga WASM design editor. Tauri v2 desktop, also 
 
 ## Monorepo
 
-Bun workspace with three packages:
+Bun workspace with four packages:
 
 - `packages/core` — `@open-pencil/core`: scene graph, renderer, layout, codec, kiwi, clipboard, vector, snap, undo. Zero DOM deps, runs headless in Bun.
 - `packages/cli` — `@open-pencil/cli`: headless CLI for .fig inspection, export, linting. Uses `citty` + `agentfmt`.
+- `packages/demos` — `@open-pencil/demos`: scripted demo recording via webreel (fork: `@sld0ant/webreel-fork`). See [Demos](#demos).
 - `packages/mcp` — `@open-pencil/mcp`: MCP server for AI coding tools. Stdio + HTTP (Hono). Reuses `createServer()` factory with all core tools.
 
 The root app (`src/`) is the Tauri/Vite desktop editor. Its `src/engine/` files are thin re-export shims from `@open-pencil/core`.
@@ -33,6 +34,11 @@ The root app (`src/`) is the Tauri/Vite desktop editor. Its `src/engine/` files 
 - `bun open-pencil analyze typography <file>` — font/size/weight stats
 - `bun open-pencil analyze spacing <file>` — gap/padding values
 - `bun open-pencil analyze clusters <file>` — repeated patterns
+- `bun run demo` — record all demo videos (dev server must be running)
+- `bun run demo --scenario toolbar` — record a specific demo by name
+- `bun run demo:list` — list available demo scenarios
+- `bun run demo:preview` — preview all demos in visible browser without recording
+- `bun run demo:preview --scenario toolbar` — preview a specific demo
 
 ## Releases & CI
 
@@ -82,6 +88,18 @@ When adding features, update `CHANGELOG.md` (Unreleased section) and `README.md`
 - All CLI output must use `agentfmt` formatters — `fmtList`, `fmtHistogram`, `fmtSummary`, `fmtNode`, `fmtTree`, `kv`, `entity`, `bold`, `dim`, etc.
 - Don't hand-roll `console.log` formatting — use the helpers from `packages/cli/src/format.ts` which re-exports agentfmt with project-specific adapters (`nodeToData`, `nodeDetails`, `nodeToTreeNode`, `nodeToListItem`)
 - Every command supports `--json` for machine-readable output
+
+## Demos
+
+- `packages/demos` uses `@sld0ant/webreel-fork` (fork of [vercel-labs/webreel](https://github.com/vercel-labs/webreel)) to record scripted browser demos
+- API mirrors Playwright: `bun run demo` (all), `bun run demo --scenario <name>` (specific), `bun run demo:preview` (visible browser)
+- Scenarios defined in `packages/demos/webreel.config.json` — single config with multiple videos in the `videos` object
+- Dev server (`bun run dev` or `bun run tauri dev`) must be running at `http://localhost:1420` before recording
+- Chrome and ffmpeg are auto-downloaded to `~/.webreel` on first run (~500MB one-time)
+- Generated videos go to `packages/demos/videos/` — gitignored, not stored in repo
+- Scenarios target `data-test-id` selectors for stability
+- To add a new demo: add a video entry to `webreel.config.json` with url, steps, and optional output format
+- Output formats: WebM (project default), MP4 (`"output": "name.mp4"`), GIF (`"output": "name.gif"`)
 
 ## Tools (AI / MCP / CLI)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Demo recording infrastructure — `packages/demos` with webreel for scripted browser demo capture (`bun run demo`, `demo:list`, `demo:preview`)
+
 ### Fixes
 
 - Fix horizontal scrollbar on design and pages panels

--- a/bun.lock
+++ b/bun.lock
@@ -61,7 +61,7 @@
     },
     "packages/cli": {
       "name": "@open-pencil/cli",
-      "version": "0.4.2",
+      "version": "0.6.0",
       "bin": {
         "openpencil": "./src/index.ts",
       },
@@ -77,7 +77,7 @@
     },
     "packages/core": {
       "name": "@open-pencil/core",
-      "version": "0.4.2",
+      "version": "0.6.0",
       "dependencies": {
         "canvaskit-wasm": "^0.40.0",
         "culori": "^4.0.2",
@@ -90,6 +90,13 @@
         "typescript": "~5.8.3",
       },
     },
+    "packages/demos": {
+      "name": "@open-pencil/demos",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sld0ant/webreel-fork": "0.1.6",
+      },
+    },
     "packages/docs": {
       "name": "@open-pencil/docs",
       "version": "0.1.0",
@@ -99,7 +106,7 @@
     },
     "packages/mcp": {
       "name": "@open-pencil/mcp",
-      "version": "0.4.2",
+      "version": "0.6.0",
       "bin": {
         "openpencil-mcp": "./dist/index.js",
         "openpencil-mcp-http": "./dist/http.js",
@@ -199,6 +206,8 @@
     "@docsearch/js": ["@docsearch/js@3.8.2", "", { "dependencies": { "@docsearch/react": "3.8.2", "preact": "^10.0.0" } }, "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ=="],
 
     "@docsearch/react": ["@docsearch/react@3.8.2", "", { "dependencies": { "@algolia/autocomplete-core": "1.17.7", "@algolia/autocomplete-preset-algolia": "1.17.7", "@docsearch/css": "3.8.2", "algoliasearch": "^5.14.2" }, "peerDependencies": { "@types/react": ">= 16.8.0 < 19.0.0", "react": ">= 16.8.0 < 19.0.0", "react-dom": ">= 16.8.0 < 19.0.0", "search-insights": ">= 1 < 3" }, "optionalPeers": ["@types/react", "react", "react-dom", "search-insights"] }, "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -368,6 +377,56 @@
 
     "@iconify/utils": ["@iconify/utils@3.1.0", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "mlly": "^1.8.0" } }, "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw=="],
 
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
     "@internationalized/date": ["@internationalized/date@3.11.0", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q=="],
 
     "@internationalized/number": ["@internationalized/number@3.6.5", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g=="],
@@ -453,6 +512,8 @@
     "@open-pencil/cli": ["@open-pencil/cli@workspace:packages/cli"],
 
     "@open-pencil/core": ["@open-pencil/core@workspace:packages/core"],
+
+    "@open-pencil/demos": ["@open-pencil/demos@workspace:packages/demos"],
 
     "@open-pencil/docs": ["@open-pencil/docs@workspace:packages/docs"],
 
@@ -629,6 +690,10 @@
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@sindresorhus/fnv1a": ["@sindresorhus/fnv1a@3.1.0", "", {}, "sha512-KV321z5m/0nuAg83W1dPLy85HpHDk7Sdi4fJbwvacWsEhAh+rZUW4ZfGcXmUIvjZg4ss2bcwNlRhJ7GBEUG08w=="],
+
+    "@sld0ant/webreel-fork": ["@sld0ant/webreel-fork@0.1.6", "", { "dependencies": { "@sld0ant/webreel-fork-core": "0.1.5", "commander": "^14.0.3", "jiti": "^2.6.1", "jsonc-parser": "^3.3.1" }, "bin": { "webreel": "dist/index.js" } }, "sha512-ZLUB1HnJs3uKJ3ZNtlk1HgsduwVuwG0wMDeBWR37gAI+QHV8Y98DGn3hTwgteoLTSGY3i5YQXQd/7eCX052uGg=="],
+
+    "@sld0ant/webreel-fork-core": ["@sld0ant/webreel-fork-core@0.1.5", "", { "dependencies": { "chrome-remote-interface": "^0.33.2", "sharp": "^0.34.5" } }, "sha512-aXOM17GpL8r5PFfwZGCntRK8Tdk0/6lMX9vPRZpOkoJ2j7Cf0j2HwD+IglCNTWJxAiQknlUAcEEjYB5F7N20Uw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -919,6 +984,8 @@
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "chrome-remote-interface": ["chrome-remote-interface@0.33.3", "", { "dependencies": { "commander": "2.11.x", "ws": "^7.2.0" }, "bin": { "chrome-remote-interface": "bin/client.js" } }, "sha512-zNnn0prUL86Teru6UCAZ1yU1XeXljHl3gj7OrfPcarEfU62OUU4IujDPdTDW3dAWwRqN3ZMG/Chhkh2gPL/wiw=="],
 
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
@@ -1251,6 +1318,8 @@
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
@@ -1622,11 +1691,15 @@
 
     "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
 
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -1836,6 +1909,8 @@
 
     "@open-pencil/mcp/@types/node": ["@types/node@22.19.13", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw=="],
 
+    "@sld0ant/webreel-fork/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
@@ -1863,6 +1938,10 @@
     "@waku/sds/@libp2p/interface": ["@libp2p/interface@2.10.4", "", { "dependencies": { "@multiformats/multiaddr": "^12.4.4", "it-pushable": "^3.2.3", "it-stream-types": "^2.0.2", "main-event": "^1.0.1", "multiformats": "^13.3.6", "progress-events": "^1.0.1", "uint8arraylist": "^2.4.8" } }, "sha512-FX3uujZgjH9bb7mDSNR54j3JzJnF/ngnQH20GQ1wPk5irIeHDvmzRlUj3bJ3hHQmdB2MxLZNT6e39O1es10LFA=="],
 
     "@waku/utils/chai": ["chai@4.5.0", "", { "dependencies": { "assertion-error": "^1.1.0", "check-error": "^1.0.3", "deep-eql": "^4.1.3", "get-func-name": "^2.0.2", "loupe": "^2.3.6", "pathval": "^1.1.1", "type-detect": "^4.1.0" } }, "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw=="],
+
+    "chrome-remote-interface/commander": ["commander@2.11.0", "", {}, "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="],
+
+    "chrome-remote-interface/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "concat-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 

--- a/openspec/changes/archive/2026-03-04-add-webreel-demos/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-04-add-webreel-demos/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-04

--- a/openspec/changes/archive/2026-03-04-add-webreel-demos/design.md
+++ b/openspec/changes/archive/2026-03-04-add-webreel-demos/design.md
@@ -1,0 +1,61 @@
+## Context
+
+OpenPencil is a Bun workspace monorepo with packages at `packages/*`. All Vue components have `data-test-id` attributes (merged in `3ac016b`), enabling reliable CSS-selector-based automation. Webreel (`webreel` npm package v0.1.4) records scripted browser demos from JSON config files using headless Chrome + ffmpeg (both auto-downloaded to `~/.webreel`).
+
+The Vite dev server runs at `http://localhost:1420/`. Demo recording requires the dev server to be running.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Standalone `packages/demos` workspace package with webreel as npm dependency
+- JSON scenario configs targeting `data-test-id` selectors in the running app
+- `bun run demo:record` / `bun run demo:record <name>` from project root
+- Zero video artifacts in git — all output gitignored
+- Starter scenario proving the pipeline works
+
+**Non-Goals:**
+- CI-based automated recording (future work — needs headless Chrome + running dev server)
+- Editing or compositing videos beyond what webreel provides
+- Replacing Playwright E2E tests — demos are for marketing/docs, not testing
+
+## Decisions
+
+### 1. npm dependency from our fork
+
+Our webreel fork is published on npm as `@sld0ant/webreel-fork@0.1.5` and `@sld0ant/webreel-fork-core@0.1.5` (forked from [vercel-labs/webreel](https://github.com/vercel-labs/webreel) with deterministic headless recording fixes). Using npm is cleaner than git/file deps — proper semver, works on any machine.
+
+Alternative: `git+https://` dependency — rejected because dist/ is gitignored in the webreel repo, Bun can't build from source.
+Alternative: `file:` dependency — rejected because it only works on one machine.
+
+### 2. Separate `packages/demos` workspace package
+
+Keeps demo infrastructure isolated from the app, core, CLI, and docs. The package is `private: true`, never published. Only dependency is `webreel`.
+
+Alternative: Put configs in project root — rejected because it clutters the root and isn't consistent with the existing packages/* pattern.
+
+### 3. Wrapper script in `packages/demos/scripts/record.ts`
+
+A thin Bun script that:
+1. Invokes `bunx webreel record [names...]` with the correct config path
+2. Supports `--all` or specific scenario names as arguments
+
+This avoids issues with webreel expecting Node.js — `bunx` runs the published CLI entry point which has `#!/usr/bin/env node` but Bun handles it fine.
+
+### 4. Scenarios target `data-test-id` selectors
+
+Using `[data-test-id="toolbar-tool-frame"]` etc. These are stable, purpose-built for automation, and already exist on all components.
+
+### 5. Videos and webreel cache gitignored
+
+Add to root `.gitignore`:
+```
+packages/demos/videos/
+packages/demos/.webreel/
+```
+
+## Risks / Trade-offs
+
+- [Dev server must be running] → Document clearly; script could check port 1420 before recording
+- [Chrome/ffmpeg download on first run ~500MB] → One-time cost, cached in `~/.webreel`; document in README
+- [Webreel 0.1.x is young] → We control the fork at sld0Ant/webreel, can publish fixes independently
+- [Demo scenarios break if UI changes] → Scenarios use stable `data-test-id` attrs, not text content

--- a/openspec/changes/archive/2026-03-04-add-webreel-demos/proposal.md
+++ b/openspec/changes/archive/2026-03-04-add-webreel-demos/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+OpenPencil has data-test-id attributes on all Vue components but no automated way to record scripted demo videos showcasing the editor. The webreel project (our fork published as `@sld0ant/webreel-fork` + `@sld0ant/webreel-fork-core` on npm, forked from [vercel-labs/webreel](https://github.com/vercel-labs/webreel)) records browser interactions as MP4/GIF/WebM from JSON scenario configs. Adding a `packages/demos` workspace package with webreel integration lets us define, record, and rebuild demo videos on demand — without storing binary artifacts in git.
+
+## What Changes
+
+- New `packages/demos` Bun workspace package with `webreel` as an npm dependency
+- Scenario config files (`*.config.json`) defining demo recordings against `http://localhost:1420/`
+- Scripts: `bun run demo:record` (all), `bun run demo:record <name>` (single scenario), wired to root package.json
+- `.gitignore` entries for generated video output (`packages/demos/videos/`, `packages/demos/.webreel/`)
+- A starter demo scenario exercising toolbar tool switching (leveraging existing `data-test-id` attributes)
+
+## Capabilities
+
+### New Capabilities
+- `demo-recording`: Webreel-based demo recording infrastructure — scenario configs, record scripts, gitignore for outputs
+
+### Modified Capabilities
+- `tooling`: Add `demo:record` scripts to root package.json, document demos workflow
+
+## Impact
+
+- New workspace package `packages/demos` — no changes to existing source code
+- New npm dependency: `@sld0ant/webreel-fork` (CLI + core, pulls Chrome + ffmpeg on first run to `~/.webreel`)
+- Root `package.json`: new scripts for demo recording
+- `.gitignore`: exclude generated videos and webreel cache
+- AGENTS.md: document demos workflow

--- a/openspec/changes/archive/2026-03-04-add-webreel-demos/specs/demo-recording/spec.md
+++ b/openspec/changes/archive/2026-03-04-add-webreel-demos/specs/demo-recording/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Demo recording workspace package
+The project SHALL have a `packages/demos` workspace package that is private and contains webreel as an npm dependency for scripted demo recording.
+
+#### Scenario: Package exists in workspace
+- **WHEN** `bun install` is run at the project root
+- **THEN** `packages/demos` is resolved as a workspace member with `webreel` installed
+
+### Requirement: Scenario config file
+Demo scenarios SHALL be defined in a single `packages/demos/webreel.config.json` with a `videos` object containing named video entries (idiomatic webreel pattern). Videos target `http://localhost:1420/` using `data-test-id` selectors.
+
+#### Scenario: Config file is valid webreel config
+- **WHEN** `packages/demos/webreel.config.json` exists
+- **THEN** it SHALL be a valid webreel config with `$schema`, `videos` object, and steps using `data-test-id` selectors
+
+### Requirement: Record all demos
+The project SHALL provide a `bun run demo:record` command at the root that records all scenario configs and writes output to `packages/demos/videos/`.
+
+#### Scenario: Record all scenarios
+- **WHEN** the dev server is running at `http://localhost:1420/` and `bun run demo:record` is executed
+- **THEN** all videos in `packages/demos/webreel.config.json` are recorded and output is written to `packages/demos/videos/`
+
+### Requirement: Record single demo by name
+The project SHALL support `bun run demo:record --scenario <name>` to record a specific video from the config.
+
+#### Scenario: Record named scenario
+- **WHEN** the dev server is running and `bun run demo:record --scenario toolbar` is executed
+- **THEN** only the `toolbar` video is recorded
+
+### Requirement: Videos excluded from git
+Generated video files and webreel working directories SHALL be excluded from version control via `.gitignore`.
+
+#### Scenario: Git ignores demo outputs
+- **WHEN** demos are recorded and `git status` is run
+- **THEN** files in `packages/demos/videos/` and `packages/demos/.webreel/` do not appear as untracked
+
+### Requirement: Starter toolbar demo scenario
+A starter scenario SHALL exist demonstrating toolbar tool switching using the `data-test-id` attributes on toolbar buttons.
+
+#### Scenario: Toolbar demo records successfully
+- **WHEN** the dev server is running and the toolbar scenario is recorded
+- **THEN** a video is produced showing cursor movement between toolbar tool buttons

--- a/openspec/changes/archive/2026-03-04-add-webreel-demos/specs/tooling/spec.md
+++ b/openspec/changes/archive/2026-03-04-add-webreel-demos/specs/tooling/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Bun workspace monorepo
+The project SHALL use Bun workspaces with packages: root (app), packages/core (@open-pencil/core), packages/cli (@open-pencil/cli), packages/docs (@open-pencil/docs), packages/demos. The workspace is configured in the root package.json. CLI is runnable via `bun open-pencil` in the workspace. Demo recording is runnable via `bun run demo:record`.
+
+#### Scenario: Workspace packages resolve
+- **WHEN** the app imports from @open-pencil/core
+- **THEN** Bun resolves it to packages/core/ via workspace linking
+
+#### Scenario: Demo recording scripts available
+- **WHEN** `bun run demo:record` is executed at the project root
+- **THEN** the script delegates to the packages/demos recording workflow

--- a/openspec/changes/archive/2026-03-04-add-webreel-demos/tasks.md
+++ b/openspec/changes/archive/2026-03-04-add-webreel-demos/tasks.md
@@ -1,0 +1,21 @@
+## 1. Package Setup
+
+- [x] 1.1 Create `packages/demos/package.json` (private, type: module, `@sld0ant/webreel-fork@0.1.6` npm dependency)
+- [x] 1.2 Run `bun install` to resolve the new workspace package (root `workspaces: ["packages/*"]` glob covers it)
+
+## 2. Scenario Infrastructure
+
+- [x] 2.1 Create `packages/demos/webreel.config.json` — single config with a `videos` object containing the toolbar demo scenario (idiomatic webreel pattern). Include `$schema` for IDE autocompletion, `outDir: "videos/"`, target `http://localhost:1420/` with `data-test-id` selectors
+- [x] 2.2 Create `packages/demos/scripts/record.ts` — wrapper that: checks dev server reachability at :1420 before recording; invokes `node_modules/.bin/webreel record [names...]` with `-c` pointing to the config; passes through `--verbose`/`--watch` flags; handles non-zero exit codes with clear error messages
+- [x] 2.3 Create `packages/demos/scripts/list.ts` — parses `webreel.config.json` and prints available video names
+
+## 3. Root Integration
+
+- [x] 3.1 Add `demo:record`, `demo:list`, and `demo:preview` scripts to root `package.json`
+- [x] 3.2 Add `.gitignore` entries for `packages/demos/videos/` (generated output) and `packages/demos/.webreel/` (intermediate recording artifacts)
+
+## 4. Documentation
+
+- [x] 4.1 Add demos section to `AGENTS.md` documenting the workflow, commands, conventions, prerequisites (Chrome/ffmpeg auto-downloaded to `~/.webreel`), and that `bun run dev` or `bun run tauri dev` must be running before recording
+- [x] 4.2 Create `packages/demos/README.md` with usage, prerequisites, how to add new videos to the config, output format notes (MP4 default, GIF/WebM via `output` field)
+- [x] 4.3 Add demos entry to `CHANGELOG.md` Unreleased section

--- a/openspec/specs/demo-recording/spec.md
+++ b/openspec/specs/demo-recording/spec.md
@@ -1,0 +1,47 @@
+# demo-recording Specification
+
+## Purpose
+TBD - created by archiving change add-webreel-demos. Update Purpose after archive.
+## Requirements
+### Requirement: Demo recording workspace package
+The project SHALL have a `packages/demos` workspace package that is private and contains webreel as an npm dependency for scripted demo recording.
+
+#### Scenario: Package exists in workspace
+- **WHEN** `bun install` is run at the project root
+- **THEN** `packages/demos` is resolved as a workspace member with `webreel` installed
+
+### Requirement: Scenario config file
+Demo scenarios SHALL be defined in a single `packages/demos/webreel.config.json` with a `videos` object containing named video entries (idiomatic webreel pattern). Videos target `http://localhost:1420/` using `data-test-id` selectors.
+
+#### Scenario: Config file is valid webreel config
+- **WHEN** `packages/demos/webreel.config.json` exists
+- **THEN** it SHALL be a valid webreel config with `$schema`, `videos` object, and steps using `data-test-id` selectors
+
+### Requirement: Record all demos
+The project SHALL provide a `bun run demo:record` command at the root that records all scenario configs and writes output to `packages/demos/videos/`.
+
+#### Scenario: Record all scenarios
+- **WHEN** the dev server is running at `http://localhost:1420/` and `bun run demo:record` is executed
+- **THEN** all videos in `packages/demos/webreel.config.json` are recorded and output is written to `packages/demos/videos/`
+
+### Requirement: Record single demo by name
+The project SHALL support `bun run demo:record --scenario <name>` to record a specific video from the config.
+
+#### Scenario: Record named scenario
+- **WHEN** the dev server is running and `bun run demo:record --scenario toolbar` is executed
+- **THEN** only the `toolbar` video is recorded
+
+### Requirement: Videos excluded from git
+Generated video files and webreel working directories SHALL be excluded from version control via `.gitignore`.
+
+#### Scenario: Git ignores demo outputs
+- **WHEN** demos are recorded and `git status` is run
+- **THEN** files in `packages/demos/videos/` and `packages/demos/.webreel/` do not appear as untracked
+
+### Requirement: Starter toolbar demo scenario
+A starter scenario SHALL exist demonstrating toolbar tool switching using the `data-test-id` attributes on toolbar buttons.
+
+#### Scenario: Toolbar demo records successfully
+- **WHEN** the dev server is running and the toolbar scenario is recorded
+- **THEN** a video is produced showing cursor movement between toolbar tool buttons
+

--- a/openspec/specs/tooling/spec.md
+++ b/openspec/specs/tooling/spec.md
@@ -79,15 +79,18 @@ The codebase SHALL maintain 0 oxlint warnings and 0 tsgo type errors. `bun run c
 - **THEN** both lint and typecheck pass with zero issues
 
 ### Requirement: Bun workspace monorepo
-The project SHALL use Bun workspaces with packages: root (app), packages/core (@open-pencil/core), packages/cli (@open-pencil/cli). The workspace is configured in the root package.json. CLI is runnable via `bun open-pencil` in the workspace.
+The project SHALL use Bun workspaces with packages: root (app), packages/core (@open-pencil/core), packages/cli (@open-pencil/cli), packages/docs (@open-pencil/docs), packages/demos. The workspace is configured in the root package.json. CLI is runnable via `bun open-pencil` in the workspace. Demo recording is runnable via `bun run demo:record`.
 
 #### Scenario: Workspace packages resolve
 - **WHEN** the app imports from @open-pencil/core
 - **THEN** Bun resolves it to packages/core/ via workspace linking
 
+#### Scenario: Demo recording scripts available
+- **WHEN** `bun run demo:record` is executed at the project root
+- **THEN** the script delegates to the packages/demos recording workflow
+
 ### Requirement: npm publishing preparation
 @open-pencil/core and @open-pencil/cli SHALL have proper package.json fields for npm publishing: name, version, description, exports, main, types, files, license, repository.
-
 
 ### Requirement: Copy-paste detection
 The project SHALL use jscpd for copy-paste detection. The `bun run jscpd` command SHALL scan for duplicated code blocks.
@@ -109,3 +112,4 @@ The project SHALL include a `test:coverage` script for measuring code coverage.
 #### Scenario: Run coverage
 - **WHEN** `bun run test:coverage` is run
 - **THEN** test coverage metrics are reported
+

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "open-pencil": "bun packages/cli/src/index.ts",
     "docs:dev": "bun --filter @open-pencil/docs dev",
     "docs:build": "bun --filter @open-pencil/docs build",
-    "docs:preview": "bun --filter @open-pencil/docs preview"
+    "docs:preview": "bun --filter @open-pencil/docs preview",
+    "demo": "bun packages/demos/scripts/record.ts",
+    "demo:list": "bun packages/demos/scripts/list.ts",
+    "demo:preview": "bun packages/demos/scripts/record.ts --preview"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.37",

--- a/packages/demos/README.md
+++ b/packages/demos/README.md
@@ -1,0 +1,58 @@
+# @open-pencil/demos
+
+Scripted demo recording for OpenPencil using [webreel](https://github.com/vercel-labs/webreel) (fork: [@sld0ant/webreel-fork](https://www.npmjs.com/package/@sld0ant/webreel-fork)).
+
+## Prerequisites
+
+- Dev server running at `http://localhost:1420` — start with `bun run dev` or `bun run tauri dev`
+- Chrome and ffmpeg are auto-downloaded to `~/.webreel` on first run (~500MB one-time)
+
+## Usage
+
+```bash
+# List available demos
+bun run demo:list
+
+# Record all demos
+bun run demo
+
+# Record a specific demo
+bun run demo --scenario toolbar
+
+# Preview in visible browser (no recording, like playwright --headed)
+bun run demo:preview
+bun run demo:preview --scenario toolbar
+
+# Pass flags through to webreel
+bun run demo --verbose
+bun run demo --watch
+```
+
+## Adding a new demo
+
+Edit `webreel.config.json` and add a video entry to the `videos` object:
+
+```json
+{
+  "videos": {
+    "my-demo": {
+      "url": "/",
+      "waitFor": "[data-test-id=\"some-element\"]",
+      "steps": [
+        { "action": "pause", "ms": 500 },
+        { "action": "click", "selector": "[data-test-id=\"button\"]" }
+      ]
+    }
+  }
+}
+```
+
+Use `data-test-id` selectors for stability. See the [webreel docs](https://webreel.dev) for all available actions.
+
+## Output formats
+
+- **WebM** (project default) — `"output": "my-demo.webm"`
+- **MP4** — `"output": "my-demo.mp4"`
+- **GIF** — `"output": "my-demo.gif"`
+
+Videos are written to `videos/` and excluded from git.

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@open-pencil/demos",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "dependencies": {
+    "@sld0ant/webreel-fork": "0.1.6"
+  }
+}

--- a/packages/demos/scripts/list.ts
+++ b/packages/demos/scripts/list.ts
@@ -1,0 +1,22 @@
+import { resolve, dirname } from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = resolve(__dirname, "..", "webreel.config.json");
+
+const config = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+const names = Object.keys(config.videos ?? {});
+
+if (names.length === 0) {
+  console.log("No videos defined in webreel.config.json");
+} else {
+  console.log(`Available demos (${names.length}):\n`);
+  for (const name of names) {
+    const video = config.videos[name];
+    const url = video.url ?? "";
+    const steps = video.steps?.length ?? 0;
+    const output = video.output ?? `${name}.webm`;
+    console.log(`  ${name}  →  ${output}  (${steps} steps, ${url})`);
+  }
+}

--- a/packages/demos/scripts/record.ts
+++ b/packages/demos/scripts/record.ts
@@ -1,0 +1,86 @@
+import { resolve, dirname } from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEMOS_DIR = resolve(__dirname, "..");
+const CONFIG_PATH = resolve(DEMOS_DIR, "webreel.config.json");
+
+async function resolveWebreelBin(): Promise<string> {
+  const local = resolve(DEMOS_DIR, "node_modules/.bin/webreel");
+  if (await Bun.file(local).exists()) return local;
+  return resolve(DEMOS_DIR, "../../node_modules/.bin/webreel");
+}
+
+function readBaseUrl(): string {
+  try {
+    const config = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    return config.baseUrl ?? "http://localhost:1420";
+  } catch {
+    return "http://localhost:1420";
+  }
+}
+
+async function checkDevServer(url: string): Promise<boolean> {
+  try {
+    await fetch(url, { signal: AbortSignal.timeout(3000) });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface ParsedArgs {
+  scenario?: string;
+  verbose: boolean;
+  watch: boolean;
+  preview: boolean;
+}
+
+function parseArgs(): ParsedArgs {
+  const args = Bun.argv.slice(2);
+  const flags: ParsedArgs = { verbose: false, watch: false, preview: false };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--scenario" && i + 1 < args.length) {
+      flags.scenario = args[++i];
+    } else if (arg === "--verbose") {
+      flags.verbose = true;
+    } else if (arg === "--watch") {
+      flags.watch = true;
+    } else if (arg === "--preview") {
+      flags.preview = true;
+    }
+  }
+
+  return flags;
+}
+
+const { scenario, verbose, watch, preview } = parseArgs();
+const baseUrl = readBaseUrl();
+
+const serverUp = await checkDevServer(baseUrl);
+if (!serverUp) {
+  console.error(`Dev server not reachable at ${baseUrl}\nStart it first: bun run dev`);
+  process.exit(1);
+}
+
+const bin = await resolveWebreelBin();
+const command = preview ? "preview" : "record";
+const cmd = [bin, command];
+if (scenario) cmd.push(scenario);
+cmd.push("-c", CONFIG_PATH);
+if (verbose) cmd.push("--verbose");
+if (watch && !preview) cmd.push("--watch");
+
+const proc = Bun.spawn(cmd, {
+  cwd: DEMOS_DIR,
+  stdio: ["inherit", "inherit", "inherit"],
+});
+
+const exitCode = await proc.exited;
+if (exitCode !== 0) {
+  console.error(`\nwebreel exited with code ${exitCode}`);
+  process.exit(exitCode);
+}

--- a/packages/demos/webreel.config.json
+++ b/packages/demos/webreel.config.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://webreel.dev/schema/v1.json",
+  "outDir": "videos/",
+  "baseUrl": "http://localhost:1420",
+  "viewport": { "width": 1280, "height": 720 },
+  "defaultDelay": 400,
+  "videos": {
+    "toolbar": {
+      "url": "/",
+      "output": "toolbar.webm",
+      "waitFor": "[data-test-id=\"toolbar\"]",
+      "steps": [
+        { "action": "pause", "ms": 800 },
+        { "action": "click", "selector": "[data-test-id=\"toolbar-tool-select\"]" },
+        { "action": "click", "selector": "[data-test-id=\"toolbar-tool-frame\"]" },
+        { "action": "click", "selector": "[data-test-id=\"toolbar-tool-rectangle\"]" },
+        { "action": "click", "selector": "[data-test-id=\"toolbar-tool-pen\"]" },
+        { "action": "click", "selector": "[data-test-id=\"toolbar-tool-text\"]" },
+        { "action": "click", "selector": "[data-test-id=\"toolbar-tool-hand\"]" },
+        { "action": "click", "selector": "[data-test-id=\"toolbar-tool-select\"]" },
+        { "action": "pause", "ms": 500 }
+      ]
+    }
+  }
+}

--- a/tests/demos/demo-scripts.test.ts
+++ b/tests/demos/demo-scripts.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "path";
+import { readFileSync } from "fs";
+
+const DEMOS_DIR = join(import.meta.dir, "../../packages/demos");
+const CONFIG_PATH = join(DEMOS_DIR, "webreel.config.json");
+const LIST_SCRIPT = join(DEMOS_DIR, "scripts/list.ts");
+
+function parseConfig() {
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+}
+
+describe("webreel config", () => {
+  test("valid JSON with required fields", () => {
+    const config = parseConfig();
+    expect(config.$schema).toBeString();
+    expect(config.videos).toBeObject();
+    expect(Object.keys(config.videos).length).toBeGreaterThan(0);
+  });
+
+  test("every video has url and steps", () => {
+    const config = parseConfig();
+    for (const video of Object.values<Record<string, unknown>>(config.videos)) {
+      expect(video.url).toBeString();
+      expect(video.steps).toBeArray();
+      expect((video.steps as unknown[]).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("all steps use data-test-id selectors", () => {
+    const config = parseConfig();
+    for (const video of Object.values<Record<string, unknown>>(config.videos)) {
+      for (const step of video.steps as Record<string, unknown>[]) {
+        if (step.selector) {
+          expect(step.selector as string).toContain("data-test-id");
+        }
+      }
+    }
+  });
+
+  test("toolbar video outputs webm", () => {
+    const config = parseConfig();
+    expect(config.videos.toolbar).toBeDefined();
+    expect(config.videos.toolbar.output).toEndWith(".webm");
+  });
+});
+
+describe("demo:list", () => {
+  test("lists available demos", async () => {
+    const proc = Bun.spawn(["bun", LIST_SCRIPT], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("toolbar");
+    expect(stdout).toContain("toolbar.webm");
+  });
+});


### PR DESCRIPTION
New `packages/demos` workspace package for scripted browser demo recording using `@sld0ant/webreel-fork` (fork of vercel-labs/webreel with headless recording fixes).

- Webreel config with toolbar demo scenario targeting `data-test-id` selectors
- Playwright-style CLI: `bun run demo`, `bun run demo --scenario toolbar`, `bun run demo:preview`, `bun run demo:list`
- Dev server check before recording, `--verbose`/`--watch` passthrough
- WebM output by default, videos gitignored

---

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [x] Tests added or updated
- [x] CHANGELOG.md updated (if user-facing)