### PR TITLE
fix: resolve workspace dependencies before npm publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,23 @@ jobs:
 
       - run: bun install
 
+      - name: Resolve workspace dependencies
+        run: |
+          node -e '
+          const fs = require("fs");
+          const core = require("./packages/core/package.json");
+          const pkgs = ["packages/cli/package.json", "packages/mcp/package.json"];
+          for (const p of pkgs) {
+            const pkg = JSON.parse(fs.readFileSync(p));
+            for (const depType of ["dependencies", "devDependencies", "peerDependencies"]) {
+              if (pkg[depType]?.["@open-pencil/core"]) {
+                pkg[depType]["@open-pencil/core"] = "^" + core.version;
+              }
+            }
+            fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + "\n");
+          }
+          '
+
       - uses: pnpm/action-setup@v4
         with:
           version: latest


### PR DESCRIPTION
## Summary

- Fixes #59
- Add CI step to resolve `workspace:*` dependencies before `npm publish`

## Problem

`npm publish` doesn't resolve Bun/pnpm workspace protocol (`workspace:*`) to actual versions. This causes published packages like `@open-pencil/mcp` to have broken dependencies:

```json
"@open-pencil/core": "workspace:*"
```

Users installing the package get:
```
error: Workspace dependency "@open-pencil/core" not found
```

## Solution

Add a CI step that replaces `workspace:*` with the actual version (`^0.7.0`) before publishing to npm.

## Test plan

- [ ] Verify the node script correctly resolves dependencies in CI
- [ ] Next release should have resolved dependencies in published packages