### PR TITLE
Homebrew tap

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,42 @@
+name: Update Homebrew Tap
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  update-tap:
+    runs-on: macos-latest
+    steps:
+      - name: Update cask
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          TMPDIR=$(mktemp -d)
+          gh release download "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern 'OpenPencil_aarch64.app.tar.gz' \
+            --pattern 'OpenPencil_x64.app.tar.gz' \
+            --dir "$TMPDIR"
+
+          SHA_ARM=$(shasum -a 256 "$TMPDIR/OpenPencil_aarch64.app.tar.gz" | cut -d' ' -f1)
+          SHA_X64=$(shasum -a 256 "$TMPDIR/OpenPencil_x64.app.tar.gz" | cut -d' ' -f1)
+
+          gh repo clone open-pencil/homebrew-tap "$TMPDIR/tap"
+          cd "$TMPDIR/tap"
+
+          sed -i '' \
+            -e "s/version \".*\"/version \"$VERSION\"/" \
+            -e "/on_arm/,/end/{s/sha256 \".*\"/sha256 \"$SHA_ARM\"/;}" \
+            -e "/on_intel/,/end/{s/sha256 \".*\"/sha256 \"$SHA_X64\"/;}" \
+            Casks/open-pencil.rb
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/open-pencil.rb
+          git commit -m "Update OpenPencil to $VERSION"
+          git push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ The root app (`src/`) is the Tauri/Vite desktop editor. Its `src/engine/` files 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
 | `build.yml` | `v*` tag push or manual | Build Tauri desktop apps (5 targets), create GitHub Release, publish npm |
+| `homebrew.yml` | Release published | Update `open-pencil/homebrew-tap` cask with new version + SHA256 hashes |
 | `app.yml` | Push to `master` (non-docs) | Build web app, deploy to Cloudflare Pages (`app.openpencil.dev`) |
 | `docs.yml` | Push to `master` (`packages/docs/**`) | Build VitePress docs, deploy to Cloudflare Pages (`openpencil.dev`) |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Tailwind CSS v4 JSX export — export selections as HTML with Tailwind utility classes (`<div className="flex gap-4 p-3">`) from the Code panel, CLI (`bun open-pencil export --format jsx --style tailwind`), or programmatically via `sceneNodeToJSX(id, graph, 'tailwind')`. Supports layout, sizing, colors, border radius, opacity, rotation, overflow, shadows, blur, and typography. Uses v4 spacing semantics (px/4 multiplier) with automatic fallback to arbitrary values.
 - Code panel format toggle — switch between OpenPencil (custom components) and Tailwind (HTML + utility classes) output
+- Homebrew tap — `brew install open-pencil/tap/open-pencil` for macOS (arm64 + x64), auto-updated on each release
 - New AI/MCP tools: `analyze_colors`, `analyze_typography`, `analyze_spacing`, `analyze_clusters`, `diff_create`, `diff_show`, `get_components`, `get_current_page`, `arrange`, `node_to_component`
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -66,7 +66,13 @@ Your design files are yours. Your tools should be too.
 
 ## Installation
 
-Download the latest release from the [releases page](https://github.com/open-pencil/open-pencil/releases/latest), or [use the web app](https://app.openpencil.dev) — no install needed.
+**macOS (Homebrew):**
+
+```sh
+brew install open-pencil/tap/open-pencil
+```
+
+Or download the latest release from the [releases page](https://github.com/open-pencil/open-pencil/releases/latest), or [use the web app](https://app.openpencil.dev) — no install needed.
 
 ## Getting Started
 


### PR DESCRIPTION
Fixes #55

Created [`open-pencil/homebrew-tap`](https://github.com/open-pencil/homebrew-tap) with a cask formula supporting both arm64 and x64 macOS, seeded with v0.7.0.

Install: `brew install open-pencil/tap/open-pencil`

`homebrew.yml` workflow triggers on `release: published` — downloads the two `.app.tar.gz` assets, computes SHA256 hashes, and pushes an updated cask to the tap repo. Requires a `HOMEBREW_TAP_TOKEN` secret with push access to `open-pencil/homebrew-tap`.

---

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [ ] Tests added or updated
- [x] CHANGELOG.md updated (if user-facing)