### PR TITLE
Fix text typography import from Figma clipboard

### DIFF
--- a/packages/core/src/fonts.ts
+++ b/packages/core/src/fonts.ts
@@ -64,6 +64,10 @@ import { GOOGLE_FONTS_API_KEY } from './constants'
 const googleFontsCache = new Map<string, Record<string, string>>()
 const googleFontsFailed = new Set<string>()
 
+function normalizeFontFamily(family: string): string {
+  return family.replace(/\s+Variable$/i, '')
+}
+
 async function fetchGoogleFontFiles(family: string): Promise<Record<string, string> | null> {
   if (googleFontsCache.has(family)) return googleFontsCache.get(family)!
   if (googleFontsFailed.has(family)) return null
@@ -71,6 +75,13 @@ async function fetchGoogleFontFiles(family: string): Promise<Record<string, stri
   const url = `https://www.googleapis.com/webfonts/v1/webfonts?family=${encodeURIComponent(family)}&key=${GOOGLE_FONTS_API_KEY}`
   const response = await fetch(url)
   if (!response.ok) {
+    const normalized = normalizeFontFamily(family)
+    if (normalized !== family) {
+      const result = await fetchGoogleFontFiles(normalized)
+      if (result) googleFontsCache.set(family, result)
+      else googleFontsFailed.add(family)
+      return result
+    }
     googleFontsFailed.add(family)
     return null
   }
@@ -78,6 +89,13 @@ async function fetchGoogleFontFiles(family: string): Promise<Record<string, stri
   const data = (await response.json()) as { items?: Array<{ files?: Record<string, string> }> }
   const files = data.items?.[0]?.files
   if (!files) {
+    const normalized = normalizeFontFamily(family)
+    if (normalized !== family) {
+      const result = await fetchGoogleFontFiles(normalized)
+      if (result) googleFontsCache.set(family, result)
+      else googleFontsFailed.add(family)
+      return result
+    }
     googleFontsFailed.add(family)
     return null
   }
@@ -121,9 +139,14 @@ export async function loadFont(family: string, style = 'Regular'): Promise<Array
   if (typeof window !== 'undefined' && window.queryLocalFonts) {
     try {
       const fonts = await window.queryLocalFonts()
+      const normalized = normalizeFontFamily(family)
       const match =
         fonts.find((f: FontInfo) => f.family === family && f.style === style) ??
-        fonts.find((f: FontInfo) => f.family === family)
+        fonts.find((f: FontInfo) => f.family === family) ??
+        (normalized !== family
+          ? (fonts.find((f: FontInfo) => f.family === normalized && f.style === style) ??
+            fonts.find((f: FontInfo) => f.family === normalized))
+          : undefined)
       if (match) {
         const blob: Blob = await match.blob()
         const buffer = await blob.arrayBuffer()

--- a/packages/core/src/kiwi/kiwi-convert.ts
+++ b/packages/core/src/kiwi/kiwi-convert.ts
@@ -303,6 +303,7 @@ function convertLineHeight(
   if (!lh) return null
   if (lh.units === 'PIXELS') return lh.value
   if (lh.units === 'PERCENT') return (lh.value / 100) * (fontSize ?? 14)
+  if (lh.units === 'RAW') return lh.value * (fontSize ?? 14)
   return null
 }
 
@@ -344,9 +345,11 @@ function importStyleRuns(nc: NodeChange): StyleRun[] {
       style.italic = override.fontName.style?.toLowerCase().includes('italic') ?? false
     }
     if (override.fontSize !== undefined) style.fontSize = override.fontSize
-    if (override.letterSpacing) style.letterSpacing = override.letterSpacing.value
+    if (override.letterSpacing) {
+      style.letterSpacing = convertLetterSpacing(override.letterSpacing, override.fontSize ?? nc.fontSize)
+    }
     if (override.lineHeight) {
-      const lh = convertLineHeight(override.lineHeight, override.fontSize)
+      const lh = convertLineHeight(override.lineHeight, override.fontSize ?? nc.fontSize)
       if (lh != null) style.lineHeight = lh
     }
     const deco = override.textDecoration as string | undefined

--- a/tests/engine/clipboard.test.ts
+++ b/tests/engine/clipboard.test.ts
@@ -201,6 +201,56 @@ describe('importClipboardNodes', () => {
     expect(graph.getNode(created[2])!.letterSpacing).toBe(0)
   })
 
+  it('converts RAW lineHeight to pixels', () => {
+    const { graph, pageId } = createGraphWithPage()
+
+    const nodeChanges = [
+      { guid: { sessionID: 0, localID: 0 }, type: 'DOCUMENT', name: 'Doc' },
+      { guid: { sessionID: 0, localID: 1 }, parentIndex: { guid: { sessionID: 0, localID: 0 }, position: '!' }, type: 'CANVAS', name: 'Page' },
+      { guid: { sessionID: 0, localID: 10 }, parentIndex: { guid: { sessionID: 0, localID: 1 }, position: '!' }, type: 'TEXT', name: 'RawLH', size: { x: 100, y: 36 }, transform: { m00: 1, m01: 0, m02: 0, m10: 0, m11: 1, m12: 0 }, textData: { characters: 'A' }, fontSize: 24, lineHeight: { value: 1.5, units: 'RAW' } },
+      { guid: { sessionID: 0, localID: 11 }, parentIndex: { guid: { sessionID: 0, localID: 1 }, position: '"' }, type: 'TEXT', name: 'PixelLH', size: { x: 100, y: 20 }, transform: { m00: 1, m01: 0, m02: 0, m10: 0, m11: 1, m12: 40 }, textData: { characters: 'B' }, fontSize: 16, lineHeight: { value: 20, units: 'PIXELS' } },
+      { guid: { sessionID: 0, localID: 12 }, parentIndex: { guid: { sessionID: 0, localID: 1 }, position: '#' }, type: 'TEXT', name: 'PercentLH', size: { x: 100, y: 24 }, transform: { m00: 1, m01: 0, m02: 0, m10: 0, m11: 1, m12: 80 }, textData: { characters: 'C' }, fontSize: 20, lineHeight: { value: 120, units: 'PERCENT' } },
+    ] as any[]
+
+    const created = importClipboardNodes(nodeChanges, graph, pageId)
+    expect(graph.getNode(created[0])!.lineHeight).toBe(36) // 24 * 1.5
+    expect(graph.getNode(created[1])!.lineHeight).toBe(20)
+    expect(graph.getNode(created[2])!.lineHeight).toBe(24) // 120% of 20
+  })
+
+  it('converts letterSpacing and lineHeight in style overrides', () => {
+    const { graph, pageId } = createGraphWithPage()
+
+    const nodeChanges = [
+      { guid: { sessionID: 0, localID: 0 }, type: 'DOCUMENT', name: 'Doc' },
+      { guid: { sessionID: 0, localID: 1 }, parentIndex: { guid: { sessionID: 0, localID: 0 }, position: '!' }, type: 'CANVAS', name: 'Page' },
+      {
+        guid: { sessionID: 0, localID: 10 },
+        parentIndex: { guid: { sessionID: 0, localID: 1 }, position: '!' },
+        type: 'TEXT', name: 'Styled', size: { x: 200, y: 40 },
+        transform: { m00: 1, m01: 0, m02: 0, m10: 0, m11: 1, m12: 0 },
+        fontSize: 16,
+        textData: {
+          characters: 'Hello World',
+          characterStyleIDs: [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+          styleOverrideTable: [{
+            styleID: 1,
+            fontName: { family: 'Inter', style: 'Bold' },
+            fontSize: 20,
+            lineHeight: { value: 1.5, units: 'RAW' },
+            letterSpacing: { value: -2, units: 'PERCENT' },
+          }],
+        },
+      },
+    ] as any[]
+
+    const created = importClipboardNodes(nodeChanges, graph, pageId)
+    const node = graph.getNode(created[0])!
+    expect(node.styleRuns).toHaveLength(1)
+    expect(node.styleRuns[0].style.lineHeight).toBe(30) // 20 * 1.5
+    expect(node.styleRuns[0].style.letterSpacing).toBeCloseTo(-0.4) // 20 * -2/100
+  })
+
   it('maps SYMBOL type to COMPONENT with auto-layout', () => {
     const { graph, pageId } = createGraphWithPage()
 


### PR DESCRIPTION
Fixes #36

Three bugs in the Figma → OpenPencil import path that caused broken text layout and missing fonts:

**RAW lineHeight dropped** — `convertLineHeight()` handled PIXELS and PERCENT but returned `null` for RAW (a unitless multiplier). 24 text nodes in the reporter's file used RAW, so their line heights were lost, collapsing auto-layout.

**Style override letterSpacing ignored units** — `importStyleRuns()` used `override.letterSpacing.value` directly instead of `convertLetterSpacing()`, so percent-based values like `-4%` at 20px were treated as `-4px`. Also passed the override's own fontSize (when present) to `convertLineHeight` for correct per-run conversion.

**Variable font names not resolved** — Figma encodes variable fonts as "Inter Variable" but Google Fonts API lists them as "Inter". Added `normalizeFontFamily()` fallback in Google Fonts lookup and local font access.

---

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [x] Tests added or updated
- [ ] CHANGELOG.md updated (if user-facing)