### PR TITLE
Add event emitter to SceneGraph, refactor collab sync

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -114,6 +114,7 @@
         "diff": "^8.0.3",
         "fflate": "^0.8.2",
         "fzstd": "^0.1.1",
+        "nanoevents": "^9.1.0",
         "sucrase": "^3.35.1",
         "yoga-layout": "npm:@open-pencil/yoga-layout@3.3.0-grid.2",
       },
@@ -1888,6 +1889,8 @@
     "multiformats": ["multiformats@13.4.2", "", {}, "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "nanoevents": ["nanoevents@9.1.0", "", {}, "sha512-Jd0fILWG44a9luj8v5kED4WI+zfkkgwKyRQKItTtlPfEsh7Lznfi1kr8/iZ+XAIss4Qq5GqRB0qtWbaz9ceO/A=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,7 @@
     "diff": "^8.0.3",
     "fflate": "^0.8.2",
     "fzstd": "^0.1.1",
+    "nanoevents": "^9.1.0",
     "sucrase": "^3.35.1",
     "yoga-layout": "npm:@open-pencil/yoga-layout@3.3.0-grid.2"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,7 +46,8 @@ export {
   type VariableCollection,
   type VariableCollectionMode,
   type CharacterStyleOverride,
-  type StyleRun
+  type StyleRun,
+  type SceneGraphEvents
 } from './scene-graph'
 
 export { FigmaAPI, FigmaNodeProxy, type FigmaFontName } from './figma-api'

--- a/packages/core/src/scene-graph.ts
+++ b/packages/core/src/scene-graph.ts
@@ -1,8 +1,19 @@
+import { createNanoEvents } from 'nanoevents'
+
 import { BLACK, DEFAULT_FONT_FAMILY, DEFAULT_STROKE_MITER_LIMIT } from './constants'
 import { copyEffects, copyFills, copyStrokes, copyStyleRuns } from './copy'
 
 export type { GUID, Color } from './types'
 import type { Matrix, Vector, Color, Rect } from './types'
+import type { Emitter } from 'nanoevents'
+
+export interface SceneGraphEvents {
+  'node:created': (node: SceneNode) => void
+  'node:updated': (id: string, changes: Partial<SceneNode>) => void
+  'node:deleted': (id: string) => void
+  'node:reparented': (nodeId: string, oldParentId: string | null, newParentId: string) => void
+  'node:reordered': (nodeId: string, parentId: string, index: number) => void
+}
 
 export type HandleMirroring = 'NONE' | 'ANGLE' | 'ANGLE_AND_LENGTH'
 export type WindingRule = 'NONZERO' | 'EVENODD'
@@ -452,6 +463,7 @@ export class SceneGraph {
   variableCollections = new Map<string, VariableCollection>()
   activeMode = new Map<string, string>()
   rootId: string
+  readonly emitter: Emitter<SceneGraphEvents> = createNanoEvents()
   private absPosCache = new Map<string, Vector>()
 
   constructor() {
@@ -705,6 +717,7 @@ export class SceneGraph {
       parent.childIds.push(node.id)
     }
 
+    this.emitter.emit('node:created', node)
     return node
   }
 
@@ -713,6 +726,7 @@ export class SceneGraph {
     if (!node) return
     this.absPosCache.clear()
     Object.assign(node, changes)
+    this.emitter.emit('node:updated', id, changes)
   }
 
   reparentNode(nodeId: string, newParentId: string): void {
@@ -725,6 +739,7 @@ export class SceneGraph {
     if (!newParent) return
     if (node.parentId === newParentId) return
 
+    const oldParentId = node.parentId
     this.absPosCache.clear()
 
     // Convert absolute position
@@ -747,6 +762,8 @@ export class SceneGraph {
     // Adjust position so node stays in same visual place
     node.x = absPos.x - newParentAbs.x
     node.y = absPos.y - newParentAbs.y
+
+    this.emitter.emit('node:reparented', nodeId, oldParentId, newParentId)
   }
 
   reorderChild(nodeId: string, parentId: string, insertIndex: number): void {
@@ -774,6 +791,8 @@ export class SceneGraph {
     node.parentId = parentId
     idx = Math.min(idx, newParent.childIds.length)
     newParent.childIds.splice(idx, 0, nodeId)
+
+    this.emitter.emit('node:reordered', nodeId, parentId, idx)
   }
 
   deleteNode(id: string): void {
@@ -792,6 +811,7 @@ export class SceneGraph {
     }
 
     this.nodes.delete(id)
+    this.emitter.emit('node:deleted', id)
   }
 
   hitTest(px: number, py: number, scopeId?: string): SceneNode | null {

--- a/src/composables/use-collab.ts
+++ b/src/composables/use-collab.ts
@@ -48,8 +48,9 @@ export function useCollab(store: EditorStore) {
   let ynodes: Y.Map<Y.Map<unknown>> | null = null
   let room: Room | null = null
   let persistence: IndexeddbPersistence | null = null
-  let suppressGraphEvents = false
+  let suppressGraphSync = false
   let suppressYjsEvents = false
+  let unbindGraphEvents: (() => void) | null = null
   let sendYjsUpdate: ((data: Uint8Array, peerId?: string) => void) | null = null
   let sendAwareness: ((data: Uint8Array, peerId?: string) => void) | null = null
   let sendSyncStep1: ((data: Uint8Array, peerId?: string) => void) | null = null
@@ -73,11 +74,11 @@ export function useCollab(store: EditorStore) {
 
     ynodes.observeDeep((events) => {
       if (suppressYjsEvents) return
-      suppressGraphEvents = true
+      suppressGraphSync = true
       try {
         applyYjsToGraph(events)
       } finally {
-        suppressGraphEvents = false
+        suppressGraphSync = false
       }
       store.requestRender()
     })
@@ -191,16 +192,38 @@ export function useCollab(store: EditorStore) {
       }
     )
 
-    const origUpdateNode = store.graph.updateNode.bind(store.graph)
-    store.graph.updateNode = (id: string, changes: Partial<SceneNode>) => {
-      origUpdateNode(id, changes)
-      if (!suppressGraphEvents && ydoc && ynodes) {
-        syncNodeToYjs(id)
+    function onGraphMutation(nodeId: string) {
+      if (!suppressGraphSync && ydoc && ynodes) {
+        syncNodeToYjs(nodeId)
       }
+    }
+
+    const unbindUpdated = store.graph.emitter.on('node:updated', (id) => onGraphMutation(id))
+    const unbindCreated = store.graph.emitter.on('node:created', (node) => onGraphMutation(node.id))
+    const unbindReparented = store.graph.emitter.on('node:reparented', (nodeId) =>
+      onGraphMutation(nodeId)
+    )
+    const unbindDeleted = store.graph.emitter.on('node:deleted', (id) => {
+      if (!suppressGraphSync && ydoc && ynodes) {
+        suppressYjsEvents = true
+        ydoc.transact(() => {
+          ynodes!.delete(id)
+        })
+        suppressYjsEvents = false
+      }
+    })
+
+    unbindGraphEvents = () => {
+      unbindUpdated()
+      unbindCreated()
+      unbindReparented()
+      unbindDeleted()
     }
   }
 
   function disconnect() {
+    unbindGraphEvents?.()
+    unbindGraphEvents = null
     void room?.leave()
     room = null
     sendYjsUpdate = null

--- a/src/stores/editor.ts
+++ b/src/stores/editor.ts
@@ -605,6 +605,7 @@ export function createEditorStore() {
       await new Promise((r) => requestAnimationFrame(r))
       const imported = await readFigFile(file)
       graph = imported
+      subscribeToGraph()
       computeAllLayouts(graph)
       undo.clear()
       pageViewports.clear()
@@ -731,11 +732,13 @@ export function createEditorStore() {
       const file = new File([blob], state.documentName + '.fig')
       const imported = await readFigFile(file)
       graph = imported
+      subscribeToGraph()
       computeAllLayouts(graph)
     } else if (fileHandle) {
       const file = await fileHandle.getFile()
       const imported = await readFigFile(file)
       graph = imported
+      subscribeToGraph()
       computeAllLayouts(graph)
     } else {
       return
@@ -926,16 +929,18 @@ export function createEditorStore() {
     }
   }
 
-  function updateNode(id: string, changes: Partial<SceneNode>) {
-    graph.updateNode(id, changes)
+  function onNodeUpdated(id: string, changes: Partial<SceneNode>) {
     if ('vectorNetwork' in changes) {
       _renderer?.invalidateVectorPath(id)
     }
     _renderer?.invalidateNodePicture(id)
-    runLayoutForNode(id)
-    syncIfInsideComponent(id)
-    requestRender()
   }
+
+  function subscribeToGraph() {
+    graph.emitter.on('node:updated', onNodeUpdated)
+  }
+
+  subscribeToGraph()
 
   function syncIfInsideComponent(nodeId: string) {
     let current = graph.getNode(nodeId)
@@ -946,6 +951,13 @@ export function createEditorStore() {
       }
       current = current.parentId ? graph.getNode(current.parentId) : undefined
     }
+  }
+
+  function updateNode(id: string, changes: Partial<SceneNode>) {
+    graph.updateNode(id, changes)
+    runLayoutForNode(id)
+    syncIfInsideComponent(id)
+    requestRender()
   }
 
   function updateNodeWithUndo(id: string, changes: Partial<SceneNode>, label = 'Update') {


### PR DESCRIPTION
Add a typed event bus to `SceneGraph` using nanoevents (108 bytes). Mutation methods now emit events that subsystems can subscribe to instead of relying on manual call-site wiring or monkey-patching.

**Events:** `node:created`, `node:updated`, `node:deleted`, `node:reparented`, `node:reordered`

**What changed:**
- `packages/core/src/scene-graph.ts` — `SceneGraph.emitter` with typed `SceneGraphEvents`, events emitted from `createNode`, `updateNode`, `deleteNode`, `reparentNode`, `reorderChild`
- `src/stores/editor.ts` — renderer cache invalidation (`invalidateVectorPath`, `invalidateNodePicture`) moved from `updateNode()` wrapper to a `node:updated` event subscription; re-subscribes after file open/reload when graph instance is replaced
- `src/composables/use-collab.ts` — replaced monkey-patching of `graph.updateNode` with event subscriptions for `node:updated`, `node:created`, `node:deleted`, `node:reparented`; properly unbinds on disconnect

**Collab sync gaps fixed:** the old monkey-patch only intercepted `updateNode` — `createNode`, `deleteNode`, and `reparentNode` mutations were never synced to Yjs. Now they are.

---

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [ ] Tests added or updated
- [x] CHANGELOG.md updated (if user-facing)