### PR TITLE
feat(mcp): add export_image_file tool and fix headless PNG rendering

### DIFF
--- a/packages/core/src/render/renderer.ts
+++ b/packages/core/src/render/renderer.ts
@@ -2,6 +2,7 @@ import { parseColor, colorToFill } from '../color'
 import { TRANSPARENT } from '../constants'
 import { fetchIcons } from '../iconify'
 import { createIconFromPaths } from '../icon-render'
+import { computeAllLayouts } from '../layout'
 import { isTreeNode } from './tree'
 
 import type { SceneGraph, SceneNode, NodeType, LayoutMode, GridTrack, Stroke } from '../scene-graph'
@@ -91,6 +92,8 @@ export async function renderTree(
 
   if (options.x !== undefined) graph.updateNode(result.id, { x: options.x })
   if (options.y !== undefined) graph.updateNode(result.id, { y: options.y })
+
+  computeAllLayouts(graph)
 
   return {
     id: result.id,

--- a/packages/core/src/tools/create.ts
+++ b/packages/core/src/tools/create.ts
@@ -62,14 +62,11 @@ export const render = defineTool({
   },
   execute: async (figma, args) => {
     const { renderJSX } = await import('../render/render-jsx.js')
-    const { computeAllLayouts } = await import('../layout.js')
     const result = await renderJSX(figma.graph, args.jsx, {
       parentId: args.parent_id ?? figma.currentPageId,
       x: args.x,
       y: args.y
     })
-    // Compute layout immediately so exported images reflect flex positioning
-    computeAllLayouts(figma.graph)
     return { id: result.id, name: result.name, type: result.type, children: result.childIds }
   }
 })

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -1,4 +1,5 @@
 export { ALL_TOOLS, CORE_TOOLS, EXTENDED_TOOLS } from './registry'
+export { exportImage } from './vector'
 export { defineTool, nodeToResult, nodeSummary } from './schema'
 export type { ToolDef, ParamDef, ParamType } from './schema'
 export { toolsToAI, buildDebugLog } from './ai-adapter'

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -13,6 +13,7 @@ import {
   SceneGraph,
   headlessRenderNodes
 } from '@open-pencil/core'
+import { exportImage } from '@open-pencil/core/tools'
 
 import type { ToolDef, ParamDef, ParamType, ExportFormat } from '@open-pencil/core'
 
@@ -183,21 +184,17 @@ export function createServer(version: string, options: CreateServerOptions = {})
     },
     async ({ path: filePath, ids, format, scale }: { path: string; ids?: string[]; format?: string; scale?: number }) => {
       try {
-        // Validate path BEFORE expensive render
         const outPath = resolveAndCheckPath(filePath)
-
-        const figma = makeFigma()
-        if (!figma.exportImage) throw new Error('Image export is not available')
-
-        const nodeIds = ids && ids.length > 0
-          ? ids
-          : figma.currentPage.children.map((n: { id: string }) => n.id)
-        const fmt = ((format ?? 'PNG').toUpperCase()) as 'PNG' | 'JPG' | 'WEBP'
-        const data = await figma.exportImage(nodeIds, { scale: scale ?? 2, format: fmt })
-        if (!data || data.length === 0) throw new Error('No visible nodes to export')
-
+        const result = await exportImage.execute(makeFigma(), {
+          ids,
+          format: format ?? 'PNG',
+          scale: scale ?? 2
+        })
+        if (result && 'error' in result) throw new Error(result.error as string)
+        const { base64 } = result as { base64: string }
+        const data = Buffer.from(base64, 'base64')
         await writeFile(outPath, data)
-        return ok({ saved: outPath, bytes: data.length, format: fmt, scale: scale ?? 2 })
+        return ok({ saved: outPath, bytes: data.length, format: (format ?? 'PNG').toUpperCase(), scale: scale ?? 2 })
       } catch (e) {
         return fail(e)
       }


### PR DESCRIPTION
## Summary

Add `export_image_file` MCP tool and fix headless PNG rendering to match the editor.

## Problem

Three issues with headless image export:

1. **No file output** — `export_image` returns base64 inline. AI agents and CI pipelines need actual image files on disk.

2. **Broken flex layout** — `computeAllLayouts()` isn't called after `render` creates nodes via JSX, so Yoga never computes flex positioning. Everything collapses to top-left.

3. **Wrong text metrics** — Font loading via `fetch('/Inter-Regular.ttf')` fails silently in Node.js. Text measurement used a rough `0.6×` character-width heuristic that didn't account for font weight, kerning, or proportional widths. Result: text truncation (`$48,290` → `$48,29`), overlap (`%` wrapping), and misalignment.

## Solution

### New tool: `export_image_file`
Saves PNG/JPG/WEBP to a file path. Parameters: `path` (required), `ids`, `format`, `scale`.

### Fixed export pipeline
```
ensureInterFont()                              # load Inter from ../fonts/ into cache
  → SkiaRenderer + loadFonts()                 # renderer picks up cached Inter
  → setTextMeasurer(renderer.measureTextNode)  # use ParagraphBuilder for measurement
  → computeAllLayouts()                        # Yoga uses accurate font metrics
  → renderNodesToImage()                       # render with same fonts that measured
```

The key insight: use `renderer.measureTextNode()` (ParagraphBuilder-based) as the layout engine's text measurer. Same SkiaRenderer instance, same `fontProvider`, same font shaping — measurement and rendering are guaranteed to agree. Zero hacks.

### `computeAllLayouts` in render tool
The `render` tool now calls `computeAllLayouts()` after creating nodes, so flex layout is resolved immediately — not deferred to export time.

## Changes

| File | Change |
|------|--------|
| `packages/mcp/src/server.ts` | Add `export_image_file` tool, `ensureInterFont()`, ParagraphBuilder text measurer |
| `packages/core/src/tools/create.ts` | Call `computeAllLayouts()` after `renderJSX` |

## Before / After

| | Before | After |
|---|--------|-------|
| KPI values | `$48,29` (truncated) | `$48,290` |
| Percentages | `%` wrapping to next line | `+12.5%` single line |
| Bold text | Overlapping characters | Clean rendering |
| Layout | Collapsed to top-left | Matches editor exactly |

## Test plan

- [x] `render` → `export_image_file` produces PNG on disk
- [x] PNG layout matches .fig editor rendering
- [x] Bold text (`$48,290`, `4m 32s`) renders correctly
- [x] Percentages (`+12.5%`, `-0.8%`) stay on single line
- [x] Activity feed text doesn't wrap incorrectly
- [x] `save_file` + `export_image_file` both succeed
- [x] `bun run check` — 0 errors (lint fix: removed unused import, top-level node: imports)