### PR TITLE
fix(core): add Node/Bun filesystem fallback for bundled fonts

### DIFF
--- a/packages/core/src/fonts.ts
+++ b/packages/core/src/fonts.ts
@@ -187,6 +187,35 @@ export async function loadFont(family: string, style = 'Regular'): Promise<Array
 
   const bundledUrl = BUNDLED_FONTS[cacheKey]
   if (bundledUrl) {
+    // In Node/Bun headless environments, fetch('/Inter-Regular.ttf') fails because
+    // there is no web server. Resolve the font from the filesystem instead.
+    if (typeof window === 'undefined') {
+      try {
+        const { readFileSync } = await import('node:fs')
+        const { fileURLToPath } = await import('node:url')
+        const moduleDir = fileURLToPath(new URL('.', import.meta.url))
+        // The bundled font lives in the project's public/ directory, which is
+        // three levels up from packages/core/src/ at repo root, or may be
+        // co-located with the built output depending on the bundler.
+        const candidates = [
+          moduleDir + bundledUrl.slice(1),
+          moduleDir + '../public' + bundledUrl,
+          moduleDir + '../../public' + bundledUrl,
+          moduleDir + '../../../public' + bundledUrl
+        ]
+        for (const fontPath of candidates) {
+          try {
+            const data = readFileSync(fontPath)
+            const buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength)
+            return registerAndCache(family, style, buffer)
+          } catch {
+            continue
+          }
+        }
+      } catch (e) {
+        console.warn(`Filesystem font fallback failed for "${family}" ${style}:`, e)
+      }
+    }
     try {
       const response = await fetch(bundledUrl)
       const buffer = await response.arrayBuffer()


### PR DESCRIPTION
## Problem

`loadFont()` falls back to bundled fonts via `fetch('/Inter-Regular.ttf')`. This root-relative URL only resolves in browser environments.

In practice, `fetchGoogleFont()` provides Inter in most Node/Bun environments. However, the bundled fallback — which exists as a safety net — silently fails in all non-browser runtimes because `fetch('/')` resolves against no web server. This leaves headless rendering with no last-resort font if Google Fonts is unavailable (rate-limited, restricted network, revoked API key, offline CI).

## Fix

Before `fetch()`, detect non-browser runtime and resolve the font from the filesystem relative to the module directory. Multiple candidate paths cover both source-tree and bundled output layouts. Browser path unchanged.

## Testing

- Verified `loadFont()` filesystem resolution finds `public/Inter-Regular.ttf` from source tree
- Browser rendering unaffected (`typeof window === 'undefined'` gates the new path)
- Falls through gracefully if font file is not found at any candidate path