### PR TITLE
docs(deploy): add example Kubernetes deployment templates

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,90 @@
+# Kubernetes Deployment Templates
+
+Production-ready Kubernetes manifests for self-hosting OpenPencil.
+
+## Components
+
+- **webapp-deployment.yaml** — Web UI: fetches a release tarball, builds with Bun, serves via nginx with TLS
+- **mcp-deployment.yaml** — MCP HTTP server: installs `@open-pencil/mcp` from npm, runs behind an nginx TLS sidecar with bearer auth
+- **nginx-configmap.yaml** — Nginx reverse proxy config template for the MCP server
+
+## Quick Start
+
+### Prerequisites
+
+- A Kubernetes cluster (1.25+)
+- A TLS certificate Secret (e.g. from cert-manager)
+- A Secret containing a bearer token for MCP auth
+- A PersistentVolumeClaim for MCP file storage
+
+### Deploy the Web UI
+
+```bash
+export OPENPENCIL_VERSION=0.9.0
+export OPENPENCIL_NAMESPACE=openpencil
+export TLS_SECRET_NAME=openpencil-tls
+export NGINX_CONFIGMAP=openpencil-nginx-config
+
+kubectl create namespace "$OPENPENCIL_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+envsubst < deploy/k8s/webapp-deployment.yaml | kubectl apply -f -
+```
+
+### Deploy the MCP Server
+
+```bash
+export MCP_NAMESPACE=mcp
+export MCP_PACKAGE_VERSION=0.8.0
+export MCP_AUTH_SECRET=mcp-openpencil-auth
+export MCP_TLS_SECRET=mcp-openpencil-tls
+export MCP_NGINX_CONFIGMAP=mcp-openpencil-nginx
+export MCP_PVC_NAME=mcp-openpencil-data
+export MCP_SERVER_NAME=mcp-openpencil.example.com
+
+kubectl create namespace "$MCP_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+envsubst < deploy/k8s/nginx-configmap.yaml | kubectl apply -f -
+envsubst < deploy/k8s/mcp-deployment.yaml | kubectl apply -f -
+```
+
+### Create Supporting Resources
+
+The templates reference Secrets and PVCs that you must create yourself:
+
+```bash
+# MCP bearer auth secret
+kubectl -n "$MCP_NAMESPACE" create secret generic "$MCP_AUTH_SECRET" \
+  --from-literal=bearer_token="$(openssl rand -base64 32 | tr '+/=' '._-')"
+
+# MCP data PVC (adjust storageClassName for your cluster)
+kubectl -n "$MCP_NAMESPACE" apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $MCP_PVC_NAME
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 1Gi
+EOF
+```
+
+## Image Options
+
+All image references can be overridden via environment variables. Defaults use standard upstream images.
+
+For hardened container images, [Docker Hardened Images (DHI)](https://docs.docker.com/dhi/) provides security-hardened variants:
+
+```bash
+export NGINX_IMAGE=dhi.io/nginx:1.29.5        # webapp
+export MCP_NGINX_IMAGE=dhi.io/nginx:1.29.5    # MCP sidecar
+```
+
+DHI images require a Docker account and `docker login dhi.io` (free, no subscription needed).
+
+## Security Notes
+
+- All containers run as non-root with dropped capabilities
+- Root filesystems are read-only where possible
+- Init containers that need write access run as root but with `allowPrivilegeEscalation: false` and all capabilities dropped
+- The nginx sidecar injects the bearer token via envsubst at startup; the token never appears in ConfigMaps
+- `automountServiceAccountToken: false` prevents unnecessary API server access

--- a/deploy/k8s/mcp-deployment.yaml
+++ b/deploy/k8s/mcp-deployment.yaml
@@ -1,0 +1,177 @@
+# OpenPencil MCP HTTP Server — Kubernetes Deployment Template
+#
+# Installs @open-pencil/mcp from npm, runs the HTTP server behind an nginx
+# TLS-terminating sidecar that injects bearer auth.
+#
+# Deploy:
+#   export MCP_NAMESPACE=mcp
+#   export MCP_PACKAGE_VERSION=0.8.0
+#   export MCP_AUTH_SECRET=mcp-openpencil-auth      # Secret with key "bearer_token"
+#   export MCP_TLS_SECRET=mcp-openpencil-tls
+#   export MCP_NGINX_CONFIGMAP=mcp-openpencil-nginx
+#   export MCP_PVC_NAME=mcp-openpencil-data
+#   envsubst < deploy/k8s/mcp-deployment.yaml | kubectl apply -f -
+#
+# Required environment variables:
+#   MCP_NAMESPACE        - target namespace (e.g. "mcp")
+#   MCP_PACKAGE_VERSION  - @open-pencil/mcp npm version (e.g. "0.8.0")
+#   MCP_AUTH_SECRET      - name of Secret containing bearer token (key: "bearer_token")
+#   MCP_TLS_SECRET       - name of TLS Secret for nginx sidecar
+#   MCP_NGINX_CONFIGMAP  - name of ConfigMap with nginx.conf.template
+#   MCP_PVC_NAME         - name of PersistentVolumeClaim for .fig file storage
+#
+# Optional (with defaults):
+#   NODE_IMAGE      - Node.js runtime image  (default: node:22-alpine)
+#   MCP_NGINX_IMAGE - nginx sidecar image    (default: nginx:1.27-alpine)
+#                     For hardened images: dhi.io/nginx:1.29.5 (requires `docker login dhi.io`)
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-openpencil
+  namespace: ${MCP_NAMESPACE}
+  labels:
+    app: mcp-openpencil
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: mcp-openpencil
+  template:
+    metadata:
+      labels:
+        app: mcp-openpencil
+    spec:
+      enableServiceLinks: false
+      securityContext:
+        fsGroup: 1000
+      initContainers:
+      - name: install-mcp
+        image: ${NODE_IMAGE:-node:22-alpine}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          npm install --omit=dev --prefix /opt/openpencil \
+            "@open-pencil/mcp@${MCP_PACKAGE_VERSION}"
+          test -x /opt/openpencil/node_modules/.bin/openpencil-mcp-http
+        env:
+        - { name: HOME, value: /tmp }
+        resources:
+          requests: { cpu: 50m, memory: 128Mi }
+          limits:   { cpu: 500m, memory: 1Gi }
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+        volumeMounts:
+        - { name: runtime, mountPath: /opt/openpencil }
+        - { name: app-tmp, mountPath: /tmp }
+      containers:
+      - name: mcp-openpencil
+        image: ${NODE_IMAGE:-node:22-alpine}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          exec /opt/openpencil/node_modules/.bin/openpencil-mcp-http
+        env:
+        - { name: HOST,  value: "0.0.0.0" }
+        - { name: PORT,  value: "3100" }
+        - { name: HOME,  value: /tmp }
+        - { name: OPENPENCIL_MCP_ROOT, value: /data/openpencil }
+        - name: OPENPENCIL_MCP_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ${MCP_AUTH_SECRET}
+              key: bearer_token
+        ports:
+        - { containerPort: 3100, name: mcp }
+        workingDir: /data/openpencil
+        resources:
+          requests: { cpu: 100m, memory: 128Mi }
+          limits:   { cpu: 500m, memory: 512Mi }
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+        volumeMounts:
+        - { name: runtime, mountPath: /opt/openpencil, readOnly: true }
+        - { name: files,   mountPath: /data/openpencil }
+        - { name: app-tmp, mountPath: /tmp }
+        startupProbe:
+          httpGet: { path: /health, port: 3100 }
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 24
+        readinessProbe:
+          httpGet: { path: /health, port: 3100 }
+          periodSeconds: 10
+        livenessProbe:
+          httpGet: { path: /health, port: 3100 }
+          periodSeconds: 30
+      - name: nginx-sidecar
+        image: ${MCP_NGINX_IMAGE:-nginx:1.27-alpine}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          : "${MCP_BEARER_TOKEN:?missing MCP_BEARER_TOKEN}"
+          envsubst '${MCP_BEARER_TOKEN}' \
+            < /etc/nginx/nginx.conf.template > /tmp/nginx.conf
+          exec nginx -g 'daemon off;' -c /tmp/nginx.conf
+        env:
+        - name: MCP_BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ${MCP_AUTH_SECRET}
+              key: bearer_token
+        ports:
+        - { containerPort: 8443, name: https }
+        - { containerPort: 8080, name: http }
+        securityContext:
+          runAsUser: 101
+          runAsGroup: 101
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+        startupProbe:
+          tcpSocket: { port: 8443 }
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 12
+        readinessProbe:
+          tcpSocket: { port: 8443 }
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket: { port: 8443 }
+          periodSeconds: 30
+        volumeMounts:
+        - { name: nginx-tmp,    mountPath: /tmp }
+        - { name: nginx-config, mountPath: /etc/nginx/nginx.conf.template, subPath: nginx.conf.template }
+        - { name: tls,          mountPath: /tls, readOnly: true }
+        resources:
+          requests: { cpu: 10m, memory: 16Mi }
+          limits:   { cpu: 100m, memory: 64Mi }
+      volumes:
+      - { name: runtime,      emptyDir: {} }
+      - name: files
+        persistentVolumeClaim:
+          claimName: ${MCP_PVC_NAME}
+      - { name: app-tmp,      emptyDir: {} }
+      - { name: nginx-tmp,    emptyDir: {} }
+      - { name: nginx-config, configMap: { name: "${MCP_NGINX_CONFIGMAP}" } }
+      - { name: tls,          secret:    { secretName: "${MCP_TLS_SECRET}" } }

--- a/deploy/k8s/nginx-configmap.yaml
+++ b/deploy/k8s/nginx-configmap.yaml
@@ -1,0 +1,76 @@
+# Nginx ConfigMap for OpenPencil MCP server
+#
+# The nginx sidecar uses envsubst at startup to inject the bearer token,
+# then proxies to the MCP HTTP server on localhost:3100.
+#
+# Deploy:
+#   export MCP_NAMESPACE=mcp
+#   export MCP_SERVER_NAME="mcp-openpencil.example.com"
+#   envsubst < deploy/k8s/nginx-configmap.yaml | kubectl apply -f -
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-openpencil-nginx
+  namespace: ${MCP_NAMESPACE}
+data:
+  nginx.conf.template: |
+    worker_processes 1;
+    error_log /dev/stderr warn;
+    pid /tmp/nginx.pid;
+
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+        client_body_temp_path /tmp/client_body;
+        proxy_temp_path /tmp/proxy;
+        fastcgi_temp_path /tmp/fastcgi;
+        uwsgi_temp_path /tmp/uwsgi;
+        scgi_temp_path /tmp/scgi;
+        access_log /dev/stdout;
+
+        server {
+            listen 8080;
+            server_name _;
+            return 301 https://$$host$$request_uri;
+        }
+
+        server {
+            listen 8443 ssl default_server;
+            server_name ${MCP_SERVER_NAME:-mcp-openpencil};
+
+            ssl_certificate /tls/tls.crt;
+            ssl_certificate_key /tls/tls.key;
+
+            location = / {
+                default_type text/plain;
+                return 404 "OpenPencil MCP endpoint. Use /mcp.\n";
+            }
+
+            location = /health {
+                proxy_pass http://127.0.0.1:3100/health;
+                proxy_http_version 1.1;
+                proxy_set_header Host $$host;
+                proxy_set_header X-Real-IP $$remote_addr;
+                proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto https;
+            }
+
+            location /mcp {
+                proxy_pass http://127.0.0.1:3100/mcp;
+                proxy_http_version 1.1;
+                proxy_buffering off;
+                proxy_request_buffering off;
+                proxy_read_timeout 600s;
+                proxy_send_timeout 600s;
+                proxy_set_header Host $$host;
+                proxy_set_header X-Real-IP $$remote_addr;
+                proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto https;
+                proxy_set_header Authorization "Bearer $${MCP_BEARER_TOKEN}";
+                client_max_body_size 50m;
+            }
+        }
+    }

--- a/deploy/k8s/webapp-deployment.yaml
+++ b/deploy/k8s/webapp-deployment.yaml
@@ -1,0 +1,141 @@
+# OpenPencil Web UI — Kubernetes Deployment Template
+#
+# Builds the PWA from a release tarball and serves it via nginx with TLS.
+#
+# Deploy:
+#   export OPENPENCIL_VERSION=0.9.0
+#   export OPENPENCIL_NAMESPACE=openpencil
+#   export TLS_SECRET_NAME=openpencil-tls
+#   export NGINX_CONFIGMAP=openpencil-nginx-config
+#   envsubst < deploy/k8s/webapp-deployment.yaml | kubectl apply -f -
+#
+# Required environment variables:
+#   OPENPENCIL_VERSION   - release tag (e.g. "0.9.0")
+#   OPENPENCIL_NAMESPACE - target namespace (e.g. "openpencil")
+#   TLS_SECRET_NAME      - name of a TLS Secret for nginx
+#   NGINX_CONFIGMAP      - name of a ConfigMap with your nginx.conf
+#
+# Optional (with defaults):
+#   BUN_IMAGE     - Bun builder image     (default: oven/bun:1.3.10-alpine)
+#   NGINX_IMAGE   - nginx serving image   (default: nginx:1.27-alpine)
+#                   For hardened images: dhi.io/nginx:1.29.5 (requires `docker login dhi.io`)
+#   BUSYBOX_IMAGE - fetch init image      (default: busybox:1.37.0)
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openpencil
+  namespace: ${OPENPENCIL_NAMESPACE}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: openpencil
+  template:
+    metadata:
+      labels:
+        app: openpencil
+    spec:
+      enableServiceLinks: false
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+      - name: fetch-source
+        image: ${BUSYBOX_IMAGE:-busybox:1.37.0}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          wget -O /tmp/src.tar.gz \
+            "https://github.com/open-pencil/open-pencil/archive/refs/tags/v${OPENPENCIL_VERSION}.tar.gz"
+          mkdir -p /src
+          tar -xzf /tmp/src.tar.gz --strip-components=1 -C /src
+          test -f /src/package.json
+        resources:
+          requests: { cpu: 10m, memory: 32Mi }
+          limits:   { cpu: 100m, memory: 128Mi }
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+        volumeMounts:
+        - { name: source,    mountPath: /src }
+        - { name: fetch-tmp, mountPath: /tmp }
+      - name: build
+        image: ${BUN_IMAGE:-oven/bun:1.3.10-alpine}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          cd /src
+          export HOME=/tmp
+          bun install --frozen-lockfile
+          bun run build
+          cp -R dist/. /srv/
+          chmod -R a+rX /srv
+          test -f /srv/index.html
+        resources:
+          requests: { cpu: 100m, memory: 512Mi }
+          limits:   { cpu: "1", memory: 2Gi }
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+        volumeMounts:
+        - { name: source,    mountPath: /src }
+        - { name: dist,      mountPath: /srv }
+        - { name: build-tmp, mountPath: /tmp }
+      containers:
+      - name: nginx
+        image: ${NGINX_IMAGE:-nginx:1.27-alpine}
+        ports:
+        - { containerPort: 8443, name: https }
+        - { containerPort: 8080, name: http }
+        securityContext:
+          runAsUser: 101
+          runAsGroup: 101
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+        startupProbe:
+          tcpSocket: { port: 8443 }
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 12
+        readinessProbe:
+          tcpSocket: { port: 8443 }
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket: { port: 8443 }
+          periodSeconds: 30
+        volumeMounts:
+        - { name: nginx-config, mountPath: /etc/nginx/nginx.conf, subPath: nginx.conf }
+        - { name: dist,         mountPath: /usr/share/nginx/html, readOnly: true }
+        - { name: tls,          mountPath: /tls,                  readOnly: true }
+        - { name: nginx-tmp,    mountPath: /tmp }
+        resources:
+          requests: { cpu: 10m, memory: 32Mi }
+          limits:   { cpu: 100m, memory: 64Mi }
+      volumes:
+      - { name: source,       emptyDir: {} }
+      - { name: dist,         emptyDir: {} }
+      - { name: fetch-tmp,    emptyDir: {} }
+      - { name: build-tmp,    emptyDir: {} }
+      - { name: nginx-config, configMap: { name: "${NGINX_CONFIGMAP}" } }
+      - { name: tls,          secret:    { secretName: "${TLS_SECRET_NAME}" } }
+      - { name: nginx-tmp,    emptyDir: {} }


### PR DESCRIPTION
## Summary

Example Kubernetes manifests for self-hosting OpenPencil, contributed from a production deployment. Intended as a reference starting point, not a prescriptive deployment method.

- **webapp-deployment.yaml** — Init containers fetch a release tarball and build with Bun; nginx serves the static PWA with TLS
- **mcp-deployment.yaml** — Init container installs `@open-pencil/mcp` from npm; nginx TLS sidecar with bearer auth injection
- **nginx-configmap.yaml** — Reverse proxy template for the MCP sidecar
- **README** — Quick start, env var reference, image options, security notes

All org-specific values are parameterized via `envsubst`. Default images use standard upstream (nginx:1.27-alpine, node:22-alpine); [DHI hardened images](https://docs.docker.com/dhi/) documented as an option. All containers run non-root with dropped capabilities and read-only root filesystems where possible.

Relates to #113, #114