### PR TITLE
fix(fig-export): default COLOR variable alpha to 1 when missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix save crash ("Missing required field 'a'") when COLOR variable values are missing the alpha channel — now defaults to 1
+
 ## 0.10.0 — 2026-03-15
 
 ### Performance

--- a/packages/core/src/fig-export.ts
+++ b/packages/core/src/fig-export.ts
@@ -33,8 +33,9 @@ function variableValueToKiwi(
     }
   }
   if (type === 'COLOR' && typeof value === 'object' && 'r' in value) {
+    const color = value as { r: number; g: number; b: number; a?: number }
     return {
-      value: { colorValue: { r: value.r, g: value.g, b: value.b, a: value.a } },
+      value: { colorValue: { r: color.r, g: color.g, b: color.b, a: color.a ?? 1 } },
       dataType: 'COLOR',
       resolvedDataType: 'COLOR'
     }

--- a/tests/engine/fig-export-variables.test.ts
+++ b/tests/engine/fig-export-variables.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect, beforeAll } from 'bun:test'
+
+import {
+  exportFigFile,
+  parseFigFile,
+  initCodec,
+  SceneGraph,
+} from '@open-pencil/core'
+
+beforeAll(async () => {
+  await initCodec()
+})
+
+describe('COLOR variable alpha handling', () => {
+  test('COLOR variable without alpha exports successfully', async () => {
+    const graph = new SceneGraph()
+    const col = graph.createCollection('Colors')
+    // Simulate a COLOR variable value missing the alpha field
+    graph.createVariable('brand', 'COLOR', col.id, { r: 0.2, g: 0.4, b: 0.8 } as any)
+
+    const exported = await exportFigFile(graph)
+    const reimported = await parseFigFile(exported.buffer as ArrayBuffer)
+
+    const vars = [...reimported.variables.values()]
+    const colorVar = vars.find((v) => v.name === 'brand')!
+    expect(colorVar.type).toBe('COLOR')
+    const val = Object.values(colorVar.valuesByMode)[0] as { r: number; g: number; b: number; a: number }
+    expect(val.r).toBeCloseTo(0.2, 1)
+    expect(val.g).toBeCloseTo(0.4, 1)
+    expect(val.b).toBeCloseTo(0.8, 1)
+    expect(val.a).toBe(1)
+  })
+
+  test('COLOR variable with explicit alpha preserves it', async () => {
+    const graph = new SceneGraph()
+    const col = graph.createCollection('Colors')
+    graph.createVariable('overlay', 'COLOR', col.id, { r: 0, g: 0, b: 0, a: 0.5 })
+
+    const exported = await exportFigFile(graph)
+    const reimported = await parseFigFile(exported.buffer as ArrayBuffer)
+
+    const vars = [...reimported.variables.values()]
+    const colorVar = vars.find((v) => v.name === 'overlay')!
+    const val = Object.values(colorVar.valuesByMode)[0] as { r: number; g: number; b: number; a: number }
+    expect(val.a).toBeCloseTo(0.5, 1)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #128

- In `variableValueToKiwi()`, cast the COLOR value to allow optional `a` and default to `1` — matches the `safeColor()` pattern used for fills/strokes/effects in `kiwi-serialize.ts`
- Adds 2 tests: export with missing alpha (defaults to 1), export with explicit alpha (preserves 0.5)
- Updates CHANGELOG.md

## Test plan

- [x] New test: `COLOR variable without alpha exports successfully` — verifies missing `a` defaults to 1 after roundtrip
- [x] New test: `COLOR variable with explicit alpha preserves it` — verifies `a: 0.5` survives roundtrip
- [x] Verified first test fails WITHOUT the fix (throws "Missing required field 'a'")
- [x] `bun run check` — 0 warnings, 0 errors
- [x] `bun run format` — clean
- [x] `bun run test:dupes` — 1.26% (under 3%)
- [x] `bun run test:unit` — 862 pass, 3 fail (pre-existing LFS fixture issue), 32 skip
