### PR TITLE
Fix switch_page not persisting across MCP tool calls

### DIFF
--- a/src/automation/server.ts
+++ b/src/automation/server.ts
@@ -76,6 +76,11 @@ export function connectAutomation(getStore: () => EditorStore) {
     if (!def) throw new Error(`Unknown tool: ${toolName}`)
     const figma = makeFigma()
     const result = await def.execute(figma, toolArgs)
+
+    if (figma.currentPageId !== store.state.currentPageId) {
+      void store.switchPage(figma.currentPageId)
+    }
+
     if (def.mutates) {
       computeAllLayouts(store.graph, store.state.currentPageId)
       store.requestRender()

--- a/tests/engine/tools.test.ts
+++ b/tests/engine/tools.test.ts
@@ -489,6 +489,31 @@ describe('page tools', () => {
 
     expect(figma.currentPage.name).toBe('Page 2')
   })
+
+  test('switch_page persists across separate FigmaAPI instances (RPC simulation)', () => {
+    const { graph } = setup()
+    const switchPage = ALL_TOOLS.find((t) => t.name === 'switch_page')!
+    const getCurrentPage = ALL_TOOLS.find((t) => t.name === 'get_current_page')!
+    const createPage = ALL_TOOLS.find((t) => t.name === 'create_page')!
+
+    let currentPageId = graph.getPages()[0].id
+
+    function rpcCall(tool: (typeof ALL_TOOLS)[number], args: Record<string, unknown>) {
+      const figma = new FigmaAPI(graph)
+      figma.currentPage = figma.wrapNode(currentPageId)
+      const result = tool.execute(figma, args)
+      if (figma.currentPageId !== currentPageId) {
+        currentPageId = figma.currentPageId
+      }
+      return result
+    }
+
+    rpcCall(createPage, { name: 'Second' })
+    rpcCall(switchPage, { page: 'Second' })
+    const result = rpcCall(getCurrentPage, {}) as { id: string; name: string }
+
+    expect(result.name).toBe('Second')
+  })
 })
 
 describe('eval', () => {


### PR DESCRIPTION
Each RPC tool call in `src/automation/server.ts` creates a fresh `FigmaAPI` instance via `makeFigma()`. When `switch_page` runs, it sets `currentPageId` on that throwaway instance — the editor store is never updated. The next tool call creates another fresh `FigmaAPI` seeded from the unchanged store, so `get_current_page` still reports the original page.

After executing any tool, check if `figma.currentPageId` diverged from `store.state.currentPageId` and call `store.switchPage()` to sync it back (saves/restores viewport, loads fonts).

RPC simulation test creates separate `FigmaAPI` instances per call (mirroring the real automation flow) and verifies `get_current_page` returns the switched page.

Fixes #112

---

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [x] Tests added or updated
- [ ] CHANGELOG.md updated (if user-facing)