### PR TITLE
JSX editor in Code panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- JSX editor in Code panel — write or paste OpenPencil JSX to create design nodes, with syntax highlighting, undo support, and error display
+- "Copy JSX Reference" button in JSX editor — copies the full prop/tag reference to clipboard for LLM prompts
 - Lock and visibility toggle buttons in layers panel (hover to reveal, always shown when active)
 - Figma-style selection scope — double-click to enter groups/frames/components, Escape to exit
 - Nested container navigation — each double-click goes one level deeper

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -191,7 +191,8 @@ export {
   type RenderResult,
   sceneNodeToJSX,
   selectionToJSX,
-  type JSXFormat
+  type JSXFormat,
+  JSX_REFERENCE
 } from './render'
 export {
   parseFigmaClipboard,

--- a/packages/core/src/render/index.ts
+++ b/packages/core/src/render/index.ts
@@ -34,3 +34,5 @@ export { createElement } from './mini-react'
 export { renderJSX, renderTreeNode, buildComponent } from './render-jsx'
 
 export { sceneNodeToJSX, selectionToJSX, type JSXFormat } from './export-jsx'
+
+export { JSX_REFERENCE } from './jsx-reference'

--- a/packages/core/src/render/jsx-reference.ts
+++ b/packages/core/src/render/jsx-reference.ts
@@ -1,0 +1,154 @@
+/**
+ * Human-readable reference for the OpenPencil JSX format.
+ * Intended for copying into LLM prompts or documentation.
+ *
+ * Keep in sync with:
+ *   - renderer.ts (TYPE_MAP, propsToOverrides, apply* helpers)
+ *   - render-jsx.ts (buildComponent tag aliases)
+ *   - export-jsx.ts (collectProps, nodeToJSX)
+ */
+export const JSX_REFERENCE = `# OpenPencil JSX Reference
+
+## Elements
+
+| Tag | Description |
+|-----|-------------|
+| Frame | Container / auto-layout frame |
+| Rectangle | Rectangle shape |
+| Ellipse | Circle / ellipse shape |
+| Text | Text node (children = text content) |
+| Line | Line shape |
+| Star | Star shape |
+| Polygon | Polygon shape (default 3 sides) |
+| Vector | Vector path |
+| Group | Group container |
+| Section | Section (like Frame, for organization) |
+| Component | Component definition |
+| Icon | Iconify icon (requires name prop) |
+
+Aliases: View = Frame, Rect = Rectangle
+
+## Layout Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| flex | "row" \\| "col" | Enable auto-layout direction |
+| gap | number | Spacing between children |
+| wrap | boolean | Enable flex wrap |
+| rowGap | number | Cross-axis gap when wrap is on |
+| justify | "start" \\| "end" \\| "center" \\| "between" | Main axis alignment |
+| items | "start" \\| "end" \\| "center" \\| "stretch" | Cross axis alignment |
+| p | number | Padding (all sides) |
+| px | number | Horizontal padding |
+| py | number | Vertical padding |
+| pt, pr, pb, pl | number | Individual side padding |
+| grow | number | Flex grow factor |
+
+## Sizing Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| w | number \\| "fill" \\| "hug" | Width |
+| h | number \\| "fill" \\| "hug" | Height |
+| x | number | X position |
+| y | number | Y position |
+| minW | number | Minimum width |
+| maxW | number | Maximum width |
+
+## Appearance Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| bg | string | Background color (hex, e.g. "#FF0000") |
+| stroke | string | Stroke color |
+| strokeWidth | number | Stroke weight (default 1) |
+| rounded | number | Corner radius (all corners) |
+| roundedTL | number | Top-left corner radius |
+| roundedTR | number | Top-right corner radius |
+| roundedBL | number | Bottom-left corner radius |
+| roundedBR | number | Bottom-right corner radius |
+| cornerSmoothing | number | iOS-style corner smoothing |
+| opacity | number | 0–1 opacity |
+| rotate | number | Rotation in degrees |
+| blendMode | string | Blend mode (e.g. "multiply") |
+| overflow | "hidden" | Clip content |
+
+## Text Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| size | number | Font size (default 14) |
+| font | string | Font family |
+| weight | number \\| "bold" \\| "medium" | Font weight |
+| color | string | Text color (hex) |
+| textAlign | "left" \\| "center" \\| "right" \\| "justified" | Text alignment |
+| lineHeight | number | Line height in px |
+| letterSpacing | number | Letter spacing in px |
+| textDecoration | "underline" \\| "strikethrough" | Text decoration |
+| textCase | "upper" \\| "lower" \\| "title" | Text transform |
+| maxLines | number | Max visible lines (enables truncation) |
+| truncate | boolean | Enable text truncation |
+
+## Shape Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| points | number | Point count (Star default 5, Polygon default 3) |
+| innerRadius | number | Star inner radius ratio |
+
+## Effect Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| shadow | string | Drop shadow: "offsetX offsetY blur color" |
+| blur | number | Layer blur radius |
+
+## Grid Layout
+
+| Prop | Type | Description |
+|------|------|-------------|
+| grid | boolean | Enable CSS Grid layout |
+| columns | string \\| number | Grid template columns (e.g. "1fr 1fr 1fr" or 3) |
+| rows | string \\| number | Grid template rows |
+| columnGap | number | Column gap |
+| rowGap | number | Row gap |
+| colStart | number | Grid column start (child) |
+| rowStart | number | Grid row start (child) |
+| colSpan | number | Grid column span (child) |
+| rowSpan | number | Grid row span (child) |
+
+## Icon Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| name | string | Iconify icon name (e.g. "lucide:heart") |
+| size | number | Icon size (default 24) |
+| color | string | Icon color (hex) |
+| label | string | Display name for the icon node |
+
+## Examples
+
+\`\`\`jsx
+{/* Card with title and description */}
+<Frame name="Card" w={320} flex="col" gap={16} p={24} bg="#FFFFFF" rounded={16}>
+  <Text size={18} weight="bold" color="#111">Card Title</Text>
+  <Text size={14} color="#6B7280">Description text here</Text>
+</Frame>
+
+{/* Horizontal button row */}
+<Frame flex="row" gap={8} items="center">
+  <Rectangle w={40} h={40} bg="#3B82F6" rounded={8} />
+  <Text size={14} weight="medium" color="#000">Click me</Text>
+</Frame>
+
+{/* Grid layout */}
+<Frame grid columns="1fr 1fr 1fr" gap={16} p={16} w={400}>
+  <Rectangle w={100} h={100} bg="#EF4444" rounded={8} />
+  <Rectangle w={100} h={100} bg="#22C55E" rounded={8} />
+  <Rectangle w={100} h={100} bg="#3B82F6" rounded={8} />
+</Frame>
+
+{/* Star shape */}
+<Star w={48} h={48} points={5} innerRadius={0.38} bg="#EAB308" />
+\`\`\`
+`

--- a/packages/core/src/render/render-jsx.ts
+++ b/packages/core/src/render/render-jsx.ts
@@ -9,24 +9,64 @@ import type { SceneGraph } from '../scene-graph'
 /**
  * Build a component function from a JSX string using sucrase.
  * Works in both Node/Bun and the browser (no native bindings).
+ * Supports single-root and multi-root JSX (multiple top-level elements
+ * are wrapped in a fragment `<>...</>`).
  */
 export function buildComponent(jsxString: string): () => unknown {
+  const trimmed = jsxString.trim()
+  const needsFragment = /^<[A-Za-z]/.test(trimmed) && hasMultipleRoots(trimmed)
+  const jsx = needsFragment ? `<>${trimmed}</>` : trimmed
+
   const code = `
     const __h = React.createElement
+    const __frag = ''
     const Frame = 'frame', Text = 'text', Rectangle = 'rectangle', Ellipse = 'ellipse'
     const Line = 'line', Star = 'star', Polygon = 'polygon', Vector = 'vector'
     const Group = 'group', Section = 'section', View = 'frame', Rect = 'rectangle'
+    const Component = 'component', Instance = 'frame'
     const Icon = 'icon'
-    return function Component() { return ${jsxString.trim()} }
+    return function __render() { return ${jsx} }
   `
 
   const result = transform(code, {
     transforms: ['typescript', 'jsx'],
     jsxPragma: '__h',
+    jsxFragmentPragma: '__frag',
     production: true
   })
 
   return new Function('React', result.code)(React) as () => unknown
+}
+
+function hasMultipleRoots(jsx: string): boolean {
+  let depth = 0
+  let roots = 0
+  let i = 0
+  while (i < jsx.length) {
+    if (jsx[i] === '<') {
+      if (jsx[i + 1] === '/') {
+        const end = jsx.indexOf('>', i)
+        if (end === -1) break
+        depth--
+        i = end + 1
+        if (depth === 0) roots++
+        continue
+      }
+      const end = jsx.indexOf('>', i)
+      if (end === -1) break
+      if (jsx[end - 1] === '/') {
+        if (depth === 0) roots++
+        i = end + 1
+      } else {
+        depth++
+        i = end + 1
+      }
+      if (roots > 1) return true
+      continue
+    }
+    i++
+  }
+  return roots > 1
 }
 
 interface RenderJSXOptions {
@@ -37,13 +77,14 @@ interface RenderJSXOptions {
 
 /**
  * Render a JSX string into the scene graph.
+ * Returns an array when the JSX contains multiple root elements.
  * Works in both Node/Bun and the browser.
  */
 export async function renderJSX(
   graph: SceneGraph,
   jsxString: string,
   options?: RenderJSXOptions
-): Promise<RenderResult> {
+): Promise<RenderResult[]> {
   const Component = buildComponent(jsxString)
   const element = React.createElement(Component, null)
   const tree = resolveToTree(element)
@@ -52,7 +93,19 @@ export async function renderJSX(
     throw new Error('JSX must return a Figma element (Frame, Text, etc)')
   }
 
-  return renderTree(graph, tree, options)
+  if (tree.type === '' && tree.children.length > 0) {
+    const results: RenderResult[] = []
+    for (const child of tree.children) {
+      if (typeof child === 'string') continue
+      results.push(await renderTree(graph, child, options))
+    }
+    if (results.length === 0) {
+      throw new Error('JSX must return a Figma element (Frame, Text, etc)')
+    }
+    return results
+  }
+
+  return [await renderTree(graph, tree, options)]
 }
 
 /**

--- a/packages/core/src/tools/create.ts
+++ b/packages/core/src/tools/create.ts
@@ -79,11 +79,12 @@ export const render = defineTool({
       }
     }
 
-    const result = await renderJSX(figma.graph, args.jsx, {
+    const results = await renderJSX(figma.graph, args.jsx, {
       parentId,
       x: args.x,
       y: args.y
     })
+    const result = results[0]
 
     if (args.replace_id && replaceIndex >= 0) {
       figma.graph.reorderChild(result.id, parentId, replaceIndex)

--- a/packages/core/src/tools/structure.ts
+++ b/packages/core/src/tools/structure.ts
@@ -268,7 +268,8 @@ export const nodeReplaceWith = defineTool({
     const y = node.y
     node.remove()
     const { renderJSX } = await import('../render/render-jsx.js')
-    const result = await renderJSX(figma.graph, args.jsx, { parentId, x, y })
+    const results = await renderJSX(figma.graph, args.jsx, { parentId, x, y })
+    const result = results[0]
     return { id: result.id, name: result.name, type: result.type }
   }
 })

--- a/src/components/CodePanel.vue
+++ b/src/components/CodePanel.vue
@@ -2,7 +2,7 @@
 import Prism from 'prismjs'
 import 'prismjs/components/prism-jsx'
 import { ScrollAreaRoot, ScrollAreaScrollbar, ScrollAreaThumb, ScrollAreaViewport } from 'reka-ui'
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 
 import { selectionToJSX } from '@open-pencil/core'
 import { useEditorStore } from '@/stores/editor'
@@ -12,6 +12,12 @@ import type { JSXFormat } from '@open-pencil/core'
 const store = useEditorStore()
 const copied = ref(false)
 const jsxFormat = ref<JSXFormat>('openpencil')
+const editing = ref(false)
+const editorCode = ref('')
+const editorError = ref('')
+const applying = ref(false)
+const textareaRef = ref<HTMLTextAreaElement>()
+const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform)
 
 function toggleFormat() {
   jsxFormat.value = jsxFormat.value === 'openpencil' ? 'tailwind' : 'openpencil'
@@ -30,6 +36,12 @@ const highlightedLines = computed(() => {
   return jsxCode.value.split('\n').map((line) => Prism.highlight(line, grammar, 'jsx'))
 })
 
+const editorHighlightedLines = computed(() => {
+  if (!editorCode.value) return []
+  const grammar = Prism.languages.jsx ?? Prism.languages.javascript
+  return editorCode.value.split('\n').map((line) => Prism.highlight(line, grammar, 'jsx'))
+})
+
 let copyTimeout: ReturnType<typeof setTimeout> | undefined
 
 function copyCode() {
@@ -42,17 +54,168 @@ function copyCode() {
 watch(jsxCode, () => {
   copied.value = false
 })
+
+function enterEditMode() {
+  editorCode.value = jsxCode.value
+  editing.value = true
+  editorError.value = ''
+  void nextTick(() => textareaRef.value?.focus())
+}
+
+function exitEditMode() {
+  editing.value = false
+  editorCode.value = ''
+  editorError.value = ''
+}
+
+async function applyJSX() {
+  const code = editorCode.value.trim()
+  if (!code) return
+
+  applying.value = true
+  editorError.value = ''
+
+  try {
+    await store.renderJSXWithUndo(code)
+    editorCode.value = ''
+    editing.value = false
+  } catch (e) {
+    editorError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    applying.value = false
+  }
+}
+
+function handleEditorKeydown(e: KeyboardEvent) {
+  if (e.key === 'Tab') {
+    e.preventDefault()
+    const textarea = textareaRef.value
+    if (!textarea) return
+    const start = textarea.selectionStart
+    const end = textarea.selectionEnd
+    editorCode.value = editorCode.value.substring(0, start) + '  ' + editorCode.value.substring(end)
+    void nextTick(() => {
+      textarea.selectionStart = textarea.selectionEnd = start + 2
+    })
+  }
+
+  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+    e.preventDefault()
+    void applyJSX()
+  }
+
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    exitEditMode()
+  }
+}
 </script>
 
 <template>
-  <div
-    v-if="!jsxCode"
-    data-test-id="code-panel-empty"
-    class="flex flex-1 items-center justify-center px-4 text-center"
-  >
-    <span class="text-xs text-muted">Select a layer to see its JSX code</span>
+  <!-- Editor mode -->
+  <div v-if="editing" data-test-id="code-panel-editor" class="flex min-h-0 flex-1 flex-col">
+    <div class="flex shrink-0 items-center justify-between border-b border-border px-3 py-1.5">
+      <span class="text-[11px] text-muted">JSX Editor</span>
+      <div class="flex items-center gap-1">
+        <button
+          data-test-id="code-panel-apply"
+          class="flex items-center gap-1 rounded bg-blue-600 px-2 py-0.5 text-[11px] text-white hover:bg-blue-500 disabled:opacity-50"
+          :disabled="!editorCode.trim() || applying"
+          @click="applyJSX"
+        >
+          <icon-lucide-play class="size-3" />
+          {{ applying ? 'Applying…' : 'Apply' }}
+        </button>
+        <button
+          data-test-id="code-panel-cancel"
+          class="rounded px-1.5 py-0.5 text-[11px] text-muted hover:bg-hover hover:text-surface"
+          @click="exitEditMode"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+
+    <div v-if="editorError" class="border-b border-red-500/30 bg-red-500/10 px-3 py-2">
+      <p class="text-[11px] text-red-400">{{ editorError }}</p>
+    </div>
+
+    <div class="relative min-h-0 flex-1">
+      <ScrollAreaRoot class="absolute inset-0">
+        <ScrollAreaViewport class="size-full">
+          <div class="relative p-3">
+            <!-- Syntax-highlighted underlay -->
+            <div class="pointer-events-none" aria-hidden="true">
+              <div
+                v-for="(html, i) in editorHighlightedLines"
+                :key="i"
+                class="flex text-xs leading-5"
+              >
+                <span
+                  class="mr-3 shrink-0 text-right text-muted/40 select-none"
+                  style="min-width: 1.5em"
+                  >{{ i + 1 }}</span
+                >
+                <pre
+                  class="m-0 min-w-0 flex-1 break-words whitespace-pre-wrap"
+                ><code v-html="html" /></pre>
+              </div>
+              <div v-if="!editorCode" class="flex text-xs leading-5">
+                <span
+                  class="mr-3 shrink-0 text-right text-muted/40 select-none"
+                  style="min-width: 1.5em"
+                  >1</span
+                >
+                <span class="text-muted/40">Paste or write JSX here…</span>
+              </div>
+            </div>
+
+            <!-- Invisible textarea overlay -->
+            <textarea
+              ref="textareaRef"
+              v-model="editorCode"
+              data-test-id="code-panel-textarea"
+              class="absolute inset-0 m-3 resize-none border-0 bg-transparent font-mono text-xs leading-5 text-transparent caret-white outline-none"
+              style="padding-left: calc(1.5em + 0.75rem)"
+              spellcheck="false"
+              autocomplete="off"
+              autocorrect="off"
+              autocapitalize="off"
+              @keydown="handleEditorKeydown"
+            />
+          </div>
+        </ScrollAreaViewport>
+        <ScrollAreaScrollbar orientation="vertical" class="flex w-1.5 touch-none p-px select-none">
+          <ScrollAreaThumb class="relative flex-1 rounded-full bg-white/10" />
+        </ScrollAreaScrollbar>
+      </ScrollAreaRoot>
+    </div>
+
+    <div class="shrink-0 border-t border-border px-3 py-1.5">
+      <span class="text-[10px] text-muted/60">
+        {{ isMac ? '⌘' : 'Ctrl' }}+Enter to apply · Esc to cancel
+      </span>
+    </div>
   </div>
 
+  <!-- Empty state -->
+  <div
+    v-else-if="!jsxCode"
+    data-test-id="code-panel-empty"
+    class="flex flex-1 flex-col items-center justify-center gap-3 px-4 text-center"
+  >
+    <span class="text-xs text-muted">Select a layer to see its JSX code</span>
+    <button
+      data-test-id="code-panel-new"
+      class="flex items-center gap-1 rounded border border-border px-2.5 py-1 text-[11px] text-muted hover:bg-hover hover:text-surface"
+      @click="enterEditMode"
+    >
+      <icon-lucide-plus class="size-3" />
+      Write JSX
+    </button>
+  </div>
+
+  <!-- Read-only view -->
   <div v-else data-test-id="code-panel" class="flex min-h-0 flex-1 flex-col">
     <div
       data-test-id="code-panel-header"
@@ -68,15 +231,25 @@ watch(jsxCode, () => {
           {{ jsxFormat === 'openpencil' ? 'OpenPencil' : 'Tailwind' }}
         </button>
       </div>
-      <button
-        data-test-id="code-panel-copy"
-        class="flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-muted hover:bg-hover hover:text-surface"
-        @click="copyCode"
-      >
-        <icon-lucide-check v-if="copied" class="size-3 text-green-400" />
-        <icon-lucide-copy v-else class="size-3" />
-        {{ copied ? 'Copied' : 'Copy' }}
-      </button>
+      <div class="flex items-center gap-1">
+        <button
+          data-test-id="code-panel-edit"
+          class="flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-muted hover:bg-hover hover:text-surface"
+          title="Write JSX"
+          @click="enterEditMode"
+        >
+          <icon-lucide-pencil class="size-3" />
+        </button>
+        <button
+          data-test-id="code-panel-copy"
+          class="flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-muted hover:bg-hover hover:text-surface"
+          @click="copyCode"
+        >
+          <icon-lucide-check v-if="copied" class="size-3 text-green-400" />
+          <icon-lucide-copy v-else class="size-3" />
+          {{ copied ? 'Copied' : 'Copy' }}
+        </button>
+      </div>
     </div>
 
     <ScrollAreaRoot class="min-h-0 flex-1">

--- a/src/components/CodePanel.vue
+++ b/src/components/CodePanel.vue
@@ -16,6 +16,7 @@ const editing = ref(false)
 const editorCode = ref('')
 const editorError = ref('')
 const applying = ref(false)
+const replaceIds = ref<string[]>([])
 const textareaRef = ref<HTMLTextAreaElement>()
 const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform)
 
@@ -57,6 +58,7 @@ watch(jsxCode, () => {
 
 function enterEditMode() {
   editorCode.value = jsxCode.value
+  replaceIds.value = [...store.state.selectedIds]
   editing.value = true
   editorError.value = ''
   void nextTick(() => textareaRef.value?.focus())
@@ -66,6 +68,7 @@ function exitEditMode() {
   editing.value = false
   editorCode.value = ''
   editorError.value = ''
+  replaceIds.value = []
 }
 
 async function applyJSX() {
@@ -76,8 +79,9 @@ async function applyJSX() {
   editorError.value = ''
 
   try {
-    await store.renderJSXWithUndo(code)
+    await store.renderJSXWithUndo(code, replaceIds.value.length > 0 ? replaceIds.value : undefined)
     editorCode.value = ''
+    replaceIds.value = []
     editing.value = false
   } catch (e) {
     editorError.value = e instanceof Error ? e.message : String(e)

--- a/src/components/CodePanel.vue
+++ b/src/components/CodePanel.vue
@@ -56,7 +56,10 @@ watch(jsxCode, () => {
   copied.value = false
 })
 
+const canEdit = computed(() => jsxFormat.value === 'openpencil')
+
 function enterEditMode() {
+  jsxFormat.value = 'openpencil'
   editorCode.value = jsxCode.value
   replaceIds.value = [...store.state.selectedIds]
   editing.value = true
@@ -237,9 +240,10 @@ function handleEditorKeydown(e: KeyboardEvent) {
       </div>
       <div class="flex items-center gap-1">
         <button
+          v-if="canEdit"
           data-test-id="code-panel-edit"
           class="flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-muted hover:bg-hover hover:text-surface"
-          title="Write JSX"
+          title="Edit JSX"
           @click="enterEditMode"
         >
           <icon-lucide-pencil class="size-3" />

--- a/src/components/CodePanel.vue
+++ b/src/components/CodePanel.vue
@@ -4,7 +4,7 @@ import 'prismjs/components/prism-jsx'
 import { ScrollAreaRoot, ScrollAreaScrollbar, ScrollAreaThumb, ScrollAreaViewport } from 'reka-ui'
 import { computed, nextTick, ref, watch } from 'vue'
 
-import { selectionToJSX } from '@open-pencil/core'
+import { selectionToJSX, JSX_REFERENCE } from '@open-pencil/core'
 import { useEditorStore } from '@/stores/editor'
 
 import type { JSXFormat } from '@open-pencil/core'
@@ -19,6 +19,15 @@ const applying = ref(false)
 const replaceIds = ref<string[]>([])
 const textareaRef = ref<HTMLTextAreaElement>()
 const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform)
+const refCopied = ref(false)
+let refCopyTimeout: ReturnType<typeof setTimeout> | undefined
+
+function copyReference() {
+  navigator.clipboard.writeText(JSX_REFERENCE)
+  refCopied.value = true
+  clearTimeout(refCopyTimeout)
+  refCopyTimeout = setTimeout(() => (refCopied.value = false), 2000)
+}
 
 function toggleFormat() {
   jsxFormat.value = jsxFormat.value === 'openpencil' ? 'tailwind' : 'openpencil'
@@ -122,7 +131,18 @@ function handleEditorKeydown(e: KeyboardEvent) {
   <!-- Editor mode -->
   <div v-if="editing" data-test-id="code-panel-editor" class="flex min-h-0 flex-1 flex-col">
     <div class="flex shrink-0 items-center justify-between border-b border-border px-3 py-1.5">
-      <span class="text-[11px] text-muted">JSX Editor</span>
+      <div class="flex items-center gap-1.5">
+        <span class="text-[11px] text-muted">JSX Editor</span>
+        <button
+          data-test-id="code-panel-copy-ref"
+          class="flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-muted hover:bg-hover hover:text-surface"
+          title="Copy JSX Reference"
+          @click="copyReference"
+        >
+          <icon-lucide-check v-if="refCopied" class="size-3 text-green-400" />
+          <icon-lucide-book-open v-else class="size-3" />
+        </button>
+      </div>
       <div class="flex items-center gap-1">
         <button
           data-test-id="code-panel-apply"

--- a/src/composables/use-keyboard.ts
+++ b/src/composables/use-keyboard.ts
@@ -167,15 +167,15 @@ export function useKeyboard() {
 
   // --- Shift (no mod) ---
   whenever(
-    computed(() => keys['shift+digit1'].value && !keys['meta'].value && !keys['control'].value),
+    computed(() => keys['shift+digit1'].value && !keys['meta'].value && !keys['control'].value && !isEditingNow()),
     () => store.zoomToFit()
   )
   whenever(
-    computed(() => keys['shift+digit2'].value && !keys['meta'].value && !keys['control'].value),
+    computed(() => keys['shift+digit2'].value && !keys['meta'].value && !keys['control'].value && !isEditingNow()),
     () => store.zoomToSelection()
   )
   whenever(
-    computed(() => keys['shift+keya'].value && !keys['meta'].value && !keys['control'].value),
+    computed(() => keys['shift+keya'].value && !keys['meta'].value && !keys['control'].value && !isEditingNow()),
     () => {
       const node = store.selectedNode.value
       if (node?.type === 'FRAME' && store.selectedNodes.value.length === 1) {
@@ -187,6 +187,12 @@ export function useKeyboard() {
   )
 
   // --- Plain keys (no modifiers) ---
+  // Guard: ignore plain-key shortcuts when focus is inside an input or textarea
+  function isEditingNow(): boolean {
+    const el = document.activeElement
+    return el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement
+  }
+
   function plain(key: string): ComputedRef<boolean> {
     return computed(
       () =>
@@ -194,7 +200,8 @@ export function useKeyboard() {
         !keys['meta'].value &&
         !keys['control'].value &&
         !keys['shift'].value &&
-        !keys['alt'].value
+        !keys['alt'].value &&
+        !isEditingNow()
     )
   }
 

--- a/src/stores/editor.ts
+++ b/src/stores/editor.ts
@@ -2088,10 +2088,10 @@ export function createEditorStore() {
     const { renderJSX } = await import('@open-pencil/core/render')
     const pageId = state.currentPageId
     const prevSelection = new Set(state.selectedIds)
-    const result = await renderJSX(graph, jsxString, { parentId: pageId })
-    const rootId = result.id
-    const allNodes = collectSubtrees(graph, [rootId])
-    state.selectedIds = new Set([rootId])
+    const results = await renderJSX(graph, jsxString, { parentId: pageId })
+    const rootIds = results.map((r) => r.id)
+    const allNodes = collectSubtrees(graph, rootIds)
+    state.selectedIds = new Set(rootIds)
     requestRender()
 
     undo.push({
@@ -2104,10 +2104,10 @@ export function createEditorStore() {
           })
         }
         computeAllLayouts(graph, pageId)
-        state.selectedIds = new Set([rootId])
+        state.selectedIds = new Set(rootIds)
       },
       inverse: () => {
-        graph.deleteNode(rootId)
+        for (const id of [...rootIds].reverse()) graph.deleteNode(id)
         computeAllLayouts(graph, pageId)
         state.selectedIds = prevSelection
       }

--- a/src/stores/editor.ts
+++ b/src/stores/editor.ts
@@ -2084,30 +2084,54 @@ export function createEditorStore() {
     }
   }
 
-  async function renderJSXWithUndo(jsxString: string) {
+  async function renderJSXWithUndo(jsxString: string, replaceNodeIds?: string[]) {
     const { renderJSX } = await import('@open-pencil/core/render')
     const pageId = state.currentPageId
     const prevSelection = new Set(state.selectedIds)
-    const results = await renderJSX(graph, jsxString, { parentId: pageId })
+    const replacing = replaceNodeIds && replaceNodeIds.length > 0
+
+    let oldSnapshots: SceneNode[] = []
+    let insertParentId = pageId
+    let insertIndex = -1
+
+    if (replacing) {
+      const first = graph.getNode(replaceNodeIds[0])
+      if (first?.parentId) {
+        insertParentId = first.parentId
+        const parent = graph.getNode(insertParentId)
+        if (parent) insertIndex = parent.childIds.indexOf(replaceNodeIds[0])
+      }
+      oldSnapshots = collectSubtrees(graph, replaceNodeIds)
+      for (const id of [...replaceNodeIds].reverse()) graph.deleteNode(id)
+    }
+
+    const results = await renderJSX(graph, jsxString, { parentId: insertParentId })
     const rootIds = results.map((r) => r.id)
-    const allNodes = collectSubtrees(graph, rootIds)
+
+    if (insertIndex >= 0) {
+      for (let i = rootIds.length - 1; i >= 0; i--) {
+        graph.reorderChild(rootIds[i], insertParentId, insertIndex)
+      }
+    }
+
+    computeAllLayouts(graph, pageId)
+    const newSnapshots = collectSubtrees(graph, rootIds)
     state.selectedIds = new Set(rootIds)
     requestRender()
+
+    const oldRootIds = replacing ? replaceNodeIds.filter((id) => oldSnapshots.some((n) => n.id === id)) : []
 
     undo.push({
       label: 'Render JSX',
       forward: () => {
-        for (const snapshot of allNodes) {
-          graph.createNode(snapshot.type, snapshot.parentId ?? pageId, {
-            ...snapshot,
-            childIds: []
-          })
-        }
+        for (const id of [...oldRootIds].reverse()) graph.deleteNode(id)
+        for (const s of newSnapshots) graph.createNode(s.type, s.parentId ?? pageId, { ...s, childIds: [] })
         computeAllLayouts(graph, pageId)
         state.selectedIds = new Set(rootIds)
       },
       inverse: () => {
         for (const id of [...rootIds].reverse()) graph.deleteNode(id)
+        for (const s of oldSnapshots) graph.createNode(s.type, s.parentId ?? pageId, { ...s, childIds: [] })
         computeAllLayouts(graph, pageId)
         state.selectedIds = prevSelection
       }

--- a/src/stores/editor.ts
+++ b/src/stores/editor.ts
@@ -2084,6 +2084,36 @@ export function createEditorStore() {
     }
   }
 
+  async function renderJSXWithUndo(jsxString: string) {
+    const { renderJSX } = await import('@open-pencil/core/render')
+    const pageId = state.currentPageId
+    const prevSelection = new Set(state.selectedIds)
+    const result = await renderJSX(graph, jsxString, { parentId: pageId })
+    const rootId = result.id
+    const allNodes = collectSubtrees(graph, [rootId])
+    state.selectedIds = new Set([rootId])
+    requestRender()
+
+    undo.push({
+      label: 'Render JSX',
+      forward: () => {
+        for (const snapshot of allNodes) {
+          graph.createNode(snapshot.type, snapshot.parentId ?? pageId, {
+            ...snapshot,
+            childIds: []
+          })
+        }
+        computeAllLayouts(graph, pageId)
+        state.selectedIds = new Set([rootId])
+      },
+      inverse: () => {
+        graph.deleteNode(rootId)
+        computeAllLayouts(graph, pageId)
+        state.selectedIds = prevSelection
+      }
+    })
+  }
+
   function deleteSelected() {
     const entries: Array<{ id: string; parentId: string; snapshot: SceneNode; index: number }> = []
     for (const id of state.selectedIds) {
@@ -2452,6 +2482,7 @@ export function createEditorStore() {
     duplicateSelected,
     writeCopyData,
     pasteFromHTML,
+    renderJSXWithUndo,
     mobileCopy,
     mobileCut,
     mobilePaste,

--- a/tests/engine/render.test.ts
+++ b/tests/engine/render.test.ts
@@ -336,7 +336,7 @@ describe('renderJSX (string → scene graph)', () => {
         <Text name="Hello" size={16} color="#000">World</Text>
       </Frame>
     `
-    const result = await renderJSX(g, jsx)
+    const [result] = await renderJSX(g, jsx)
 
     expect(result.name).toBe('Test')
     const node = g.nodes.get(result.id)!
@@ -356,7 +356,7 @@ describe('renderJSX (string → scene graph)', () => {
         <Text name="Description" size={14} color="#6B7280">Lorem ipsum</Text>
       </Frame>
     `
-    const result = await renderJSX(g, jsx)
+    const [result] = await renderJSX(g, jsx)
     const card = g.nodes.get(result.id)!
 
     expect(card.layoutMode).toBe('VERTICAL')
@@ -365,11 +365,30 @@ describe('renderJSX (string → scene graph)', () => {
 
   it('renders with position', async () => {
     const g = createGraph()
-    const result = await renderJSX(g, '<Frame name="At" w={50} h={50} />', { x: 100, y: 200 })
+    const [result] = await renderJSX(g, '<Frame name="At" w={50} h={50} />', { x: 100, y: 200 })
     const node = g.nodes.get(result.id)!
 
     expect(node.x).toBe(100)
     expect(node.y).toBe(200)
+  })
+
+  it('renders multiple root elements', async () => {
+    const g = createGraph()
+    const results = await renderJSX(g, '<Rectangle name="A" w={10} h={10} />\n\n<Ellipse name="B" w={20} h={20} />')
+
+    expect(results.length).toBe(2)
+    expect(results[0].name).toBe('A')
+    expect(results[0].type).toBe('RECTANGLE')
+    expect(results[1].name).toBe('B')
+    expect(results[1].type).toBe('ELLIPSE')
+  })
+
+  it('renders Component tag', async () => {
+    const g = createGraph()
+    const [result] = await renderJSX(g, '<Component name="Btn" w={100} h={40} />')
+
+    expect(result.name).toBe('Btn')
+    expect(result.type).toBe('COMPONENT')
   })
 })
 
@@ -530,7 +549,7 @@ describe('grid layout rendering', () => {
         <Rectangle name="B" w={50} h={50} />
       </Frame>
     `
-    const result = await renderJSX(g, jsx)
+    const [result] = await renderJSX(g, jsx)
     const frame = g.nodes.get(result.id)!
 
     expect(frame.layoutMode).toBe('GRID')
@@ -605,7 +624,7 @@ describe('grid layout rendering', () => {
         </Frame>
       </Frame>
     `
-    const result = await renderJSX(g, jsx)
+    const [result] = await renderJSX(g, jsx)
     computeAllLayouts(g)
     const grid = g.getChildren(result.id).find(c => c.name === 'G')!
     expect(grid.width).toBe(360)
@@ -623,7 +642,7 @@ describe('grid layout rendering', () => {
         </Frame>
       </Frame>
     `
-    const result = await renderJSX(g, jsx)
+    const [result] = await renderJSX(g, jsx)
     computeAllLayouts(g)
     const grid = g.getChildren(result.id).find(c => c.name === 'G')!
     expect(grid.width).toBe(350)
@@ -642,7 +661,7 @@ describe('grid layout rendering', () => {
         </Frame>
       </Frame>
     `
-    const result = await renderJSX(g, jsx)
+    const [result] = await renderJSX(g, jsx)
     computeAllLayouts(g)
     const content = g.getChildren(result.id).find(c => c.name === 'Content')!
     const grid = g.getChildren(content.id).find(c => c.name === 'G')!
@@ -661,7 +680,7 @@ describe('grid layout rendering', () => {
         </Frame>
       </Frame>
     `
-    const result = await renderJSX(g, jsx)
+    const [result] = await renderJSX(g, jsx)
     computeAllLayouts(g)
     const grid = g.getChildren(result.id).find(c => c.name === 'G')!
     expect(grid.height).toBe(460)
@@ -671,7 +690,7 @@ describe('grid layout rendering', () => {
 describe('text props round-trip', () => {
   it('lineHeight renders and exports', async () => {
     const g = createGraph()
-    const result = await renderJSX(g, '<Text color="#000" lineHeight={24}>Hello</Text>')
+    const [result] = await renderJSX(g, '<Text color="#000" lineHeight={24}>Hello</Text>')
     const n = g.getNode(result.id)!
     expect(n.lineHeight).toBe(24)
     const jsx = sceneNodeToJSX(n.id, g)
@@ -680,7 +699,7 @@ describe('text props round-trip', () => {
 
   it('letterSpacing renders and exports', async () => {
     const g = createGraph()
-    const result = await renderJSX(g, '<Text color="#000" letterSpacing={2}>Spaced</Text>')
+    const [result] = await renderJSX(g, '<Text color="#000" letterSpacing={2}>Spaced</Text>')
     const n = g.getNode(result.id)!
     expect(n.letterSpacing).toBe(2)
     const jsx = sceneNodeToJSX(n.id, g)
@@ -689,7 +708,7 @@ describe('text props round-trip', () => {
 
   it('textDecoration renders and exports', async () => {
     const g = createGraph()
-    const result = await renderJSX(g, '<Text color="#000" textDecoration="underline">Link</Text>')
+    const [result] = await renderJSX(g, '<Text color="#000" textDecoration="underline">Link</Text>')
     const n = g.getNode(result.id)!
     expect(n.textDecoration).toBe('UNDERLINE')
     const jsx = sceneNodeToJSX(n.id, g)
@@ -698,7 +717,7 @@ describe('text props round-trip', () => {
 
   it('textCase renders and exports', async () => {
     const g = createGraph()
-    const result = await renderJSX(g, '<Text color="#000" textCase="upper">label</Text>')
+    const [result] = await renderJSX(g, '<Text color="#000" textCase="upper">label</Text>')
     const n = g.getNode(result.id)!
     expect(n.textCase).toBe('UPPER')
     const jsx = sceneNodeToJSX(n.id, g)
@@ -707,7 +726,7 @@ describe('text props round-trip', () => {
 
   it('maxLines renders with truncation', async () => {
     const g = createGraph()
-    const result = await renderJSX(g, '<Text color="#000" maxLines={2}>Long text here</Text>')
+    const [result] = await renderJSX(g, '<Text color="#000" maxLines={2}>Long text here</Text>')
     const n = g.getNode(result.id)!
     expect(n.maxLines).toBe(2)
     expect(n.textTruncation).toBe('ENDING')
@@ -717,7 +736,7 @@ describe('text props round-trip', () => {
 
   it('truncate without maxLines', async () => {
     const g = createGraph()
-    const result = await renderJSX(g, '<Text color="#000" truncate>Overflow</Text>')
+    const [result] = await renderJSX(g, '<Text color="#000" truncate>Overflow</Text>')
     const n = g.getNode(result.id)!
     expect(n.textTruncation).toBe('ENDING')
     const jsx = sceneNodeToJSX(n.id, g)
@@ -726,7 +745,7 @@ describe('text props round-trip', () => {
 
   it('defaults omit text props', async () => {
     const g = createGraph()
-    const result = await renderJSX(g, '<Text color="#000">Plain</Text>')
+    const [result] = await renderJSX(g, '<Text color="#000">Plain</Text>')
     const n = g.getNode(result.id)!
     expect(n.lineHeight).toBeNull()
     expect(n.letterSpacing).toBe(0)
@@ -744,7 +763,7 @@ describe('text props round-trip', () => {
 
   it('text w="fill" in flex="col" exports as w="fill" not w={computed}', async () => {
     const g = createGraph()
-    const result = await renderJSX(g, `
+    const [result] = await renderJSX(g, `
       <Frame name="Card" flex="col" w={300} p={20}>
         <Text name="Title" size={22} weight="bold" color="#111" w="fill">Hello World</Text>
       </Frame>
@@ -760,7 +779,7 @@ describe('text props round-trip', () => {
 
   it('text grow={1} in flex="row" exports as grow not w={computed}', async () => {
     const g = createGraph()
-    const result = await renderJSX(g, `
+    const [result] = await renderJSX(g, `
       <Frame name="Row" flex="row" w={300}>
         <Text name="Label" color="#999" w={60}>Label</Text>
         <Text name="Value" color="#111" w="fill">Some value text</Text>


### PR DESCRIPTION
Editable JSX in the Code panel — write, paste, or edit OpenPencil JSX to create and update design nodes directly. No AI integration needed.

**Editor mode:**
- "Write JSX" button in empty state, pencil icon in read-only view (OpenPencil format only)
- Syntax-highlighted textarea with line numbers and placeholder
- Apply (+ Cmd/Ctrl+Enter), Cancel (+ Esc), Tab inserts 2 spaces
- Inline error display on parse/render failure
- Editing existing selection replaces original nodes at the same position
- "Copy JSX Reference" button (📖) copies full tag/prop/example reference to clipboard

**Core changes:**
- `renderJSX` now returns `RenderResult[]` — supports multi-root JSX via fragment wrapping
- `buildComponent` adds `Component` and `Instance` tag aliases
- `renderJSXWithUndo` in editor store with full undo/redo
- Guard keyboard shortcuts when focus is in input/textarea (`useMagicKeys` fired delete/tool shortcuts while typing)

Fixes #130

---

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [x] Tests added or updated
- [x] CHANGELOG.md updated (if user-facing)