### PR TITLE
Guard keyboard shortcuts during canvas text editing

### DIFF
--- a/src/composables/use-keyboard.ts
+++ b/src/composables/use-keyboard.ts
@@ -95,6 +95,7 @@ export function useKeyboard() {
     onEventFired(e) {
       if (e.type !== 'keydown') return
       if (isEditing(e)) return
+      if (store.state.editingTextId) return
 
       if (!e.metaKey && !e.ctrlKey && !e.altKey) {
         const tool = TOOL_SHORTCUTS[e.key.toLowerCase()]
@@ -194,7 +195,8 @@ export function useKeyboard() {
         !keys['meta'].value &&
         !keys['control'].value &&
         !keys['shift'].value &&
-        !keys['alt'].value
+        !keys['alt'].value &&
+        !store.state.editingTextId
     )
   }
 


### PR DESCRIPTION
Fixes #142

Backspace/Delete and tool shortcuts (V, R, F, T, etc.) fired during canvas text editing because the guard only checked for DOM input/textarea focus (`document.activeElement`), not the canvas TextEditor state (`editingTextId`).

Two places guarded:
- `onEventFired` — prevents tool switching (typing "v" switched to Move tool)
- `plain()` helper — prevents Backspace/Delete from calling `deleteSelected()`

---

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [ ] Tests added or updated
- [x] CHANGELOG.md updated (if user-facing)