### PR TITLE
feat: add spacebar hold to temporarily activate Hand (pan) tool

### DIFF
--- a/src/composables/use-keyboard.ts
+++ b/src/composables/use-keyboard.ts
@@ -90,6 +90,28 @@ export function useKeyboard() {
     if (html) store.pasteFromHTML(html, cursorPos)
   })
 
+  // Spacebar hold → temporary Hand tool (Figma-style canvas pan)
+  let toolBeforeSpace: string | null = null
+
+  useEventListener(window, 'keydown', (e: KeyboardEvent) => {
+    if (isEditing(e)) return
+    if (e.code === 'Space' && !e.metaKey && !e.ctrlKey && !e.altKey && !e.repeat) {
+      if (store.state.activeTool !== 'HAND') {
+        toolBeforeSpace = store.state.activeTool
+        store.setTool('HAND')
+      }
+      e.preventDefault()
+    }
+  })
+
+  useEventListener(window, 'keyup', (e: KeyboardEvent) => {
+    if (e.code === 'Space' && toolBeforeSpace) {
+      store.setTool(toolBeforeSpace as any)
+      toolBeforeSpace = null
+      e.preventDefault()
+    }
+  })
+
   const keys = useMagicKeys({
     passive: false,
     onEventFired(e) {


### PR DESCRIPTION
## Summary

Hold **Spacebar** to temporarily switch to the Hand tool for panning the canvas. Release to return to the previously active tool. This matches the standard Figma UX pattern.

## Changes

`src/composables/use-keyboard.ts`:
- Added `keydown` listener: on Space press, save current tool and switch to HAND
- Added `keyup` listener: on Space release, restore the saved tool
- Uses `useEventListener` (not `useMagicKeys`) for reliable `keyup` detection
- Guards: `isEditing()`, `e.repeat`, modifier keys, already in HAND mode

## Behavior

| Action | Result |
|--------|--------|
| Hold Spacebar | Switch to Hand tool, cursor becomes grab |
| Drag while holding | Pan the canvas |
| Release Spacebar | Return to previous tool (Select, Frame, etc.) |
| Spacebar during text edit | No effect (normal space character) |
| Already in Hand mode (`H`) | No effect |

Fixes #147