### PR TITLE
feat(fonts): load multiple CJK Google Fonts for full CJK coverage

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -280,5 +280,5 @@ export const CJK_FALLBACK_FAMILIES_LINUX = [
   'Droid Sans Fallback'
 ]
 
-export const CJK_GOOGLE_FONT = 'Noto Sans SC'
+export const CJK_GOOGLE_FONTS = ['Noto Sans SC', 'Noto Sans JP', 'Noto Sans KR']
 

--- a/packages/core/src/fonts.ts
+++ b/packages/core/src/fonts.ts
@@ -6,7 +6,7 @@ import {
   CJK_FALLBACK_FAMILIES_MACOS,
   CJK_FALLBACK_FAMILIES_WINDOWS,
   CJK_FALLBACK_FAMILIES_LINUX,
-  CJK_GOOGLE_FONT,
+  CJK_GOOGLE_FONTS,
   GOOGLE_FONTS_API_KEY
 } from './constants'
 import type { SceneGraph } from './scene-graph'
@@ -309,8 +309,8 @@ export function collectFontKeys(graph: SceneGraph, nodeIds: string[]): Array<[st
   return [...fontKeys].map((k) => k.split('\0') as [string, string])
 }
 
-let cjkFallbackFamily: string | null = null
-let cjkFallbackPromise: Promise<string | null> | null = null
+let cjkFallbackFamilies: string[] = []
+let cjkFallbackPromise: Promise<string[]> | null = null
 
 function getCJKCandidates(): string[] {
   if (typeof navigator === 'undefined') return [...CJK_FALLBACK_FAMILIES_LINUX]
@@ -320,37 +320,53 @@ function getCJKCandidates(): string[] {
   return CJK_FALLBACK_FAMILIES_LINUX
 }
 
-export async function ensureCJKFallback(): Promise<string | null> {
-  if (cjkFallbackFamily) return cjkFallbackFamily
+export async function ensureCJKFallback(): Promise<string[]> {
+  if (cjkFallbackFamilies.length > 0) return cjkFallbackFamilies
   if (cjkFallbackPromise) return cjkFallbackPromise
 
   cjkFallbackPromise = (async () => {
+    // Try local system fonts first
     for (const family of getCJKCandidates()) {
       const buffer = await findLocalFont(family)
       if (buffer && registerAndCache(family, 'Regular', buffer)) {
-        cjkFallbackFamily = family
-        return family
+        cjkFallbackFamilies.push(family)
       }
     }
 
-    const data = await loadFont(CJK_GOOGLE_FONT, 'Regular')
-    if (data) {
-      cjkFallbackFamily = CJK_GOOGLE_FONT
-      return CJK_GOOGLE_FONT
+    // Load all CJK Google Fonts in parallel for full coverage
+    if (cjkFallbackFamilies.length === 0) {
+      const results = await Promise.allSettled(
+        CJK_GOOGLE_FONTS.map(async (family) => {
+          const data = await loadFont(family, 'Regular')
+          return data ? family : null
+        })
+      )
+      for (const result of results) {
+        if (result.status === 'fulfilled' && result.value) {
+          cjkFallbackFamilies.push(result.value)
+        }
+      }
     }
 
-    return null
+    return cjkFallbackFamilies
   })()
 
   return cjkFallbackPromise
 }
 
+/** @deprecated Use getCJKFallbackFamilies() instead */
 export function getCJKFallbackFamily(): string | null {
-  return cjkFallbackFamily
+  return cjkFallbackFamilies[0] ?? null
+}
+
+export function getCJKFallbackFamilies(): string[] {
+  return cjkFallbackFamilies
 }
 
 export function setCJKFallbackFamily(family: string): void {
-  cjkFallbackFamily = family
+  if (!cjkFallbackFamilies.includes(family)) {
+    cjkFallbackFamilies.push(family)
+  }
 }
 
 export function weightToStyle(weight: number, italic = false): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,6 +94,7 @@ export {
   ensureNodeFont,
   ensureCJKFallback,
   getCJKFallbackFamily,
+  getCJKFallbackFamilies,
   setCJKFallbackFamily,
   styleToWeight,
   weightToStyle,

--- a/packages/core/src/renderer/renderer.ts
+++ b/packages/core/src/renderer/renderer.ts
@@ -416,8 +416,8 @@ export class SkiaRenderer {
     this.fontsLoaded = true
     this.invalidateAllPictures()
 
-    void ensureCJKFallback().then((family) => {
-      if (family) this.invalidateAllPictures()
+    void ensureCJKFallback().then((families) => {
+      if (families.length > 0) this.invalidateAllPictures()
     })
   }
 

--- a/packages/core/src/renderer/text.ts
+++ b/packages/core/src/renderer/text.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_FONT_SIZE, DEFAULT_FONT_FAMILY } from '../constants'
-import { isFontLoaded, getCJKFallbackFamily } from '../fonts'
+import { isFontLoaded, getCJKFallbackFamilies } from '../fonts'
 
 import type { SceneNode } from '../scene-graph'
 import type { CanvasKit, FontWeight, Paragraph, TypefaceFontProvider } from 'canvaskit-wasm'
@@ -166,14 +166,14 @@ export function buildParagraph(
   const ck = r.ck
   const baseColor = color ?? ck.BLACK
   const baseFontSize = node.fontSize || DEFAULT_FONT_SIZE
-  const cjkFallback = getCJKFallbackFamily()
+  const cjkFallbacks = getCJKFallbackFamilies()
 
   const truncateOpts = buildTruncateOpts(node, baseFontSize)
 
   const fontFamilies = (primary: string) => {
     const families = [primary]
     if (primary !== DEFAULT_FONT_FAMILY) families.push(DEFAULT_FONT_FAMILY)
-    if (cjkFallback) families.push(cjkFallback)
+    families.push(...cjkFallbacks)
     return families
   }
 


### PR DESCRIPTION
## Summary

- Replace single `CJK_GOOGLE_FONT` (`Noto Sans SC`) with `CJK_GOOGLE_FONTS` array containing **Noto Sans SC, Noto Sans JP, and Noto Sans KR**
- Load all three fonts in parallel via `Promise.allSettled` when local system fonts are unavailable
- Pass all loaded CJK families as fallbacks in the text renderer
- Backward compatible: `getCJKFallbackFamily()` still works, new `getCJKFallbackFamilies()` returns the full list

## Problem

When the Local Font Access API is blocked (common in web browsers without user activation), the CJK fallback falls through to Google Fonts. Previously only `Noto Sans SC` (Simplified Chinese) was loaded, which meant **Korean and Japanese text rendered as tofu** (missing glyph boxes).

## Before / After

| Before | After |
|--------|-------|
| Korean/Japanese text shows as □□□ | All three CJK scripts render correctly |
| Only `Noto Sans SC` loaded as fallback | `Noto Sans SC` + `Noto Sans JP` + `Noto Sans KR` loaded in parallel |

## Changed files

| File | Change |
|------|--------|
| `packages/core/src/constants.ts` | `CJK_GOOGLE_FONT` → `CJK_GOOGLE_FONTS` array |
| `packages/core/src/fonts.ts` | `ensureCJKFallback()` loads multiple fonts, new `getCJKFallbackFamilies()` |
| `packages/core/src/index.ts` | Export `getCJKFallbackFamilies` |
| `packages/core/src/renderer/renderer.ts` | Handle array return from `ensureCJKFallback()` |
| `packages/core/src/renderer/text.ts` | Spread all CJK fallback families into font list |

## Test plan

- [x] Verified Korean (한글), Chinese (你好世界), Japanese (こんにちは) all render correctly on the canvas
- [x] TypeScript type check passes (no new errors)
- [x] Existing `setCJKFallbackFamily()` API unchanged for backward compat