### PR TITLE
Assets panel with components, images, and SVG import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ patches/skia-webgpu/
 Caddyfile.dev
 components.d.ts
 vue-stream-markdown/
+pr-141-review.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Assets tab in left panel — browse, search, and insert components and images with thumbnail previews, variant expansion, instance counts, drag-to-canvas, and context menu
 - Lock and visibility toggle buttons in layers panel (hover to reveal, always shown when active)
 - Figma-style selection scope — double-click to enter groups/frames/components, Escape to exit
 - Nested container navigation — each double-click goes one level deeper

--- a/openspec/changes/archive/2026-03-23-asset-components-view/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-23-asset-components-view/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-23

--- a/openspec/changes/archive/2026-03-23-asset-components-view/design.md
+++ b/openspec/changes/archive/2026-03-23-asset-components-view/design.md
@@ -1,0 +1,228 @@
+## Context
+
+The left sidebar (`LayersPanel.vue`) has a fixed layout: PagesPanel (top SplitterPanel) + "Layers" header + LayerTree (bottom SplitterPanel), managed by reka-ui SplitterGroup. There's no tab switching — the bottom section is always the layer tree.
+
+The scene graph has full component infrastructure: `COMPONENT`, `COMPONENT_SET`, `INSTANCE` node types. `instanceIndex` maps componentId → Set of instance IDs. `getInstances(componentId)` returns all instances. `createInstance(componentId, parentId, overrides)` handles deep-cloning with componentId mapping. COMPONENT_SET is a parent container — its direct children are COMPONENT nodes (variants).
+
+For rendering thumbnails, `renderNodesToImage()` in `render-image.ts` creates an offscreen CanvasKit surface, renders nodes, encodes to PNG. It needs `CanvasKit`, `SkiaRenderer`, `SceneGraph`, `pageId`, `nodeIds`, and `{ scale, format }`.
+
+The store has `_ck` (CanvasKit) and `_renderer` (SkiaRenderer) as private vars. `renderer` is exposed as a getter but `_ck` is not. `renderExportImage()` uses both internally. We need to either expose `_ck` or add a store-level thumbnail method.
+
+`createInstanceFromComponent(componentId, x?, y?)` exists in the store. BUG: it uses `component.parentId ?? state.currentPageId` as the parent. When dragging from Assets to canvas, if the component is on Page 2 but we're viewing Page 1, the instance gets created on Page 2 (component's parent page), invisible to the user. Fix: add an explicit `targetPageId` parameter.
+
+`goToMainComponent()` navigates to a component but uses hardcoded `viewW = 800, viewH = 600` instead of `window.innerWidth/Height`. Other methods (`zoomToBounds`, `zoomTo100`) correctly use `window.innerWidth/Height`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Layers/Assets tab switcher in left panel bottom section
+- Component list grouped by page with collapsible sections
+- COMPONENT_SET expands to show variant children (individual COMPONENTs inside)
+- Each item: 48×48 thumbnail, name (truncated), type icon, instance count badge, description in title attribute
+- Full-text search by name across all pages
+- Drag from panel → drop on canvas → INSTANCE at drop position
+- Double-click item → INSTANCE at viewport center
+- Right-click context menu: "Go to component", "Insert instance"
+- `focusNode(nodeId)` store helper for page-switching + viewport centering
+- MCP system prompt mentions component discovery tools
+
+**Non-Goals:**
+- Remote/shared component libraries (requires backend)
+- Component documentation editing in the panel
+- Component properties panel (property definitions, boolean/text/instance-swap props)
+- Thumbnail caching to IndexedDB
+- Custom drag ghost image
+- Keyboard shortcut for tab switching (future)
+
+## Decisions
+
+### 1. Tab switcher — reka-ui TabsRoot in bottom SplitterPanel
+
+**What changes:** In `LayersPanel.vue`, the bottom SplitterPanel currently has:
+```html
+<header>Layers</header>
+<LayerTree />
+```
+Replace with:
+```html
+<TabsRoot v-model="store.state.leftPanelTab">
+  <TabsList> Layers | Assets </TabsList>
+  <TabsContent value="layers"><LayerTree /></TabsContent>
+  <TabsContent value="assets"><AssetsPanel /></TabsContent>
+</TabsRoot>
+```
+
+Style: TabsTrigger with `text-[11px] tracking-wider uppercase` matching current header. Active state via `data-[state=active]:text-surface data-[state=active]:font-semibold`, inactive `text-muted`. No background change — just text weight/color, matching PropertiesPanel tab style.
+
+### 2. Component enumeration — SceneGraph.getComponentsGroupedByPage()
+
+**Method signature:**
+```ts
+getComponentsGroupedByPage(): Array<{ page: SceneNode; components: SceneNode[] }>
+```
+
+**Algorithm:**
+```
+for each page in getPages():
+  components = []
+  stack = [...page.childIds]
+  while stack not empty:
+    id = stack.pop()
+    node = nodes.get(id)
+    if node.type === 'COMPONENT':
+      components.push(node)
+    elif node.type === 'COMPONENT_SET':
+      components.push(node)
+      // DON'T recurse into COMPONENT_SET children — those are variants, shown via expansion
+    elif CONTAINER_TYPES.has(node.type):
+      stack.push(...node.childIds)  // recurse into frames/groups/sections
+  if components.length > 0:
+    result.push({ page, components })
+```
+
+Key: we DON'T recurse into COMPONENT_SET children at the top level — those COMPONENT children (variants) are shown when the set is expanded in the UI. We DO recurse into frames, groups, sections to find components nested inside them.
+
+### 3. COMPONENT_SET variant expansion
+
+In `AssetsPanel.vue`, when rendering a COMPONENT_SET item, wrap it in a reka-ui `CollapsibleRoot`. The trigger shows the set name + grid icon. The content lists its direct COMPONENT children as individual AssetItem rows (indented). Each variant is individually draggable/insertable.
+
+**Data flow:**
+```
+group.components = [ButtonSet(COMPONENT_SET), Card(COMPONENT)]
+→ ButtonSet expands to show: Button/Primary(COMPONENT), Button/Secondary(COMPONENT)
+→ Card is a standalone COMPONENT
+```
+
+Variant children come from `graph.getChildren(componentSet.id).filter(c => c.type === 'COMPONENT')`.
+
+### 4. Thumbnails — store-level renderComponentThumbnail()
+
+**Why store-level, not composable:** `_ck` (CanvasKit instance) is private to the store. Rather than expose it, add:
+```ts
+function renderComponentThumbnail(nodeId: string, size = 48): string | null {
+  if (!_ck || !_renderer) return null
+  const node = graph.getNode(nodeId)
+  if (!node) return null
+  // Find which page this component is on
+  const pageId = findPageId(graph, nodeId)
+  if (!pageId) return null
+  const bytes = renderNodesToImage(_ck, _renderer, graph, pageId, [nodeId], { scale: 1, format: 'PNG' })
+  if (!bytes) return null
+  const blob = new Blob([bytes], { type: 'image/png' })
+  return URL.createObjectURL(blob)
+}
+```
+
+**Composable `use-component-thumbnails`** calls this store method and manages the reactive Map + blob URL lifecycle:
+- Input: computed list of component IDs
+- Output: reactive `Map<string, string>` (nodeId → blob URL)
+- Watch `sceneVersion` with 500ms `watchDebounced` from `@vueuse/core`
+- On update: diff old vs new IDs, revoke removed blob URLs, render only new/changed ones
+- Cleanup on `onScopeDispose`: revoke all blob URLs
+
+### 5. Instance count — instanceIndex lookup
+
+Each AssetItem shows instance count badge: `graph.instanceIndex.get(node.id)?.size ?? 0`. The `instanceIndex` is already maintained by createNode/updateNode/deleteNode. No extra tracking needed. Badge shows as dim text like "3×" next to the name.
+
+### 6. Drag-and-drop — extend use-canvas-drop
+
+**Priority order in event handlers:**
+1. Check `dataTransfer.types.includes('application/x-openpencil-component')` FIRST
+2. Fall through to `hasImageFiles(e)` check
+
+**dragover handler extension:**
+```ts
+if (e.dataTransfer?.types.includes('application/x-openpencil-component')) {
+  e.preventDefault()
+  if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
+  isDraggingOver.value = true
+  return  // don't fall through to image check
+}
+```
+
+**drop handler extension:**
+```ts
+const componentId = e.dataTransfer?.getData('application/x-openpencil-component')
+if (componentId) {
+  e.preventDefault()
+  isDraggingOver.value = false
+  const rect = canvas.getBoundingClientRect()
+  const { x, y } = store.screenToCanvas(e.clientX - rect.left, e.clientY - rect.top)
+  store.createInstanceFromComponent(componentId, x, y, state.currentPageId)
+  return
+}
+```
+
+### 7. Fix createInstanceFromComponent — explicit targetPageId
+
+**Current (broken):**
+```ts
+const parentId = component.parentId ?? state.currentPageId
+```
+
+**Fixed:**
+```ts
+function createInstanceFromComponent(componentId: string, x?: number, y?: number, targetPageId?: string) {
+  ...
+  const parentId = targetPageId ?? state.currentPageId
+  ...
+}
+```
+
+When called from context menu / keyboard (no target page), defaults to current page.
+When called from drag-drop, explicitly passes `state.currentPageId`.
+
+### 8. focusNode — generalized viewport navigation
+
+```ts
+function focusNode(nodeId: string) {
+  const node = graph.getNode(nodeId)
+  if (!node) return
+  // Walk up to find page
+  let current: SceneNode | undefined = node
+  while (current && current.type !== 'CANVAS') {
+    current = current.parentId ? graph.getNode(current.parentId) : undefined
+  }
+  if (current && current.id !== state.currentPageId) {
+    void switchPage(current.id)
+  }
+  state.selectedIds = new Set([nodeId])
+  const abs = graph.getAbsolutePosition(nodeId)
+  const viewW = window.innerWidth
+  const viewH = window.innerHeight
+  state.panX = viewW / 2 - (abs.x + node.width / 2) * state.zoom
+  state.panY = viewH / 2 - (abs.y + node.height / 2) * state.zoom
+  requestRender()
+}
+```
+
+Then refactor `goToMainComponent` to use `focusNode`:
+```ts
+function goToMainComponent() {
+  const node = selectedNode.value
+  if (!node?.componentId) return
+  const main = graph.getMainComponent(node.id)
+  if (!main) return
+  focusNode(main.id)
+}
+```
+
+### 9. AssetItem context menu
+
+Use reka-ui `ContextMenuRoot/ContextMenuTrigger/ContextMenuContent/ContextMenuItem` (already used in `CanvasContextMenu.vue`). Two items:
+- "Insert instance" → `createInstanceFromComponent(node.id, cx, cy)` at viewport center
+- "Go to component" → `focusNode(node.id)`
+
+### 10. Component description
+
+SceneNode already has a `description: string` field (default `''`). Show as `title` attribute on the AssetItem root div — native browser tooltip on hover. No custom tooltip component needed for v1.
+
+## Risks / Trade-offs
+
+**[Thumbnail rendering blocks main thread]** → `renderNodesToImage` is synchronous. For 50 components at 48×48, each render is ~1-2ms = ~100ms total. Acceptable with 500ms debounce. If it becomes noticeable, can move to `requestIdleCallback` batching later.
+
+**[Blob URL memory]** → Each thumbnail is ~1-5KB PNG. 100 components = ~500KB. Blob URLs are revoked on re-render and on composable dispose. Acceptable.
+
+**[Component list O(n) scan]** → `getComponentsGroupedByPage()` walks all nodes. For a 10K node document, this is ~1ms. Cached by Vue computed until sceneVersion changes. Fine.
+
+**[COMPONENT_SET expansion fetches children every render]** → `graph.getChildren(setId)` is a map lookup + filter. Negligible cost.

--- a/openspec/changes/archive/2026-03-23-asset-components-view/proposal.md
+++ b/openspec/changes/archive/2026-03-23-asset-components-view/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+There's no way to browse or search existing components in a document. Users who create reusable COMPONENT / COMPONENT_SET nodes must hunt through the layers tree or remember where they placed them. Figma solves this with an Assets panel that lists all components grouped by page, with search, thumbnail previews, variant expansion for COMPONENT_SETs, and drag-to-canvas insertion. This is a fundamental usability gap — especially as documents grow and accumulate dozens of components.
+
+## What Changes
+
+- Add a **Layers/Assets tab switcher** to the left sidebar bottom section, keeping PagesPanel untouched above
+- The **Assets tab** lists all COMPONENT and COMPONENT_SET nodes in the document, grouped by page in collapsible sections
+- **COMPONENT_SET nodes expand** to show their child COMPONENT variants — each variant is individually insertable
+- Each component shows: **thumbnail preview** (48×48 CanvasKit render), **name** (truncated), **type icon** (◆ component / ▦ set), **instance count** badge, **description** tooltip
+- **Search** filters components by name (case-insensitive substring match)
+- **Drag-and-drop** from the Assets panel onto the canvas creates an INSTANCE at the drop position
+- **Double-click** inserts an instance at viewport center
+- **Right-click context menu** with "Go to component", "Insert instance" actions
+- Add `getComponentsGroupedByPage()` method to SceneGraph for component enumeration
+- Expose a `renderComponentThumbnail()` store method for thumbnail generation
+- Fix `createInstanceFromComponent()` parentId to use current page for cross-page insertion
+- Add `focusNode(nodeId)` store helper for viewport centering (replaces hardcoded 800×600 in `goToMainComponent`)
+- Update `ACP_DESIGN_CONTEXT` system prompt to mention `get_components` and `create_instance` tools
+
+## Capabilities
+
+### New Capabilities
+- `asset-panel`: Left-sidebar Assets tab with component browsing, search, variant expansion, thumbnails, drag-to-canvas, click-to-insert, context menu
+
+### Modified Capabilities
+- `editor-ui`: Left sidebar bottom section gains Layers/Assets tab switcher
+- `components`: SceneGraph gets `getComponentsGroupedByPage()` helper; store gets `focusNode()` + fixes to `createInstanceFromComponent()` cross-page parentId
+
+## Impact
+
+- `packages/core/src/scene-graph.ts` — new `getComponentsGroupedByPage()` method
+- `src/stores/editor.ts` — new `leftPanelTab` state, `focusNode()`, `renderComponentThumbnail()`, fix `createInstanceFromComponent()` parentId
+- `src/components/LayersPanel.vue` — add TabsRoot/TabsTrigger switching bottom section
+- `src/components/AssetsPanel.vue` — new: component listing with search, page groups, empty states
+- `src/components/AssetItem.vue` — new: component row with thumbnail, name, type icon, instance count, drag, context menu
+- `src/composables/use-component-thumbnails.ts` — new: debounced CanvasKit thumbnail rendering with blob URL lifecycle
+- `src/composables/use-canvas-drop.ts` — extend to handle `application/x-openpencil-component` MIME type
+- `src/constants.ts` — update `ACP_DESIGN_CONTEXT`
+- `tests/engine/scene-graph.test.ts` — new tests for `getComponentsGroupedByPage()`

--- a/openspec/changes/archive/2026-03-23-asset-components-view/specs/asset-panel/spec.md
+++ b/openspec/changes/archive/2026-03-23-asset-components-view/specs/asset-panel/spec.md
@@ -1,0 +1,135 @@
+## ADDED Requirements
+
+### Requirement: Assets panel displays all components grouped by page
+The Assets panel SHALL list all COMPONENT and COMPONENT_SET nodes in the document, grouped under collapsible page sections (expanded by default). Each page section shows the page name as header with a chevron toggle. INSTANCE nodes SHALL NOT appear in the listing. Empty pages (with no components) SHALL be omitted. Components nested inside frames/groups/sections SHALL be found via recursive traversal.
+
+#### Scenario: Document with components on two pages
+- **WHEN** the document has components "Button" and "Card" on Page 1, and "Header" on Page 2
+- **THEN** the Assets panel shows two collapsible sections: "Page 1" with Button and Card, "Page 2" with Header
+
+#### Scenario: Document with no components
+- **WHEN** the document has no COMPONENT or COMPONENT_SET nodes
+- **THEN** the Assets panel shows an empty state: centered icon, "No components" title, and hint "Select a frame and press ⌥⌘K to create a component"
+
+#### Scenario: Page with no components is hidden
+- **WHEN** Page 3 has shapes but no COMPONENT nodes
+- **THEN** Page 3 does not appear in the Assets panel listing
+
+#### Scenario: Component nested inside a frame
+- **WHEN** a COMPONENT "Icon" exists inside a frame "Icons Container" on Page 1
+- **THEN** "Icon" appears in the Page 1 section of the Assets panel
+
+### Requirement: COMPONENT_SET variant expansion
+COMPONENT_SET items in the Assets panel SHALL be expandable (reka-ui Collapsible) to reveal their child COMPONENT nodes (variants). Each variant SHALL be individually selectable, draggable, and insertable. The set itself is also insertable (inserts the first variant by default).
+
+#### Scenario: Expand component set to see variants
+- **WHEN** a COMPONENT_SET "Button" has children "Button/Primary" and "Button/Secondary"
+- **THEN** clicking the expand chevron reveals "Button/Primary" and "Button/Secondary" as indented items
+
+#### Scenario: Insert specific variant
+- **WHEN** user drags "Button/Secondary" from the expanded set onto the canvas
+- **THEN** an INSTANCE of "Button/Secondary" (not "Button/Primary") is created
+
+#### Scenario: Insert from collapsed set
+- **WHEN** user drags the collapsed "Button" COMPONENT_SET onto the canvas
+- **THEN** an INSTANCE of the first variant child is created
+
+### Requirement: Component search by name
+The Assets panel SHALL provide a search input that filters components by name using case-insensitive substring matching. The search applies across all pages. When the search query is active, only matching components are shown (page grouping preserved, empty groups hidden). COMPONENT_SET children (variants) SHALL also be searched. Clearing the search restores the full list.
+
+#### Scenario: Search finds matching components
+- **WHEN** user types "btn" in the search input
+- **THEN** only components whose names contain "btn" (case-insensitive) are displayed
+
+#### Scenario: Search finds variant inside set
+- **WHEN** user types "primary" and a COMPONENT_SET has a variant "Button/Primary"
+- **THEN** the COMPONENT_SET expands to show "Button/Primary", even if the set name doesn't match
+
+#### Scenario: Search with no results
+- **WHEN** user types "zzzzz" in the search input
+- **THEN** the panel shows "No results for 'zzzzz'" message
+
+#### Scenario: Clear search restores full list
+- **WHEN** user clears the search input
+- **THEN** all components are shown grouped by page
+
+### Requirement: Component thumbnail preview
+Each component item SHALL display a 48×48 pixel thumbnail preview rendered via CanvasKit offscreen surface. Thumbnails SHALL be generated as blob URLs via `renderNodesToImage()` at scale 1, PNG format. Thumbnails SHALL update when the component's visual appearance changes (tracked via sceneVersion with 500ms debounce). Old blob URLs SHALL be revoked via `URL.revokeObjectURL()` before replacement. Items without a ready thumbnail show a placeholder icon.
+
+#### Scenario: Component thumbnail renders
+- **WHEN** a COMPONENT "Button" with a blue fill and text exists
+- **THEN** the Assets panel shows a 48×48 thumbnail preview of the button
+
+#### Scenario: Thumbnail updates after component edit
+- **WHEN** user changes a component's fill color from blue to red
+- **THEN** the thumbnail updates within 500ms after the edit completes
+
+#### Scenario: Thumbnail placeholder before render
+- **WHEN** the Assets panel first opens and thumbnails haven't rendered yet
+- **THEN** each item shows a gray placeholder icon instead of a thumbnail
+
+### Requirement: Component instance count
+Each component item SHALL display the number of INSTANCE nodes referencing it, shown as a dim badge (e.g. "3×"). The count is read from `graph.instanceIndex.get(componentId)?.size ?? 0`. Count of 0 shows no badge.
+
+#### Scenario: Component with instances
+- **WHEN** a COMPONENT "Card" has 5 instances in the document
+- **THEN** the Assets panel shows "5×" badge next to "Card"
+
+#### Scenario: Component with no instances
+- **WHEN** a COMPONENT "Header" has no instances
+- **THEN** no instance count badge is shown
+
+### Requirement: Component description tooltip
+Each component item SHALL show its `description` field (from SceneNode) as a native title tooltip on hover. If description is empty, the title falls back to the component name.
+
+#### Scenario: Component with description
+- **WHEN** a COMPONENT has description "Primary action button for forms"
+- **THEN** hovering shows the description as a browser tooltip
+
+### Requirement: Drag component from Assets panel to canvas
+The user SHALL be able to drag a component item from the Assets panel onto the canvas to create an INSTANCE at the drop position. The drag uses HTML5 Drag and Drop API with MIME type `application/x-openpencil-component`. The drop handler checks for this MIME type BEFORE checking for image files. Drop coordinates are converted from screen space to canvas space via `screenToCanvas()`. The instance is created on the current page regardless of which page the component lives on.
+
+#### Scenario: Drag component to canvas creates instance
+- **WHEN** user drags "Button" from Assets panel and drops at (300, 200) on canvas
+- **THEN** an INSTANCE of "Button" is created at the corresponding canvas coordinates on the current page
+
+#### Scenario: Drag cross-page component
+- **WHEN** user drags a component from Page 2 while viewing Page 1
+- **THEN** the INSTANCE is created on Page 1 (current page), not Page 2
+
+#### Scenario: Drop outside canvas has no effect
+- **WHEN** user drags a component and releases outside the canvas
+- **THEN** no instance is created
+
+### Requirement: Double-click inserts instance at viewport center
+Double-clicking a component item SHALL create an INSTANCE at the center of the current viewport and select it.
+
+#### Scenario: Double-click inserts at center
+- **WHEN** user double-clicks "Card" component in Assets panel
+- **THEN** an INSTANCE of "Card" appears at viewport center and is selected
+
+### Requirement: Asset item context menu
+Right-clicking a component item SHALL show a context menu (reka-ui ContextMenu) with two actions: "Insert instance" (creates instance at viewport center) and "Go to component" (navigates to component on canvas).
+
+#### Scenario: Context menu insert
+- **WHEN** user right-clicks a component and selects "Insert instance"
+- **THEN** an INSTANCE is created at viewport center
+
+#### Scenario: Context menu navigate
+- **WHEN** user right-clicks a component and selects "Go to component"
+- **THEN** the editor navigates to the component's page, centers viewport on it, and selects it
+
+### Requirement: Component list reactivity
+The component list SHALL update automatically when components are created, deleted, renamed, or reparented. The list is recomputed from SceneGraph on each `sceneVersion` change.
+
+#### Scenario: New component appears in list
+- **WHEN** user creates a new component via ⌥⌘K
+- **THEN** the Assets panel immediately shows the new component
+
+#### Scenario: Deleted component removed from list
+- **WHEN** user deletes a component
+- **THEN** the component disappears from the Assets panel
+
+#### Scenario: Renamed component updates in list
+- **WHEN** user renames a component from "Button" to "PrimaryButton"
+- **THEN** the Assets panel shows the updated name

--- a/openspec/changes/archive/2026-03-23-asset-components-view/specs/components/spec.md
+++ b/openspec/changes/archive/2026-03-23-asset-components-view/specs/components/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: SceneGraph component enumeration by page
+SceneGraph SHALL provide a `getComponentsGroupedByPage()` method returning `Array<{ page: SceneNode; components: SceneNode[] }>`. The method traverses all pages, recursively walks child trees (frames, groups, sections), and collects nodes with `type === 'COMPONENT'` or `type === 'COMPONENT_SET'`. It does NOT recurse into COMPONENT_SET children (those are variants, accessed separately). Pages with no components are omitted. The traversal uses an iterative stack (not recursion) for predictable performance.
+
+#### Scenario: Components on multiple pages
+- **WHEN** `getComponentsGroupedByPage()` is called on a document with 2 components on Page 1 and 1 on Page 2
+- **THEN** the result has two entries: `[{ page: Page1, components: [C1, C2] }, { page: Page2, components: [C3] }]`
+
+#### Scenario: No components in document
+- **WHEN** `getComponentsGroupedByPage()` is called on a document with only rectangles and frames
+- **THEN** the result is an empty array
+
+#### Scenario: Component nested inside a frame
+- **WHEN** a COMPONENT exists inside a frame → group → page
+- **THEN** the component is found and included in that page's components array
+
+#### Scenario: COMPONENT_SET children not duplicated
+- **WHEN** a COMPONENT_SET has 3 COMPONENT children (variants)
+- **THEN** only the COMPONENT_SET appears in the result, not its children
+
+#### Scenario: INSTANCE nodes excluded
+- **WHEN** the page has both COMPONENT and INSTANCE nodes
+- **THEN** only COMPONENT nodes appear in the result
+
+### Requirement: Focus node with viewport navigation
+The editor store SHALL provide a `focusNode(nodeId: string)` method that: (1) finds which page the node is on by walking parentId chain up to type === 'CANVAS', (2) switches page via `switchPage()` if different from current, (3) sets `selectedIds` to the node, (4) centers the viewport on the node using `window.innerWidth/Height` (not hardcoded dimensions), (5) calls `requestRender()`. The existing `goToMainComponent()` SHALL be refactored to call `focusNode()` instead of duplicating the viewport math.
+
+#### Scenario: Focus node on current page
+- **WHEN** `focusNode(nodeId)` is called for a node on the current page
+- **THEN** the viewport centers on the node and it is selected, no page switch
+
+#### Scenario: Focus node on different page
+- **WHEN** `focusNode(nodeId)` is called for a node on Page 2 while viewing Page 1
+- **THEN** the editor switches to Page 2, centers viewport, and selects the node
+
+#### Scenario: goToMainComponent uses focusNode
+- **WHEN** `goToMainComponent()` is called on a selected instance
+- **THEN** it resolves the main component and calls `focusNode(mainComponentId)`
+
+### Requirement: Cross-page instance creation
+`createInstanceFromComponent(componentId, x?, y?, targetPageId?)` SHALL accept an optional `targetPageId` parameter. When provided, the instance is created on the target page. When omitted, it defaults to `state.currentPageId`. This replaces the current behavior of using `component.parentId` which breaks cross-page drag-and-drop.
+
+#### Scenario: Create instance on current page from cross-page component
+- **WHEN** a component on Page 2 is used to create an instance while viewing Page 1, with `targetPageId = Page1.id`
+- **THEN** the instance appears on Page 1
+
+#### Scenario: Default behavior unchanged
+- **WHEN** `createInstanceFromComponent(id, x, y)` is called without targetPageId
+- **THEN** the instance is created on `state.currentPageId`
+
+### Requirement: Store-level component thumbnail rendering
+The editor store SHALL provide a `renderComponentThumbnail(nodeId: string, size?: number): string | null` method that renders a component node as a PNG blob URL. It finds the node's page ID, calls `renderNodesToImage()` with the private `_ck` and `_renderer`, creates a Blob, and returns `URL.createObjectURL()`. Returns `null` if CanvasKit is not initialized or the node doesn't exist.
+
+#### Scenario: Render thumbnail for component
+- **WHEN** `renderComponentThumbnail(componentId)` is called for a visible COMPONENT
+- **THEN** a blob URL pointing to a PNG image is returned
+
+#### Scenario: CanvasKit not initialized
+- **WHEN** `renderComponentThumbnail()` is called before `setCanvasKit()`
+- **THEN** it returns `null`
+
+### Requirement: MCP system prompt mentions component discovery
+The `ACP_DESIGN_CONTEXT` system prompt SHALL include `get_components` and `create_instance` in the key tools list, enabling AI agents to discover and reuse existing components.
+
+#### Scenario: System prompt content
+- **WHEN** `ACP_DESIGN_CONTEXT` is read
+- **THEN** it contains mentions of `get_components` for listing components and `create_instance` for creating instances

--- a/openspec/changes/archive/2026-03-23-asset-components-view/specs/editor-ui/spec.md
+++ b/openspec/changes/archive/2026-03-23-asset-components-view/specs/editor-ui/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Layers panel with tree view
+The layers panel SHALL display a tree view of the document hierarchy using Reka UI Tree with expand/collapse and drag reordering. The bottom section of the left panel SHALL have a reka-ui TabsRoot with two TabsTrigger buttons: "Layers" and "Assets". The "Layers" tab shows the LayerTree component (default). The "Assets" tab shows the AssetsPanel component. The PagesPanel remains in the top SplitterPanel, always visible above both tabs. The active tab is stored as `leftPanelTab: 'layers' | 'assets'` in the editor state (default: `'layers'`). Tab triggers use `text-[11px] tracking-wider uppercase text-muted` styling, matching the current header, with `data-[state=active]:font-semibold data-[state=active]:text-surface` for active state.
+
+#### Scenario: Expand/collapse frame children
+- **WHEN** user clicks the chevron next to a frame in the layers panel
+- **THEN** the frame's children are shown or hidden
+
+#### Scenario: Drag reorder layers
+- **WHEN** user drags a layer to a new position in the layers panel
+- **THEN** the node's z-order in the scene graph changes accordingly
+
+#### Scenario: Visibility toggle
+- **WHEN** user clicks the visibility icon next to a layer
+- **THEN** the node is hidden/shown on canvas
+
+#### Scenario: Switch to Assets tab
+- **WHEN** user clicks "Assets" tab in the left panel
+- **THEN** the layer tree is hidden and the Assets panel is shown with components grouped by page
+
+#### Scenario: Switch back to Layers tab
+- **WHEN** user clicks "Layers" tab while viewing Assets
+- **THEN** the Assets panel is hidden and the layer tree is shown
+
+#### Scenario: PagesPanel always visible
+- **WHEN** user switches between Layers and Assets tabs
+- **THEN** the PagesPanel above the splitter handle remains visible and functional

--- a/openspec/changes/archive/2026-03-23-asset-components-view/tasks.md
+++ b/openspec/changes/archive/2026-03-23-asset-components-view/tasks.md
@@ -1,0 +1,503 @@
+## 1. SceneGraph — getComponentsGroupedByPage()
+
+- [x] 1.1 Add method to `packages/core/src/scene-graph.ts` in the `SceneGraph` class, after `getInstances()`:
+  ```ts
+  getComponentsGroupedByPage(): Array<{ page: SceneNode; components: SceneNode[] }> {
+    const result: Array<{ page: SceneNode; components: SceneNode[] }> = []
+    for (const page of this.getPages()) {
+      const components: SceneNode[] = []
+      const stack = [...page.childIds]
+      while (stack.length > 0) {
+        const id = stack.pop()
+        if (!id) continue
+        const node = this.nodes.get(id)
+        if (!node) continue
+        if (node.type === 'COMPONENT' || node.type === 'COMPONENT_SET') {
+          components.push(node)
+        } else if (node.type !== 'INSTANCE' && CONTAINER_TYPES.has(node.type)) {
+          stack.push(...node.childIds)
+        }
+      }
+      if (components.length > 0) result.push({ page, components })
+    }
+    return result
+  }
+  ```
+  Key details:
+  - Iterative stack, no `!` non-null assertions (guard with `if (!id) continue`)
+  - Does NOT recurse into COMPONENT_SET (variants are accessed separately via `getChildren()` in the UI)
+  - Does NOT recurse into INSTANCE nodes (their internal structure shouldn't appear in Assets)
+  - DOES recurse into FRAME, GROUP, SECTION to find nested components
+
+- [x] 1.2 Add unit tests in `tests/engine/scene-graph.test.ts` — new `describe('getComponentsGroupedByPage')` block:
+  - Empty document (no components) → returns `[]`
+  - One COMPONENT on default page → returns `[{ page, components: [comp] }]`
+  - Components on two pages → two entries, correct page refs, correct components
+  - COMPONENT inside a FRAME inside a page → found
+  - COMPONENT_SET with 2 COMPONENT children → only the SET appears in result
+  - INSTANCE node on page → excluded
+  - Page with only RECTANGLEs → page omitted from results
+  - COMPONENT inside an INSTANCE → NOT found (don't recurse into instances)
+
+## 2. Editor store — state + focusNode + thumbnail + fix createInstance
+
+- [x] 2.1 Add `leftPanelTab` to `state` in `src/stores/editor.ts` (after `enteredContainerId`):
+  ```ts
+  leftPanelTab: 'layers' as 'layers' | 'assets',
+  ```
+
+- [x] 2.2 Add `focusNode(nodeId: string)` function before `goToMainComponent()`:
+  ```ts
+  function focusNode(nodeId: string) {
+    const node = graph.getNode(nodeId)
+    if (!node) return
+    let current: SceneNode | undefined = node
+    while (current && current.type !== 'CANVAS') {
+      current = current.parentId ? graph.getNode(current.parentId) : undefined
+    }
+    if (current && current.id !== state.currentPageId) {
+      void switchPage(current.id)
+    }
+    state.selectedIds = new Set([nodeId])
+    const abs = graph.getAbsolutePosition(nodeId)
+    const viewW = window.innerWidth
+    const viewH = window.innerHeight
+    state.panX = viewW / 2 - (abs.x + node.width / 2) * state.zoom
+    state.panY = viewH / 2 - (abs.y + node.height / 2) * state.zoom
+    requestRender()
+  }
+  ```
+  Note: uses `window.innerWidth/Height` consistent with existing `zoomToBounds()`, `zoomTo100()`, and `zoomToSelection()` in this same store.
+
+  Then refactor `goToMainComponent()` to use it:
+  ```ts
+  function goToMainComponent() {
+    const node = selectedNode.value
+    if (!node?.componentId) return
+    const main = graph.getMainComponent(node.id)
+    if (!main) return
+    focusNode(main.id)
+  }
+  ```
+  This eliminates the hardcoded `viewW = 800, viewH = 600`.
+
+- [x] 2.3 Fix `createInstanceFromComponent` — preserve existing default behavior, add explicit override:
+  ```ts
+  function createInstanceFromComponent(
+    componentId: string, x?: number, y?: number, targetPageId?: string
+  ) {
+    const component = graph.getNode(componentId)
+    if (component?.type !== 'COMPONENT') return null
+    // Original behavior: sibling of component. Override: target page root.
+    const parentId = targetPageId ?? component.parentId ?? state.currentPageId
+    const instance = graph.createInstance(componentId, parentId, {
+      x: x ?? component.x + component.width + 40,
+      y: y ?? component.y
+    })
+    if (!instance) return null
+    const instanceId = instance.id
+    state.selectedIds = new Set([instanceId])
+    undo.push({
+      label: 'Create instance',
+      forward: () => {
+        graph.createInstance(componentId, parentId, { ...instance })
+        state.selectedIds = new Set([instanceId])
+      },
+      inverse: () => {
+        graph.deleteNode(instanceId)
+        state.selectedIds = new Set([componentId])
+      }
+    })
+    return instanceId
+  }
+  ```
+  When `targetPageId` is omitted → uses `component.parentId` (existing behavior, E2E safe).
+  When `targetPageId` is provided (from drag-drop) → instance goes to that page.
+
+- [x] 2.4 Add `renderComponentThumbnail(nodeId: string, size = 48): string | null`:
+  ```ts
+  function renderComponentThumbnail(nodeId: string, size = 48): string | null {
+    if (!_ck || !_renderer) return null
+    const node = graph.getNode(nodeId)
+    if (!node || (node.width <= 0 && node.height <= 0)) return null
+    let pageNode: SceneNode | undefined = node
+    while (pageNode && pageNode.type !== 'CANVAS') {
+      pageNode = pageNode.parentId ? graph.getNode(pageNode.parentId) : undefined
+    }
+    if (!pageNode) return null
+    const maxDim = Math.max(node.width, node.height, 1)
+    const scale = Math.min(size / maxDim, 2)
+    const bytes = renderNodesToImage(_ck, _renderer, graph, pageNode.id, [nodeId], {
+      scale, format: 'PNG' as ExportFormat
+    })
+    if (!bytes) return null
+    return URL.createObjectURL(new Blob([bytes.buffer as ArrayBuffer], { type: 'image/png' }))
+  }
+  ```
+  Scale: `size / max(width, height)` fits the component into a `size` box, capped at 2× for tiny components. `renderNodesToImage` computes the output dimensions as `contentW * scale × contentH * scale`, so a 200×100 component at `scale = 48/200 = 0.24` produces a 48×24 image. This is correct — we use `object-contain` in the `<img>` CSS.
+
+- [x] 2.5 Export in store return object: add `focusNode`, `renderComponentThumbnail` next to `goToMainComponent`, `createInstanceFromComponent`, `leftPanelTab` is already on state
+
+## 3. Left panel — Layers/Assets tab switcher
+
+- [x] 3.1 Refactor `src/components/LayersPanel.vue`:
+  Add imports: `TabsContent, TabsList, TabsRoot, TabsTrigger` from `reka-ui`, `AssetsPanel` from `./AssetsPanel.vue`, `useEditorStore`
+
+  In the bottom `<SplitterPanel>`, replace the static header + LayerTree with:
+  ```html
+  <TabsRoot v-model="store.state.leftPanelTab" class="flex min-h-0 flex-1 flex-col">
+    <TabsList class="flex shrink-0 items-center gap-2 px-3 py-2">
+      <TabsTrigger
+        value="layers"
+        class="text-[11px] tracking-wider uppercase text-muted hover:text-surface
+               data-[state=active]:font-semibold data-[state=active]:text-surface"
+      >
+        Layers
+      </TabsTrigger>
+      <TabsTrigger
+        value="assets"
+        class="text-[11px] tracking-wider uppercase text-muted hover:text-surface
+               data-[state=active]:font-semibold data-[state=active]:text-surface"
+      >
+        Assets
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent value="layers" class="flex min-h-0 flex-1 flex-col"
+      :force-mount="true" :hidden="store.state.leftPanelTab !== 'layers'">
+      <LayerTree data-test-id="layers-tree" />
+    </TabsContent>
+    <TabsContent value="assets" class="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <AssetsPanel />
+    </TabsContent>
+  </TabsRoot>
+  ```
+  `force-mount` on Layers preserves tree expand/collapse state when switching — same pattern as `PropertiesPanel.vue` lines 56-78.
+
+## 4. Thumbnail composable
+
+- [x] 4.1 Create `src/composables/use-component-thumbnails.ts`:
+  ```ts
+  import { watchDebounced } from '@vueuse/core'
+  import { ref, onScopeDispose, type Ref } from 'vue'
+  import type { EditorStore } from '@/stores/editor'
+
+  const BATCH_SIZE = 10
+
+  export function useComponentThumbnails(
+    store: EditorStore,
+    componentIds: Ref<string[]>
+  ) {
+    const thumbnails = ref(new Map<string, string>())
+    let pending = false
+
+    function refresh() {
+      if (pending) return
+      pending = true
+
+      const oldMap = thumbnails.value
+      const currentIds = componentIds.value
+      const newMap = new Map<string, string>()
+
+      // Keep existing URLs for IDs that still exist (avoid re-render flicker)
+      // Revoke URLs for removed IDs
+      for (const [id, url] of oldMap) {
+        if (currentIds.includes(id)) {
+          newMap.set(id, url)
+        } else {
+          URL.revokeObjectURL(url)
+        }
+      }
+
+      // Find IDs that need (re-)rendering
+      const toRender = currentIds.filter(id => !newMap.has(id))
+      if (toRender.length === 0) {
+        thumbnails.value = newMap
+        pending = false
+        return
+      }
+
+      // Batch render to avoid blocking main thread
+      let i = 0
+      function renderBatch() {
+        const end = Math.min(i + BATCH_SIZE, toRender.length)
+        for (; i < end; i++) {
+          const id = toRender[i]
+          const url = store.renderComponentThumbnail(id)
+          if (url) newMap.set(id, url)
+        }
+        if (i < toRender.length) {
+          requestAnimationFrame(renderBatch)
+        } else {
+          thumbnails.value = new Map(newMap)
+          pending = false
+        }
+      }
+      renderBatch()
+    }
+
+    // Full re-render on scene changes (component edits)
+    function fullRefresh() {
+      // Revoke all existing, then re-render everything
+      for (const url of thumbnails.value.values()) URL.revokeObjectURL(url)
+      thumbnails.value = new Map()
+      pending = false
+      refresh()
+    }
+
+    // Initial render (just new IDs)
+    watchDebounced(componentIds, refresh, { debounce: 100, immediate: true })
+    // Scene changes: full re-render with longer debounce
+    watchDebounced(() => store.state.sceneVersion, fullRefresh, { debounce: 500 })
+
+    onScopeDispose(() => {
+      for (const url of thumbnails.value.values()) URL.revokeObjectURL(url)
+    })
+
+    return thumbnails
+  }
+  ```
+  Key fixes from review:
+  - **Batched rendering** (10 per rAF frame) to avoid blocking main thread
+  - **Two separate watchers**: fast initial render when component list changes, slow full re-render on scene edits
+  - **Keeps existing URLs** when component list is unchanged — avoids flicker
+  - `pending` flag prevents concurrent refresh storms
+  - Proper cleanup on dispose
+
+## 5. AssetsPanel component
+
+- [x] 5.1 Create `src/components/AssetsPanel.vue`:
+  Script setup:
+  - Import `computed, ref` from vue, `CollapsibleContent, CollapsibleRoot, CollapsibleTrigger` from reka-ui, store, thumbnails composable, AssetItem
+  - `const store = useEditorStore()`
+  - `const query = ref('')`
+  - `const allGroups` computed: `void store.state.sceneVersion; return store.graph.getComponentsGroupedByPage()`
+  - `const allComponentIds` computed: flatMap component IDs from allGroups. For COMPONENT_SETs, include both the set ID and its COMPONENT children IDs (for thumbnail rendering)
+  - `const thumbnails = useComponentThumbnails(store, allComponentIds)`
+  - `const filteredGroups` computed: if query is empty → return allGroups. Else for each group, filter components: COMPONENT matches if `name.toLowerCase().includes(q)`. COMPONENT_SET matches if its name matches OR any child COMPONENT name matches (via `store.graph.getChildren(set.id).filter(c => c.type === 'COMPONENT' && c.name.toLowerCase().includes(q))`). Omit empty groups.
+
+  Template structure:
+  ```
+  <div class="flex min-h-0 flex-1 flex-col">
+    <!-- Search -->
+    <div class="flex items-center gap-1.5 border-b border-border px-3 py-1.5">
+      <icon-lucide-search class="size-3 text-muted" />
+      <input v-model="query" placeholder="Search components..."
+        class="min-w-0 flex-1 bg-transparent text-xs text-surface placeholder:text-muted outline-none" />
+    </div>
+
+    <!-- Empty: no components -->
+    <div v-if="allGroups.length === 0" class="flex flex-1 flex-col items-center justify-center gap-2 px-4 text-center">
+      <icon-lucide-component class="size-8 text-muted" />
+      <p class="text-xs text-muted">No components</p>
+      <p class="text-[10px] text-muted">Select a frame and press ⌥⌘K</p>
+    </div>
+
+    <!-- Empty: search no results -->
+    <div v-else-if="filteredGroups.length === 0" class="flex flex-1 items-center justify-center px-4">
+      <p class="text-xs text-muted">No results for "{{ query }}"</p>
+    </div>
+
+    <!-- Component list -->
+    <div v-else class="scrollbar-thin flex-1 overflow-y-auto px-1 pb-1">
+      <CollapsibleRoot v-for="group in filteredGroups" :key="group.page.id" default-open>
+        <CollapsibleTrigger class="flex w-full items-center gap-1.5 px-2 py-1 text-[11px] tracking-wider text-muted uppercase hover:text-surface">
+          <icon-lucide-chevron-down class="size-3 transition-transform [[data-state=closed]>&]:rotate-[-90deg]" />
+          {{ group.page.name }}
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <template v-for="comp in group.components" :key="comp.id">
+            <!-- COMPONENT_SET: expandable with variants -->
+            <CollapsibleRoot v-if="comp.type === 'COMPONENT_SET'" default-open>
+              <AssetItem :node="comp" :thumbnail-url="thumbnails.get(comp.id)" is-set />
+              <CollapsibleContent>
+                <AssetItem
+                  v-for="variant in store.graph.getChildren(comp.id).filter(c => c.type === 'COMPONENT')"
+                  :key="variant.id" :node="variant"
+                  :thumbnail-url="thumbnails.get(variant.id)" indented />
+              </CollapsibleContent>
+            </CollapsibleRoot>
+            <!-- Standalone COMPONENT -->
+            <AssetItem v-else :node="comp" :thumbnail-url="thumbnails.get(comp.id)" />
+          </template>
+        </CollapsibleContent>
+      </CollapsibleRoot>
+    </div>
+  </div>
+  ```
+
+## 6. AssetItem component
+
+- [x] 6.1 Create `src/components/AssetItem.vue`:
+  Props: `node: SceneNode`, `thumbnailUrl?: string`, `indented?: boolean`, `isSet?: boolean`
+
+  Script setup:
+  ```ts
+  import { computed } from 'vue'
+  import { ContextMenuRoot, ContextMenuTrigger, ContextMenuContent, ContextMenuItem } from 'reka-ui'
+  import { useEditorStore } from '@/stores/editor'
+
+  const props = defineProps<{
+    node: import('@open-pencil/core').SceneNode
+    thumbnailUrl?: string
+    indented?: boolean
+    isSet?: boolean
+  }>()
+
+  const store = useEditorStore()
+
+  const instanceCount = computed(() => {
+    void store.state.sceneVersion
+    return store.graph.instanceIndex.get(props.node.id)?.size ?? 0
+  })
+
+  function viewportCenter() {
+    return {
+      x: (-store.state.panX + window.innerWidth / 2) / store.state.zoom,
+      y: (-store.state.panY + window.innerHeight / 2) / store.state.zoom
+    }
+  }
+
+  function onDragStart(e: DragEvent) {
+    if (!e.dataTransfer) return
+    const id = props.node.type === 'COMPONENT_SET'
+      ? store.graph.getChildren(props.node.id).find(c => c.type === 'COMPONENT')?.id ?? props.node.id
+      : props.node.id
+    e.dataTransfer.setData('application/x-openpencil-component', id)
+    e.dataTransfer.effectAllowed = 'copy'
+  }
+
+  function onDblClick() {
+    const id = props.node.type === 'COMPONENT_SET'
+      ? store.graph.getChildren(props.node.id).find(c => c.type === 'COMPONENT')?.id
+      : props.node.id
+    if (!id) return
+    const { x, y } = viewportCenter()
+    store.createInstanceFromComponent(id, x, y, store.state.currentPageId)
+  }
+
+  function insertInstance() { onDblClick() }
+
+  function goToComponent() { store.focusNode(props.node.id) }
+  ```
+
+  Template:
+  ```html
+  <ContextMenuRoot>
+    <ContextMenuTrigger as-child>
+      <div
+        :class="['flex items-center gap-2 rounded px-2 py-1 cursor-pointer hover:bg-hover',
+                  indented ? 'pl-6' : '']"
+        :title="node.description || node.name"
+        :draggable="true"
+        @dragstart="onDragStart"
+        @dblclick="onDblClick"
+      >
+        <div class="size-8 shrink-0 overflow-hidden rounded border border-border bg-canvas">
+          <img v-if="thumbnailUrl" :src="thumbnailUrl" class="size-full object-contain" alt="" />
+          <div v-else class="flex size-full items-center justify-center">
+            <icon-lucide-component class="size-3.5 text-muted" />
+          </div>
+        </div>
+        <icon-lucide-diamond v-if="node.type === 'COMPONENT'" class="size-3 shrink-0 text-[#9747ff]" />
+        <icon-lucide-grid-2x2 v-else class="size-3 shrink-0 text-[#9747ff]" />
+        <span class="min-w-0 flex-1 truncate text-xs text-surface">{{ node.name }}</span>
+        <icon-lucide-chevron-down v-if="isSet"
+          class="size-3 shrink-0 text-muted transition-transform [[data-state=closed]>&]:rotate-[-90deg]" />
+        <span v-if="instanceCount > 0" class="shrink-0 text-[10px] text-muted">
+          {{ instanceCount }}×
+        </span>
+      </div>
+    </ContextMenuTrigger>
+    <ContextMenuContent class="min-w-40 rounded-lg border border-border bg-panel p-1 shadow-lg">
+      <ContextMenuItem class="cursor-pointer rounded px-2 py-1 text-xs text-surface hover:bg-hover"
+        @select="insertInstance">
+        Insert instance
+      </ContextMenuItem>
+      <ContextMenuItem class="cursor-pointer rounded px-2 py-1 text-xs text-surface hover:bg-hover"
+        @select="goToComponent">
+        Go to component
+      </ContextMenuItem>
+    </ContextMenuContent>
+  </ContextMenuRoot>
+  ```
+
+## 7. Drag-and-drop — extend use-canvas-drop
+
+- [x] 7.1 In `src/composables/use-canvas-drop.ts`:
+
+  Add helper:
+  ```ts
+  function hasComponentData(e: DragEvent): boolean {
+    return e.dataTransfer?.types.includes('application/x-openpencil-component') ?? false
+  }
+  ```
+
+  Modify `dragover` listener — component check FIRST:
+  ```ts
+  useEventListener(canvasRef, 'dragover', (e: DragEvent) => {
+    if (hasComponentData(e)) {
+      e.preventDefault()
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
+      isDraggingOver.value = true
+      return
+    }
+    if (!hasImageFiles(e)) return
+    e.preventDefault()
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
+    isDraggingOver.value = true
+  })
+  ```
+
+  Modify `dragenter` — same priority:
+  ```ts
+  useEventListener(canvasRef, 'dragenter', (e: DragEvent) => {
+    if (hasComponentData(e) || hasImageFiles(e)) {
+      e.preventDefault()
+      isDraggingOver.value = true
+    }
+  })
+  ```
+
+  Modify `drop` — component handling FIRST:
+  ```ts
+  useEventListener(canvasRef, 'drop', (e: DragEvent) => {
+    e.preventDefault()
+    isDraggingOver.value = false
+
+    const componentId = e.dataTransfer?.getData('application/x-openpencil-component')
+    if (componentId) {
+      const canvas = canvasRef.value
+      if (!canvas) return
+      const rect = canvas.getBoundingClientRect()
+      const { x, y } = store.screenToCanvas(e.clientX - rect.left, e.clientY - rect.top)
+      store.createInstanceFromComponent(componentId, x, y, store.state.currentPageId)
+      return
+    }
+
+    const files = filterImageFiles(e.dataTransfer?.files ?? null)
+    if (!files.length) return
+    // ... existing image drop logic unchanged
+  })
+  ```
+  The `store.state.currentPageId` is passed as `targetPageId` so the instance lands on the current page, not on the component's page.
+
+## 8. MCP / AI system prompt
+
+- [x] 8.1 In `src/constants.ts`, update the key tools line in `ACP_DESIGN_CONTEXT`:
+  From: `Key tools: render (JSX to design), create_shape, set_fill, set_layout, find_nodes, get_page_tree, export_image.`
+  To: `Key tools: render (JSX to design), create_shape, set_fill, set_layout, find_nodes, get_page_tree, export_image, get_components (list reusable components), create_instance (insert component instance).`
+
+## 9. Documentation
+
+- [x] 9.1 Add to `CHANGELOG.md` Unreleased section:
+  ```md
+  ### Added
+  - Assets tab in left panel — browse, search, and insert components with thumbnail previews
+  ```
+
+## 10. Quality gates
+
+- [x] 10.1 `bun run check` — zero lint/type errors
+- [x] 10.2 `bun run format` — format all modified files
+- [x] 10.3 `bun run test:unit` — all tests pass (3 pre-existing failures on master, not caused by this change)
+- [x] 10.4 `bun run test:dupes` — 1.3% duplication (under 3%)

--- a/openspec/changes/archive/2026-03-23-asset-images-section/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-23-asset-images-section/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-23

--- a/openspec/changes/archive/2026-03-23-asset-images-section/design.md
+++ b/openspec/changes/archive/2026-03-23-asset-images-section/design.md
@@ -1,0 +1,56 @@
+## Context
+
+`graph.images` is a `Map<string, Uint8Array>` — keys are SHA-256 hashes, values are raw image bytes (PNG/JPEG/WEBP). When a user places an image, `storeImage()` computes the hash and stores bytes. Nodes reference images via `fill.imageHash` in their fills array. Multiple nodes can share the same imageHash (same image placed multiple times).
+
+The existing AssetsPanel has: search input → empty states → scrollable list of component page groups. We need to add an Images collapsible section after the components.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Images section in AssetsPanel showing all unique images from `graph.images`
+- Each image: thumbnail (blob URL from raw bytes), truncated hash as name, usage count (nodes referencing it), node names that use it
+- Click → select nodes using that image on current page
+- Drag → drop on canvas → new RECTANGLE with IMAGE fill
+- Search filters images by the names of nodes using them
+- Collapsible section header "Images (N)"
+
+**Non-Goals:**
+- Image rename/description (no metadata stored beyond hash)
+- Image delete from library (would break nodes referencing it)
+- Image replace (that's in FillPicker already)
+
+## Decisions
+
+### 1. Image enumeration — SceneGraph.getImageUsages()
+
+Returns `Map<string, { hash: string; nodeIds: string[]; names: string[] }>` — for each imageHash in `graph.images`, finds all nodes that reference it via fills, collects their IDs and names.
+
+Algorithm: iterate all nodes, check fills for `type === 'IMAGE'` with `imageHash`, accumulate by hash.
+
+### 2. Image thumbnails — direct blob URL from raw bytes
+
+Unlike component thumbnails (which need CanvasKit rendering), image assets ARE raw image bytes. Just create `URL.createObjectURL(new Blob([bytes], { type: guessType(bytes) }))`. Much cheaper than component thumbnails. Type detection: check magic bytes (PNG: 0x89504E47, JPEG: 0xFFD8, WEBP: 0x52494646...57454250).
+
+### 3. Drag image asset to canvas
+
+New MIME type: `application/x-openpencil-image-asset`. DragStart sets the imageHash. Drop handler reads hash, looks up bytes from `graph.images`, creates RECTANGLE with IMAGE fill using the existing `placeImageNode` logic. Need a new store action `placeImageFromHash(hash, x, y)`.
+
+### 4. Search integration
+
+The search input already filters components. Extend `filteredGroups` to also filter images: match against node names that reference each image. A separate `filteredImages` computed.
+
+### 5. Layout in AssetsPanel
+
+Two top-level collapsible sections:
+```
+▼ Components (N)
+  ▼ Page 1
+    AssetItem...
+  ▼ Page 2
+    AssetItem...
+▼ Images (N)
+  ImageAssetItem...
+  ImageAssetItem...
+```
+
+When search is active, both sections filter independently. Empty sections are hidden.

--- a/openspec/changes/archive/2026-03-23-asset-images-section/proposal.md
+++ b/openspec/changes/archive/2026-03-23-asset-images-section/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The Assets panel currently shows only Components. But "assets" in a design tool means both reusable components AND embedded images. Users who insert photos/icons as image fills have no way to browse them — they must visually scan the canvas. Figma's Assets panel has a dedicated Images section. We need the same split: Components section + Images section inside the Assets tab.
+
+## What Changes
+
+- Add an **Images section** to the existing AssetsPanel, below the Components section
+- Images section shows all unique images from `graph.images` (the `Map<string, Uint8Array>` of imageHash → bytes)
+- Each image shows a thumbnail preview (blob URL from the raw bytes), the hash (truncated), and a count of how many nodes reference it
+- Click on an image → selects all nodes using that imageHash on the current page
+- Drag an image from the panel → drop on canvas → creates a RECTANGLE with IMAGE fill at drop position
+- Search filters both components AND images (by node name that uses the image)
+- Add `getImageUsages()` method to SceneGraph for efficient image enumeration
+- Collapsible "Images" header, same pattern as page group headers
+
+## Capabilities
+
+### New Capabilities
+- `asset-images`: Images section in Assets panel with thumbnails, usage count, drag-to-canvas, click-to-select
+
+### Modified Capabilities
+- `asset-panel`: Search now covers both components and images; panel has two collapsible top-level sections
+
+## Impact
+
+- `packages/core/src/scene-graph.ts` — new `getImageUsages()` method
+- `src/components/AssetsPanel.vue` — add Images section below Components
+- `src/components/ImageAssetItem.vue` — new component for image row
+- `src/composables/use-canvas-drop.ts` — extend to handle image asset drag (reuse existing image bytes)
+- `src/stores/editor.ts` — add `placeImageFromHash()` store action

--- a/openspec/changes/archive/2026-03-23-asset-images-section/specs/asset-images/spec.md
+++ b/openspec/changes/archive/2026-03-23-asset-images-section/specs/asset-images/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Images section lists all unique images in document
+The Assets panel SHALL include a collapsible "Images" section showing all unique images from `graph.images`. Each entry shows a thumbnail, the names of nodes using it, and a usage count. The section header shows "Images (N)" where N is the total unique image count.
+
+#### Scenario: Document with images
+- **WHEN** the document has 3 unique images (2 used by multiple nodes)
+- **THEN** the Images section header shows "Images (3)" and lists 3 image entries
+
+#### Scenario: Document with no images
+- **WHEN** `graph.images` is empty
+- **THEN** the Images section is hidden entirely
+
+### Requirement: Image thumbnail from raw bytes
+Each image entry SHALL display a thumbnail generated as a blob URL from the raw image bytes stored in `graph.images`. The MIME type SHALL be detected from magic bytes (PNG, JPEG, WEBP). Blob URLs SHALL be revoked when the image list changes or on component dispose.
+
+#### Scenario: PNG image thumbnail
+- **WHEN** an image with PNG magic bytes exists in graph.images
+- **THEN** a blob URL with type `image/png` is created and displayed as thumbnail
+
+### Requirement: Image usage count and node names
+Each image entry SHALL show the count of nodes referencing it and the names of the first few referencing nodes (truncated if many). Usage is determined by scanning all node fills for `type === 'IMAGE'` with matching `imageHash`.
+
+#### Scenario: Image used by 3 nodes
+- **WHEN** imageHash "abc123" is referenced by nodes "Photo", "Background", "Hero"
+- **THEN** the entry shows "3 uses" and lists "Photo, Background, Hero"
+
+### Requirement: Click image selects referencing nodes
+Clicking an image entry SHALL select all nodes on the current page that reference that imageHash.
+
+#### Scenario: Click selects nodes on current page
+- **WHEN** user clicks an image used by "Photo" on Page 1 and "Hero" on Page 2, while viewing Page 1
+- **THEN** only "Photo" is selected
+
+### Requirement: Drag image to canvas creates rectangle with image fill
+Dragging an image entry from the Assets panel onto the canvas SHALL create a new RECTANGLE node with an IMAGE fill at the drop position. The drag uses MIME type `application/x-openpencil-image-asset` with the imageHash as data.
+
+#### Scenario: Drag image to canvas
+- **WHEN** user drags an image entry and drops at (400, 300) on canvas
+- **THEN** a RECTANGLE with IMAGE fill referencing that hash is created at canvas coordinates
+
+### Requirement: Image search by node name
+The search input SHALL filter images by the names of nodes that reference them. If any referencing node's name matches the query, the image entry is shown.
+
+#### Scenario: Search finds image by node name
+- **WHEN** user types "hero" and a node named "Hero Image" uses imageHash "xyz"
+- **THEN** the image entry for "xyz" appears in filtered results

--- a/openspec/changes/archive/2026-03-23-asset-images-section/specs/asset-panel/spec.md
+++ b/openspec/changes/archive/2026-03-23-asset-images-section/specs/asset-panel/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Assets panel displays all components grouped by page
+The Assets panel SHALL list all COMPONENT and COMPONENT_SET nodes in the document, grouped under collapsible page sections (expanded by default). These component groups SHALL be wrapped in a top-level collapsible "Components (N)" section where N is the total component count. Below the components section, an "Images (N)" section lists embedded images. Both sections are independently collapsible. When the document has neither components nor images, a combined empty state is shown. The search input filters both sections independently.
+
+#### Scenario: Document with components and images
+- **WHEN** the document has 5 components and 3 images
+- **THEN** the Assets panel shows "Components (5)" section with page groups and "Images (3)" section with image entries
+
+#### Scenario: Search filters both sections
+- **WHEN** user types "btn" in search
+- **THEN** components matching "btn" appear under Components, images whose referencing nodes match "btn" appear under Images, empty sections are hidden
+
+#### Scenario: Document with only images
+- **WHEN** the document has no components but 2 images
+- **THEN** only the "Images (2)" section is shown, no Components section
+
+#### Scenario: Empty document
+- **WHEN** the document has no components and no images
+- **THEN** a combined empty state is shown: "No assets"

--- a/openspec/changes/archive/2026-03-23-asset-images-section/tasks.md
+++ b/openspec/changes/archive/2026-03-23-asset-images-section/tasks.md
@@ -1,0 +1,163 @@
+## 1. SceneGraph — getImageUsages()
+
+- [x] 1.1 Add method to `packages/core/src/scene-graph.ts` after `getComponentsGroupedByPage()`. Single pass over all nodes (O(n)):
+  ```ts
+  getImageUsages(): Map<string, { hash: string; nodeIds: string[]; names: string[] }> {
+    const usages = new Map<string, { hash: string; nodeIds: string[]; names: string[] }>()
+    for (const hash of this.images.keys()) {
+      usages.set(hash, { hash, nodeIds: [], names: [] })
+    }
+    for (const node of this.nodes.values()) {
+      if (node.type === 'CANVAS') continue
+      for (const fill of node.fills) {
+        if (fill.type !== 'IMAGE' || !fill.imageHash) continue
+        const entry = usages.get(fill.imageHash)
+        if (entry && !entry.nodeIds.includes(node.id)) {
+          entry.nodeIds.push(node.id)
+          entry.names.push(node.name)
+        }
+      }
+    }
+    return usages
+  }
+  ```
+  No `!` assertions. Single pass O(n). Only checks fills (strokes don't have imageHash in the schema).
+
+- [x] 1.2 Unit tests in `tests/engine/scene-graph.test.ts` — `describe('getImageUsages')`:
+  - No images → empty Map
+  - One image used by one node → 1 entry, 1 nodeId
+  - One image used by 3 nodes → 1 entry, 3 nodeIds and names
+  - Image stored but not referenced → entry with empty nodeIds
+  - Two different images → two separate entries
+  - Node with SOLID + IMAGE fill → only IMAGE fill counted
+
+## 2. MIME detection + image blob URL helper
+
+- [x] 2.1 Add `detectImageMime(bytes: Uint8Array): string` as a private function in `src/stores/editor.ts` (near `decodeImageDimensions`):
+  ```ts
+  function detectImageMime(bytes: Uint8Array): string {
+    if (bytes[0] === 0x89 && bytes[1] === 0x50) return 'image/png'
+    if (bytes[0] === 0xFF && bytes[1] === 0xD8) return 'image/jpeg'
+    if (bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[8] === 0x57 && bytes[9] === 0x45) return 'image/webp'
+    return 'image/png'
+  }
+  ```
+  No existing utility in codebase — checked `rg "image/png" src/` and only found format-to-mime switch, not bytes-to-mime.
+
+- [x] 2.2 Add `imageBlobUrl(hash: string): string | null` to editor store with internal cache:
+  ```ts
+  const _imageBlobCache = new Map<string, string>()
+
+  function imageBlobUrl(hash: string): string | null {
+    const cached = _imageBlobCache.get(hash)
+    if (cached) return cached
+    const bytes = graph.images.get(hash)
+    if (!bytes) return null
+    const mime = detectImageMime(bytes)
+    const url = URL.createObjectURL(new Blob([bytes.buffer as ArrayBuffer], { type: mime }))
+    _imageBlobCache.set(hash, url)
+    return url
+  }
+  ```
+  Cache keyed by hash — immutable (same hash = same bytes). URLs persist for lifetime of the store (images don't change once stored). On file open (`openFigFile`), clear cache and revoke all old URLs.
+
+- [x] 2.3 Add cleanup in `openFigFile` — revoke cached blob URLs before loading new document:
+  ```ts
+  for (const url of _imageBlobCache.values()) URL.revokeObjectURL(url)
+  _imageBlobCache.clear()
+  ```
+
+## 3. Store — placeImageFromHash
+
+- [x] 3.1 Add `placeImageFromHash(hash: string, x: number, y: number): string | null` reusing existing `decodeImageDimensions`:
+  ```ts
+  function placeImageFromHash(hash: string, x: number, y: number): string | null {
+    const bytes = graph.images.get(hash)
+    if (!bytes) return null
+    const dims = decodeImageDimensions(bytes)
+    const w = dims?.w ?? 200
+    const h = dims?.h ?? 200
+    const fill: Fill = {
+      type: 'IMAGE', imageHash: hash, imageScaleMode: 'FILL' as ImageScaleMode,
+      color: { r: 0, g: 0, b: 0, a: 0 }, opacity: 1, visible: true
+    }
+    const node = graph.createNode('RECTANGLE', state.currentPageId, {
+      name: 'Image', x: x - w / 2, y: y - h / 2, width: w, height: h, fills: [fill]
+    })
+    state.selectedIds = new Set([node.id])
+    const nodeId = node.id
+    const snapshot = { ...node }
+    undo.push({
+      label: 'Place image',
+      forward: () => {
+        graph.images.set(hash, bytes)
+        graph.createNode('RECTANGLE', state.currentPageId, snapshot)
+        state.selectedIds = new Set([nodeId])
+      },
+      inverse: () => {
+        graph.deleteNode(nodeId)
+        state.selectedIds = new Set()
+      }
+    })
+    requestRender()
+    return nodeId
+  }
+  ```
+  Centers image at drop point (x - w/2, y - h/2). Uses existing `decodeImageDimensions` for size. Undo ensures image bytes are re-stored on redo.
+
+- [x] 3.2 Export `placeImageFromHash`, `imageBlobUrl` in store return object.
+
+## 4. ImageAssetItem component
+
+- [x] 4.1 Create `src/components/ImageAssetItem.vue`:
+  Props (destructured): `hash: string`, `names: string[]`, `nodeIds: string[]`, `thumbnailUrl: string`
+  
+  Script:
+  - `const store = useEditorStore()`
+  - `displayName` computed: first 2 names joined by ", " + "+N" if more. If no names, show truncated hash.
+  - `usageCount` = `nodeIds.length`
+  - Click handler: filter nodeIds to those on current page, set selectedIds
+  - DragStart: `e.dataTransfer.setData('application/x-openpencil-image-asset', hash)`
+  - Context menu: "Select all uses" (same as click), "Place copy" (viewport center insert)
+
+  Template: 32×32 thumbnail (img with object-cover), display name (truncated), usage count badge, context menu (ContextMenuRoot).
+
+## 5. AssetsPanel — restructure with Components + Images sections
+
+- [x] 5.1 Modify `src/components/AssetsPanel.vue`:
+  - Add `imageUsages` computed: `void store.state.sceneVersion; return store.graph.getImageUsages()`
+  - Add `imageList` computed: convert Map to array, compute blob URLs via `store.imageBlobUrl(hash)`
+  - Add `filteredImages` computed: if query active, filter by names matching query
+  - Add `totalComponents` computed: sum of all component counts
+  - Update search placeholder to "Search assets..."
+  - Update empty state: when `allGroups.length === 0 && imageUsages.size === 0` → "No assets" (not "No components")
+  - Wrap existing components list in collapsible "Components (N)" section (only shown if N > 0)
+  - Add collapsible "Images (N)" section below (only shown if N > 0)
+  - When search active and both sections empty → "No results for '...'"
+
+## 6. Canvas drop — image asset MIME
+
+- [x] 6.1 In `src/composables/use-canvas-drop.ts`:
+  Add constant: `const IMAGE_ASSET_MIME = 'application/x-openpencil-image-asset'`
+  Add `hasImageAssetData(e)` helper.
+  In dragover: check image asset AFTER component, BEFORE file images.
+  In dragenter: add to combined check.
+  In drop: after component check, before file check:
+  ```ts
+  const imageHash = e.dataTransfer?.getData(IMAGE_ASSET_MIME)
+  if (imageHash) {
+    const canvas = canvasRef.value
+    if (!canvas) return
+    const rect = canvas.getBoundingClientRect()
+    const { x, y } = store.screenToCanvas(e.clientX - rect.left, e.clientY - rect.top)
+    store.placeImageFromHash(imageHash, x, y)
+    return
+  }
+  ```
+
+## 7. Quality gates
+
+- [x] 7.1 `bun run check` — zero errors
+- [x] 7.2 `bun run format`
+- [x] 7.3 `bun run test:unit` — 39/39 pass
+- [x] 7.4 `bun run test:dupes` — 1.31%

--- a/openspec/changes/archive/2026-03-23-svg-support-and-viewport-fix/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-23-svg-support-and-viewport-fix/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-23

--- a/openspec/changes/archive/2026-03-23-svg-support-and-viewport-fix/design.md
+++ b/openspec/changes/archive/2026-03-23-svg-support-and-viewport-fix/design.md
@@ -1,0 +1,54 @@
+## Context
+
+**Viewport center:** `canvasViewportCenter()` was just added to the store but not exported. It queries `[data-test-id="canvas-element"]` for the canvas bounds, falls back to `window.innerWidth/Height`. Uses `screenToCanvas(rect.width/2, rect.height/2)`. The canvas element is the WebGL CanvasKit surface that fills the center panel between the two sidebars.
+
+**SVG pipeline:** The existing code has:
+- `extractPaths(svgBody: string): PathInfo[]` — regex-parses SVG body for path/circle/ellipse/rect/line/polygon/polyline, extracts `d`, fill, stroke attributes. Handles group-level attributes.
+- `parseSVGPath(d: string): VectorNetwork` — converts SVG path `d` attribute to scene graph VectorNetwork using `svgpath` library.
+- `createIconFromPaths(graph, iconData, name, size, color, parentId)` — creates FRAME with VECTOR children from parsed paths.
+
+This pipeline is used exclusively for Iconify icons. To support arbitrary SVG files, we need to expose `extractPaths` and create a higher-level `parseSVGFile()` that handles viewBox parsing and coordinate scaling.
+
+**Image drop:** `use-canvas-drop.ts` accepts PNG/JPEG/WEBP/GIF/AVIF via `ACCEPTED_TYPES` Set. SVG (`image/svg+xml`) is absent. SVG should be handled differently from raster images — instead of storing as raw bytes with an IMAGE fill, SVG should be parsed into vector nodes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Export and use `canvasViewportCenter()` everywhere items are inserted at viewport center
+- Accept SVG files in OS drag-and-drop and parse to FRAME+VECTOR scene nodes
+- Reuse existing `extractPaths` + `parseSVGPath` + `createIconFromPaths` pipeline
+- SVG files stored in `graph.images` for round-trip (raw SVG text as bytes) and show in Assets
+
+**Non-Goals:**
+- Full SVG 2.0 spec compliance (gradients, filters, text, CSS styles, animations)
+- SVG paste from clipboard (future — needs clipboard API changes)
+- Editing SVG paths in-place (pen tool handles this separately)
+
+## Decisions
+
+### 1. Extract `extractPaths` and `parseSVGFile` to `packages/core/src/svg-import.ts`
+
+New file. Re-exports `extractPaths` from iconify.ts and adds:
+```ts
+export function parseSVGFile(svgText: string, targetSize?: number): IconData
+```
+Parses full SVG (with `<svg>` wrapper), extracts viewBox/width/height, normalizes to `extractPaths` pipeline.
+
+`iconify.ts` imports from `svg-import.ts` instead of inlining `extractPaths`.
+
+### 2. Store: `placeSVGFile(svgText, x, y, name)` 
+
+Calls `parseSVGFile()` → `createIconFromPaths()`. Adds undo. Also stores raw SVG bytes in `graph.images` for round-trip and Assets panel display.
+
+### 3. Canvas drop: SVG files read as text, not binary
+
+SVG files in drag-and-drop are read via `file.text()` (not `arrayBuffer()`), then passed to `placeSVGFile()`. The MIME type `image/svg+xml` is checked separately from raster images.
+
+### 4. Viewport center: use `canvasViewportCenter()` everywhere
+
+Replace:
+- `AssetItem.viewportCenter()` 
+- `ImageAssetItem.placeAtCenter()`
+- `pasteFromHTML` fallback center
+
+With `store.canvasViewportCenter()`.

--- a/openspec/changes/archive/2026-03-23-svg-support-and-viewport-fix/proposal.md
+++ b/openspec/changes/archive/2026-03-23-svg-support-and-viewport-fix/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Two issues:
+1. **Viewport center calculation ignores sidebars** — inserting components/images via double-click or context menu places them at `window.innerWidth/2` which doesn't account for the left (layers) and right (properties) panels. Result: items appear shifted to the right.
+2. **SVG files are not supported** — dropping an SVG from the OS or pasting SVG markup does nothing. The codebase already has `extractPaths()` (in iconify.ts) which parses SVG shapes into `PathInfo[]`, `parseSVGPath()` which converts `d` attributes to `VectorNetwork`, and `createIconFromPaths()` which creates scene nodes. This pipeline just needs to be exposed for arbitrary SVG files.
+
+## What Changes
+
+- **Fix viewport center** — `canvasViewportCenter()` already added to store but not exported/used. Export it, use in `AssetItem`, `ImageAssetItem`, and `pasteFromHTML`. Replace all raw `window.innerWidth/2` center calculations.
+- **SVG file drop from OS** — add `image/svg+xml` to accepted drop types in `use-canvas-drop.ts`. Parse dropped SVG file text, extract paths, create FRAME with VECTOR children using existing pipeline.
+- **SVG in Assets panel** — SVG files dropped onto canvas are stored as image bytes in `graph.images`. Show them in the Images section alongside raster images.
+- **Add `parseSVGFile()` to core** — extract the `extractPaths` + `parseSVGPath` + `buildIconData` pipeline into a reusable `parseSVGFile(svgText, size)` function that works on arbitrary SVG content (not just Iconify responses).
+
+## Capabilities
+
+### New Capabilities
+- `svg-import`: SVG file drag-and-drop from OS, parsed into vector scene nodes
+
+### Modified Capabilities
+- `asset-panel`: Viewport center calculation uses actual canvas bounds, not window bounds
+- `asset-images`: SVG files appear in Images section after being imported
+
+## Impact
+
+- `packages/core/src/iconify.ts` — extract `extractPaths` to a shared export, add `parseSVGFile()`
+- `src/stores/editor.ts` — export `canvasViewportCenter`, add `placeSVGFile()`, fix all viewport center usages
+- `src/components/AssetItem.vue` — use `canvasViewportCenter()`
+- `src/components/ImageAssetItem.vue` — use `canvasViewportCenter()`
+- `src/composables/use-canvas-drop.ts` — accept `image/svg+xml`, handle SVG files

--- a/openspec/changes/archive/2026-03-23-svg-support-and-viewport-fix/specs/asset-panel/spec.md
+++ b/openspec/changes/archive/2026-03-23-svg-support-and-viewport-fix/specs/asset-panel/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Assets panel displays all components grouped by page
+The Assets panel SHALL list all COMPONENT and COMPONENT_SET nodes in the document, grouped under collapsible page sections (expanded by default). These component groups SHALL be wrapped in a top-level collapsible "Components (N)" section where N is the total component count. Below the components section, an "Images (N)" section lists embedded images. Both sections are independently collapsible. When the document has neither components nor images, a combined empty state is shown. The search input filters both sections independently. When inserting assets at viewport center (via double-click or context menu), the center SHALL be calculated from the actual canvas element bounds, accounting for left and right sidebars.
+
+#### Scenario: Insert at correct viewport center
+- **WHEN** user double-clicks a component in the Assets panel with left sidebar at 300px and right sidebar at 300px
+- **THEN** the instance appears at the center of the visible canvas area between the sidebars, not at window center
+
+#### Scenario: Document with components and images
+- **WHEN** the document has 5 components and 3 images
+- **THEN** the Assets panel shows "Components (5)" section with page groups and "Images (3)" section with image entries
+
+#### Scenario: Search filters both sections
+- **WHEN** user types "btn" in search
+- **THEN** components matching "btn" appear under Components, images whose referencing nodes match "btn" appear under Images, empty sections are hidden

--- a/openspec/changes/archive/2026-03-23-svg-support-and-viewport-fix/specs/svg-import/spec.md
+++ b/openspec/changes/archive/2026-03-23-svg-support-and-viewport-fix/specs/svg-import/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: SVG file drag-and-drop from OS
+The editor SHALL accept SVG files (`image/svg+xml`) dragged from the operating system onto the canvas. The SVG SHALL be parsed into a FRAME node containing VECTOR children using the existing `extractPaths` + `parseSVGPath` pipeline. The SVG raw bytes SHALL also be stored in `graph.images` for round-trip and Assets display.
+
+#### Scenario: Drop SVG file on canvas
+- **WHEN** user drags a .svg file from OS file manager onto the canvas at (400, 300)
+- **THEN** a FRAME with VECTOR children is created at canvas coordinates, representing the SVG shapes
+
+#### Scenario: SVG with multiple shapes
+- **WHEN** an SVG contains 3 path elements and a circle
+- **THEN** the resulting FRAME has 4 VECTOR children
+
+### Requirement: parseSVGFile utility in core
+`@open-pencil/core` SHALL export a `parseSVGFile(svgText: string, targetSize?: number)` function that parses a full SVG string (with `<svg>` wrapper) and returns `IconData` with paths ready for `createIconFromPaths()`. The function SHALL extract viewBox dimensions and scale paths to targetSize if provided.
+
+#### Scenario: Parse SVG with viewBox
+- **WHEN** `parseSVGFile('<svg viewBox="0 0 100 100"><path d="M10 10L90 90"/></svg>')` is called
+- **THEN** an `IconData` with one path and width=100, height=100 is returned

--- a/openspec/changes/archive/2026-03-23-svg-support-and-viewport-fix/tasks.md
+++ b/openspec/changes/archive/2026-03-23-svg-support-and-viewport-fix/tasks.md
@@ -1,0 +1,173 @@
+## 1. Extract SVG parsing to shared module
+
+- [x] 1.1 Create `packages/core/src/svg-import.ts`. Move from `packages/core/src/iconify.ts`: `attrValue`, `num`, `shapeToD`, `resolveAttr`, `extractPaths`, and the `PathInfo` interface. Export `extractPaths` and `PathInfo`. `iconify.ts` imports `{ extractPaths, type PathInfo }` from `'./svg-import'`.
+
+- [x] 1.2 Add `parseSVGFile` to `packages/core/src/svg-import.ts`:
+  ```ts
+  export function parseSVGFile(svgText: string, targetSize?: number): IconData {
+    // 1. Parse <svg> tag attributes
+    const svgMatch = svgText.match(/<svg\b[^>]*>/)
+    const svgTag = svgMatch?.[0] ?? ''
+    const vb = attrValue(svgTag, 'viewBox')
+    let minX = 0, minY = 0, vbW = 0, vbH = 0
+    if (vb) {
+      const parts = vb.split(/[\s,]+/).map(Number)
+      ;[minX, minY, vbW, vbH] = parts
+    }
+    if (vbW <= 0) vbW = num(svgTag, 'width', 100)
+    if (vbH <= 0) vbH = num(svgTag, 'height', 100)
+
+    // 2. Strip <svg> wrapper to get body
+    const body = svgText.replace(/<svg\b[^>]*>/, '').replace(/<\/svg\s*>/, '')
+
+    // 3. Extract paths
+    const pathInfos = extractPaths(body)
+    if (pathInfos.length === 0) return { prefix: 'svg', name: 'imported', width: vbW, height: vbH, paths: [] }
+
+    // 4. Scale to targetSize if provided
+    const size = targetSize ?? Math.max(vbW, vbH)
+    const sx = size / vbW
+    const sy = size / vbH
+
+    const paths = pathInfos.map((p) => {
+      let d = p.d
+      if (minX !== 0 || minY !== 0 || sx !== 1 || sy !== 1) {
+        d = svgpath(d).translate(-minX, -minY).scale(sx, sy).round(2).toString()
+      }
+      return {
+        vectorNetwork: parseSVGPath(d, p.fillRule),
+        fill: p.fill,
+        stroke: p.stroke,
+        strokeWidth: p.strokeWidth * Math.min(sx, sy),
+        strokeCap: p.strokeCap,
+        strokeJoin: p.strokeJoin
+      }
+    })
+
+    return {
+      prefix: 'svg',
+      name: 'imported',
+      width: targetSize ?? vbW,
+      height: targetSize ?? vbH,
+      paths
+    }
+  }
+  ```
+  Import `svgpath` from `'svgpath'` and `{ parseSVGPath }` from `'./svg-path-parse'` and `type { IconData, IconPath }` from `'./iconify'`. Note: `IconData`/`IconPath` types are exported from iconify — keep them there, import into svg-import.
+
+- [x] 1.3 Export `parseSVGFile` from `packages/core/src/index.ts` barrel alongside existing iconify exports.
+
+- [x] 1.4 Add unit test `tests/engine/svg-import.test.ts`:
+  - SVG with single `<path>` and viewBox → returns IconData with 1 path, correct dimensions
+  - SVG with `<circle>` + `<rect>` → returns 2 paths
+  - SVG without viewBox, with width/height → uses those
+  - SVG with no shapes → returns empty paths array
+  - SVG with viewBox offset (minX=10, minY=10) → paths translated correctly
+
+## 2. Fix viewport center — export and use canvasViewportCenter
+
+- [x] 2.1 Export `canvasViewportCenter` in store return object (it's already defined, just needs to be in the return).
+
+- [x] 2.2 In `src/components/AssetItem.vue` — remove `viewportCenter()` function, use `store.canvasViewportCenter()` in `onDblClick`:
+  ```ts
+  function onDblClick() {
+    const id = resolveInsertableId()
+    if (!id) return
+    const { x, y } = store.canvasViewportCenter()
+    store.createInstanceFromComponent(id, x, y, store.state.currentPageId)
+  }
+  ```
+
+- [x] 2.3 In `src/components/ImageAssetItem.vue` — update `placeAtCenter()`:
+  ```ts
+  function placeAtCenter() {
+    const { x, y } = store.canvasViewportCenter()
+    store.placeImageFromHash(hash, x, y)
+  }
+  ```
+
+- [x] 2.4 In `src/stores/editor.ts` `pasteFromHTML` — replace `(-state.panX + window.innerWidth / 2) / state.zoom` fallback with `canvasViewportCenter()`:
+  ```ts
+  const center = canvasViewportCenter()
+  const cx = cursorPos?.x ?? center.x
+  const cy = cursorPos?.y ?? center.y
+  ```
+
+## 3. SVG drop from OS
+
+- [x] 3.1 Add `placeSVGFile(svgText: string, x: number, y: number, name?: string)` to editor store:
+  ```ts
+  function placeSVGFile(svgText: string, x: number, y: number, name = 'SVG') {
+    const iconData = parseSVGFile(svgText)
+    if (iconData.paths.length === 0) return null
+    const w = iconData.width
+    const h = iconData.height
+    const color: Color = { r: 0, g: 0, b: 0, a: 1 }
+    const frame = createIconFromPaths(graph, iconData, name.replace(/\.svg$/i, ''), Math.max(w, h), color, state.currentPageId, {
+      x: x - w / 2, y: y - h / 2, width: w, height: h
+    })
+    state.selectedIds = new Set([frame.id])
+    const frameId = frame.id
+    undo.push({
+      label: 'Place SVG',
+      forward: () => {
+        // Re-parse and re-create (SVG text is immutable)
+        const data = parseSVGFile(svgText)
+        createIconFromPaths(graph, data, name, Math.max(w, h), color, state.currentPageId, {
+          id: frameId, x: x - w / 2, y: y - h / 2, width: w, height: h
+        })
+        state.selectedIds = new Set([frameId])
+      },
+      inverse: () => {
+        graph.deleteNode(frameId)
+        state.selectedIds = new Set()
+      }
+    })
+    requestRender()
+    return frameId
+  }
+  ```
+  Import `parseSVGFile` from `@open-pencil/core` and `createIconFromPaths` from `@open-pencil/core`. Export `placeSVGFile` in store return.
+
+- [x] 3.2 In `src/composables/use-canvas-drop.ts`:
+  - Add `const SVG_TYPE = 'image/svg+xml'`
+  - Modify `ACCEPTED_TYPES` to include SVG_TYPE
+  - In `drop` handler, after component and image asset checks, before `filterImageFiles`:
+    ```ts
+    // SVG files: parse as vector, not raster
+    const allFiles = e.dataTransfer?.files
+    if (allFiles) {
+      const svgFiles: File[] = []
+      const rasterFiles: File[] = []
+      for (const file of allFiles) {
+        if (file.type === SVG_TYPE || file.name.endsWith('.svg')) {
+          svgFiles.push(file)
+        } else if (ACCEPTED_TYPES.has(file.type)) {
+          rasterFiles.push(file)
+        }
+      }
+      const canvas = canvasRef.value
+      if (!canvas) return
+      const rect = canvas.getBoundingClientRect()
+      const { x: cx, y: cy } = store.screenToCanvas(e.clientX - rect.left, e.clientY - rect.top)
+
+      // Place SVG files as vector nodes
+      for (const file of svgFiles) {
+        const text = await file.text()
+        store.placeSVGFile(text, cx, cy, file.name)
+      }
+      // Place raster files as images
+      if (rasterFiles.length > 0) {
+        void store.placeImageFiles(rasterFiles, cx, cy)
+      }
+      return
+    }
+    ```
+    Note: the drop handler needs to become `async` for `file.text()`. Also use filename `.svg` extension as fallback detection besides MIME type.
+
+## 4. Quality gates
+
+- [x] 4.1 `bun run check` — zero errors
+- [x] 4.2 `bun run format`
+- [x] 4.3 `bun run test:unit` — all pass
+- [x] 4.4 `bun run test:dupes` — under 3%

--- a/openspec/specs/asset-images/spec.md
+++ b/openspec/specs/asset-images/spec.md
@@ -1,0 +1,47 @@
+## Requirements
+
+### Requirement: Images section lists all unique images in document
+The Assets panel SHALL include a collapsible "Images" section showing all unique images from `graph.images`. Each entry shows a thumbnail, the names of nodes using it, and a usage count. The section header shows "Images (N)" where N is the total unique image count.
+
+#### Scenario: Document with images
+- **WHEN** the document has 3 unique images (2 used by multiple nodes)
+- **THEN** the Images section header shows "Images (3)" and lists 3 image entries
+
+#### Scenario: Document with no images
+- **WHEN** `graph.images` is empty
+- **THEN** the Images section is hidden entirely
+
+### Requirement: Image thumbnail from raw bytes
+Each image entry SHALL display a thumbnail generated as a blob URL from the raw image bytes stored in `graph.images`. The MIME type SHALL be detected from magic bytes (PNG, JPEG, WEBP). Blob URLs SHALL be revoked when the image list changes or on component dispose.
+
+#### Scenario: PNG image thumbnail
+- **WHEN** an image with PNG magic bytes exists in graph.images
+- **THEN** a blob URL with type `image/png` is created and displayed as thumbnail
+
+### Requirement: Image usage count and node names
+Each image entry SHALL show the count of nodes referencing it and the names of the first few referencing nodes (truncated if many). Usage is determined by scanning all node fills for `type === 'IMAGE'` with matching `imageHash`.
+
+#### Scenario: Image used by 3 nodes
+- **WHEN** imageHash "abc123" is referenced by nodes "Photo", "Background", "Hero"
+- **THEN** the entry shows "3 uses" and lists "Photo, Background, Hero"
+
+### Requirement: Click image selects referencing nodes
+Clicking an image entry SHALL select all nodes on the current page that reference that imageHash.
+
+#### Scenario: Click selects nodes on current page
+- **WHEN** user clicks an image used by "Photo" on Page 1 and "Hero" on Page 2, while viewing Page 1
+- **THEN** only "Photo" is selected
+
+### Requirement: Drag image to canvas creates rectangle with image fill
+Dragging an image entry from the Assets panel onto the canvas SHALL create a new RECTANGLE node with an IMAGE fill at the drop position. The drag uses MIME type `application/x-openpencil-image-asset` with the imageHash as data.
+
+#### Scenario: Drag image to canvas
+- **WHEN** user drags an image entry and drops at (400, 300) on canvas
+- **THEN** a RECTANGLE with IMAGE fill referencing that hash is created at canvas coordinates
+
+### Requirement: Image search by node name
+The search input SHALL filter images by the names of nodes that reference them. If any referencing node's name matches the query, the image entry is shown.
+
+#### Scenario: Search finds image by node name
+- **WHEN** user types "hero" and a node named "Hero Image" uses imageHash "xyz"
+- **THEN** the image entry for "xyz" appears in filtered results

--- a/openspec/specs/asset-panel/spec.md
+++ b/openspec/specs/asset-panel/spec.md
@@ -1,0 +1,155 @@
+## Requirements
+
+### Requirement: Assets panel displays all components grouped by page
+The Assets panel SHALL list all COMPONENT and COMPONENT_SET nodes in the document, grouped under collapsible page sections (expanded by default). Each page section shows the page name as header with a chevron toggle. INSTANCE nodes SHALL NOT appear in the listing. Empty pages (with no components) SHALL be omitted. Components nested inside frames/groups/sections SHALL be found via recursive traversal.
+
+#### Scenario: Document with components on two pages
+- **WHEN** the document has components "Button" and "Card" on Page 1, and "Header" on Page 2
+- **THEN** the Assets panel shows two collapsible sections: "Page 1" with Button and Card, "Page 2" with Header
+
+#### Scenario: Document with no components
+- **WHEN** the document has no COMPONENT or COMPONENT_SET nodes
+- **THEN** the Assets panel shows an empty state: centered icon, "No components" title, and hint "Select a frame and press ⌥⌘K to create a component"
+
+#### Scenario: Page with no components is hidden
+- **WHEN** Page 3 has shapes but no COMPONENT nodes
+- **THEN** Page 3 does not appear in the Assets panel listing
+
+#### Scenario: Component nested inside a frame
+- **WHEN** a COMPONENT "Icon" exists inside a frame "Icons Container" on Page 1
+- **THEN** "Icon" appears in the Page 1 section of the Assets panel
+
+### Requirement: COMPONENT_SET variant expansion
+COMPONENT_SET items in the Assets panel SHALL be expandable (reka-ui Collapsible) to reveal their child COMPONENT nodes (variants). Each variant SHALL be individually selectable, draggable, and insertable. The set itself is also insertable (inserts the first variant by default).
+
+#### Scenario: Expand component set to see variants
+- **WHEN** a COMPONENT_SET "Button" has children "Button/Primary" and "Button/Secondary"
+- **THEN** clicking the expand chevron reveals "Button/Primary" and "Button/Secondary" as indented items
+
+#### Scenario: Insert specific variant
+- **WHEN** user drags "Button/Secondary" from the expanded set onto the canvas
+- **THEN** an INSTANCE of "Button/Secondary" (not "Button/Primary") is created
+
+#### Scenario: Insert from collapsed set
+- **WHEN** user drags the collapsed "Button" COMPONENT_SET onto the canvas
+- **THEN** an INSTANCE of the first variant child is created
+
+### Requirement: Component search by name
+The Assets panel SHALL provide a search input that filters components by name using case-insensitive substring matching. The search applies across all pages. When the search query is active, only matching components are shown (page grouping preserved, empty groups hidden). COMPONENT_SET children (variants) SHALL also be searched. Clearing the search restores the full list.
+
+#### Scenario: Search finds matching components
+- **WHEN** user types "btn" in the search input
+- **THEN** only components whose names contain "btn" (case-insensitive) are displayed
+
+#### Scenario: Search finds variant inside set
+- **WHEN** user types "primary" and a COMPONENT_SET has a variant "Button/Primary"
+- **THEN** the COMPONENT_SET expands to show "Button/Primary", even if the set name doesn't match
+
+#### Scenario: Search with no results
+- **WHEN** user types "zzzzz" in the search input
+- **THEN** the panel shows "No results for 'zzzzz'" message
+
+#### Scenario: Clear search restores full list
+- **WHEN** user clears the search input
+- **THEN** all components are shown grouped by page
+
+### Requirement: Component thumbnail preview
+Each component item SHALL display a 48×48 pixel thumbnail preview rendered via CanvasKit offscreen surface. Thumbnails SHALL be generated as blob URLs via `renderNodesToImage()` at scale 1, PNG format. Thumbnails SHALL update when the component's visual appearance changes (tracked via sceneVersion with 500ms debounce). Old blob URLs SHALL be revoked via `URL.revokeObjectURL()` before replacement. Items without a ready thumbnail show a placeholder icon.
+
+#### Scenario: Component thumbnail renders
+- **WHEN** a COMPONENT "Button" with a blue fill and text exists
+- **THEN** the Assets panel shows a 48×48 thumbnail preview of the button
+
+#### Scenario: Thumbnail updates after component edit
+- **WHEN** user changes a component's fill color from blue to red
+- **THEN** the thumbnail updates within 500ms after the edit completes
+
+#### Scenario: Thumbnail placeholder before render
+- **WHEN** the Assets panel first opens and thumbnails haven't rendered yet
+- **THEN** each item shows a gray placeholder icon instead of a thumbnail
+
+### Requirement: Component instance count
+Each component item SHALL display the number of INSTANCE nodes referencing it, shown as a dim badge (e.g. "3×"). The count is read from `graph.instanceIndex.get(componentId)?.size ?? 0`. Count of 0 shows no badge.
+
+#### Scenario: Component with instances
+- **WHEN** a COMPONENT "Card" has 5 instances in the document
+- **THEN** the Assets panel shows "5×" badge next to "Card"
+
+#### Scenario: Component with no instances
+- **WHEN** a COMPONENT "Header" has no instances
+- **THEN** no instance count badge is shown
+
+### Requirement: Component description tooltip
+Each component item SHALL show its `description` field (from SceneNode) as a native title tooltip on hover. If description is empty, the title falls back to the component name.
+
+#### Scenario: Component with description
+- **WHEN** a COMPONENT has description "Primary action button for forms"
+- **THEN** hovering shows the description as a browser tooltip
+
+### Requirement: Drag component from Assets panel to canvas
+The user SHALL be able to drag a component item from the Assets panel onto the canvas to create an INSTANCE at the drop position. The drag uses HTML5 Drag and Drop API with MIME type `application/x-openpencil-component`. The drop handler checks for this MIME type BEFORE checking for image files. Drop coordinates are converted from screen space to canvas space via `screenToCanvas()`. The instance is created on the current page regardless of which page the component lives on.
+
+#### Scenario: Drag component to canvas creates instance
+- **WHEN** user drags "Button" from Assets panel and drops at (300, 200) on canvas
+- **THEN** an INSTANCE of "Button" is created at the corresponding canvas coordinates on the current page
+
+#### Scenario: Drag cross-page component
+- **WHEN** user drags a component from Page 2 while viewing Page 1
+- **THEN** the INSTANCE is created on Page 1 (current page), not Page 2
+
+#### Scenario: Drop outside canvas has no effect
+- **WHEN** user drags a component and releases outside the canvas
+- **THEN** no instance is created
+
+### Requirement: Double-click inserts instance at viewport center
+Double-clicking a component item SHALL create an INSTANCE at the center of the current viewport and select it.
+
+#### Scenario: Double-click inserts at center
+- **WHEN** user double-clicks "Card" component in Assets panel
+- **THEN** an INSTANCE of "Card" appears at viewport center and is selected
+
+### Requirement: Asset item context menu
+Right-clicking a component item SHALL show a context menu (reka-ui ContextMenu) with two actions: "Insert instance" (creates instance at viewport center) and "Go to component" (navigates to component on canvas).
+
+#### Scenario: Context menu insert
+- **WHEN** user right-clicks a component and selects "Insert instance"
+- **THEN** an INSTANCE is created at viewport center
+
+#### Scenario: Context menu navigate
+- **WHEN** user right-clicks a component and selects "Go to component"
+- **THEN** the editor navigates to the component's page, centers viewport on it, and selects it
+
+### Requirement: Component list reactivity
+The component list SHALL update automatically when components are created, deleted, renamed, or reparented. The list is recomputed from SceneGraph on each `sceneVersion` change.
+
+#### Scenario: New component appears in list
+- **WHEN** user creates a new component via ⌥⌘K
+- **THEN** the Assets panel immediately shows the new component
+
+#### Scenario: Deleted component removed from list
+- **WHEN** user deletes a component
+- **THEN** the component disappears from the Assets panel
+
+#### Scenario: Renamed component updates in list
+- **WHEN** user renames a component from "Button" to "PrimaryButton"
+- **THEN** the Assets panel shows the updated name
+
+
+### Requirement: Assets panel displays all components grouped by page
+The Assets panel SHALL list all COMPONENT and COMPONENT_SET nodes in the document, grouped under collapsible page sections (expanded by default). These component groups SHALL be wrapped in a top-level collapsible "Components (N)" section where N is the total component count. Below the components section, an "Images (N)" section lists embedded images. Both sections are independently collapsible. When the document has neither components nor images, a combined empty state is shown. The search input filters both sections independently.
+
+#### Scenario: Document with components and images
+- **WHEN** the document has 5 components and 3 images
+- **THEN** the Assets panel shows "Components (5)" section with page groups and "Images (3)" section with image entries
+
+#### Scenario: Search filters both sections
+- **WHEN** user types "btn" in search
+- **THEN** components matching "btn" appear under Components, images whose referencing nodes match "btn" appear under Images, empty sections are hidden
+
+#### Scenario: Document with only images
+- **WHEN** the document has no components but 2 images
+- **THEN** only the "Images (2)" section is shown, no Components section
+
+#### Scenario: Empty document
+- **WHEN** the document has no components and no images
+- **THEN** a combined empty state is shown: "No assets"

--- a/openspec/specs/components/spec.md
+++ b/openspec/specs/components/spec.md
@@ -103,3 +103,71 @@ After sync, instance children SHALL be reordered to match the component's child 
 #### Scenario: Reorder component children
 - **WHEN** component children are reordered from [A, B] to [B, A]
 - **THEN** after sync, instance children reflect the new order
+
+
+### Requirement: SceneGraph component enumeration by page
+SceneGraph SHALL provide a `getComponentsGroupedByPage()` method returning `Array<{ page: SceneNode; components: SceneNode[] }>`. The method traverses all pages, recursively walks child trees (frames, groups, sections), and collects nodes with `type === 'COMPONENT'` or `type === 'COMPONENT_SET'`. It does NOT recurse into COMPONENT_SET children (those are variants, accessed separately). Pages with no components are omitted. The traversal uses an iterative stack (not recursion) for predictable performance.
+
+#### Scenario: Components on multiple pages
+- **WHEN** `getComponentsGroupedByPage()` is called on a document with 2 components on Page 1 and 1 on Page 2
+- **THEN** the result has two entries: `[{ page: Page1, components: [C1, C2] }, { page: Page2, components: [C3] }]`
+
+#### Scenario: No components in document
+- **WHEN** `getComponentsGroupedByPage()` is called on a document with only rectangles and frames
+- **THEN** the result is an empty array
+
+#### Scenario: Component nested inside a frame
+- **WHEN** a COMPONENT exists inside a frame → group → page
+- **THEN** the component is found and included in that page's components array
+
+#### Scenario: COMPONENT_SET children not duplicated
+- **WHEN** a COMPONENT_SET has 3 COMPONENT children (variants)
+- **THEN** only the COMPONENT_SET appears in the result, not its children
+
+#### Scenario: INSTANCE nodes excluded
+- **WHEN** the page has both COMPONENT and INSTANCE nodes
+- **THEN** only COMPONENT nodes appear in the result
+
+### Requirement: Focus node with viewport navigation
+The editor store SHALL provide a `focusNode(nodeId: string)` method that: (1) finds which page the node is on by walking parentId chain up to type === 'CANVAS', (2) switches page via `switchPage()` if different from current, (3) sets `selectedIds` to the node, (4) centers the viewport on the node using `window.innerWidth/Height` (not hardcoded dimensions), (5) calls `requestRender()`. The existing `goToMainComponent()` SHALL be refactored to call `focusNode()` instead of duplicating the viewport math.
+
+#### Scenario: Focus node on current page
+- **WHEN** `focusNode(nodeId)` is called for a node on the current page
+- **THEN** the viewport centers on the node and it is selected, no page switch
+
+#### Scenario: Focus node on different page
+- **WHEN** `focusNode(nodeId)` is called for a node on Page 2 while viewing Page 1
+- **THEN** the editor switches to Page 2, centers viewport, and selects the node
+
+#### Scenario: goToMainComponent uses focusNode
+- **WHEN** `goToMainComponent()` is called on a selected instance
+- **THEN** it resolves the main component and calls `focusNode(mainComponentId)`
+
+### Requirement: Cross-page instance creation
+`createInstanceFromComponent(componentId, x?, y?, targetPageId?)` SHALL accept an optional `targetPageId` parameter. When provided, the instance is created on the target page. When omitted, it defaults to `state.currentPageId`. This replaces the current behavior of using `component.parentId` which breaks cross-page drag-and-drop.
+
+#### Scenario: Create instance on current page from cross-page component
+- **WHEN** a component on Page 2 is used to create an instance while viewing Page 1, with `targetPageId = Page1.id`
+- **THEN** the instance appears on Page 1
+
+#### Scenario: Default behavior unchanged
+- **WHEN** `createInstanceFromComponent(id, x, y)` is called without targetPageId
+- **THEN** the instance is created on `state.currentPageId`
+
+### Requirement: Store-level component thumbnail rendering
+The editor store SHALL provide a `renderComponentThumbnail(nodeId: string, size?: number): string | null` method that renders a component node as a PNG blob URL. It finds the node's page ID, calls `renderNodesToImage()` with the private `_ck` and `_renderer`, creates a Blob, and returns `URL.createObjectURL()`. Returns `null` if CanvasKit is not initialized or the node doesn't exist.
+
+#### Scenario: Render thumbnail for component
+- **WHEN** `renderComponentThumbnail(componentId)` is called for a visible COMPONENT
+- **THEN** a blob URL pointing to a PNG image is returned
+
+#### Scenario: CanvasKit not initialized
+- **WHEN** `renderComponentThumbnail()` is called before `setCanvasKit()`
+- **THEN** it returns `null`
+
+### Requirement: MCP system prompt mentions component discovery
+The `ACP_DESIGN_CONTEXT` system prompt SHALL include `get_components` and `create_instance` in the key tools list, enabling AI agents to discover and reuse existing components.
+
+#### Scenario: System prompt content
+- **WHEN** `ACP_DESIGN_CONTEXT` is read
+- **THEN** it contains mentions of `get_components` for listing components and `create_instance` for creating instances

--- a/openspec/specs/editor-ui/spec.md
+++ b/openspec/specs/editor-ui/spec.md
@@ -34,7 +34,7 @@ The toolbar SHALL be positioned at the bottom of the screen (Figma UI3 style) wi
 - **THEN** a STAR node is created with 5 points and 0.38 inner radius
 
 ### Requirement: Layers panel with tree view
-The layers panel SHALL display a tree view of the document hierarchy using Reka UI Tree with expand/collapse and drag reordering.
+The layers panel SHALL display a tree view of the document hierarchy using Reka UI Tree with expand/collapse and drag reordering. The bottom section of the left panel SHALL have a reka-ui TabsRoot with two TabsTrigger buttons: "Layers" and "Assets". The "Layers" tab shows the LayerTree component (default). The "Assets" tab shows the AssetsPanel component. The PagesPanel remains in the top SplitterPanel, always visible above both tabs. The active tab is stored as `leftPanelTab: 'layers' | 'assets'` in the editor state (default: `'layers'`). Tab triggers use `text-[11px] tracking-wider uppercase text-muted` styling, matching the current header, with `data-[state=active]:font-semibold data-[state=active]:text-surface` for active state.
 
 #### Scenario: Expand/collapse frame children
 - **WHEN** user clicks the chevron next to a frame in the layers panel
@@ -47,6 +47,18 @@ The layers panel SHALL display a tree view of the document hierarchy using Reka 
 #### Scenario: Visibility toggle
 - **WHEN** user clicks the visibility icon next to a layer
 - **THEN** the node is hidden/shown on canvas
+
+#### Scenario: Switch to Assets tab
+- **WHEN** user clicks "Assets" tab in the left panel
+- **THEN** the layer tree is hidden and the Assets panel is shown with components grouped by page
+
+#### Scenario: Switch back to Layers tab
+- **WHEN** user clicks "Layers" tab while viewing Assets
+- **THEN** the Assets panel is hidden and the layer tree is shown
+
+#### Scenario: PagesPanel always visible
+- **WHEN** user switches between Layers and Assets tabs
+- **THEN** the PagesPanel above the splitter handle remains visible and functional
 
 ### Requirement: Properties panel with tabs
 The properties panel SHALL be organized as a tabbed interface with Design | Code | AI tabs (reka-ui Tabs). The Design tab (DesignPanel) contains sections: Appearance (opacity, corner radius with independent mode, visibility toggle), Fill, Stroke, Effects, Typography, Layout, Position. The Code tab shows JSX export. The AI tab shows the chat interface.

--- a/openspec/specs/svg-import/spec.md
+++ b/openspec/specs/svg-import/spec.md
@@ -1,0 +1,19 @@
+## Requirements
+
+### Requirement: SVG file drag-and-drop from OS
+The editor SHALL accept SVG files (`image/svg+xml`) dragged from the operating system onto the canvas. The SVG SHALL be parsed into a FRAME node containing VECTOR children using the existing `extractPaths` + `parseSVGPath` pipeline. The SVG raw bytes SHALL also be stored in `graph.images` for round-trip and Assets display.
+
+#### Scenario: Drop SVG file on canvas
+- **WHEN** user drags a .svg file from OS file manager onto the canvas at (400, 300)
+- **THEN** a FRAME with VECTOR children is created at canvas coordinates, representing the SVG shapes
+
+#### Scenario: SVG with multiple shapes
+- **WHEN** an SVG contains 3 path elements and a circle
+- **THEN** the resulting FRAME has 4 VECTOR children
+
+### Requirement: parseSVGFile utility in core
+`@open-pencil/core` SHALL export a `parseSVGFile(svgText: string, targetSize?: number)` function that parses a full SVG string (with `<svg>` wrapper) and returns `IconData` with paths ready for `createIconFromPaths()`. The function SHALL extract viewBox dimensions and scale paths to targetSize if provided.
+
+#### Scenario: Parse SVG with viewBox
+- **WHEN** `parseSVGFile('<svg viewBox="0 0 100 100"><path d="M10 10L90 90"/></svg>')` is called
+- **THEN** an `IconData` with one path and width=100, height=100 is returned

--- a/packages/core/src/iconify.ts
+++ b/packages/core/src/iconify.ts
@@ -2,21 +2,12 @@ import svgpath from 'svgpath'
 import { iconToSVG } from '@iconify/utils'
 
 import { parseSVGPath } from './svg-path-parse'
+import { extractPaths } from './svg-import'
 
-import type { VectorNetwork, WindingRule } from './scene-graph'
+import type { VectorNetwork } from './scene-graph'
 
 const ICONIFY_API = 'https://api.iconify.design'
 const FETCH_TIMEOUT_MS = 10_000
-
-interface PathInfo {
-  d: string
-  fill: string | null
-  stroke: string | null
-  strokeWidth: number
-  strokeCap: string
-  strokeJoin: string
-  fillRule: WindingRule
-}
 
 export interface IconPath {
   vectorNetwork: VectorNetwork
@@ -61,97 +52,6 @@ function parseIconName(name: string): { prefix: string; iconName: string } {
     throw new Error(`Invalid icon name "${name}". Use prefix:name format (e.g. lucide:heart, mdi:home)`)
   }
   return { prefix: name.slice(0, colonIdx), iconName: name.slice(colonIdx + 1) }
-}
-
-function attrValue(tag: string, attr: string): string | null {
-  const re = new RegExp(`\\b${attr}="([^"]*)"`)
-  const m = tag.match(re)
-  return m ? m[1] : null
-}
-
-function num(tag: string, attr: string, fallback = 0): number {
-  const v = attrValue(tag, attr)
-  return v !== null ? parseFloat(v) : fallback
-}
-
-function shapeToD(tagName: string, tag: string): string | null {
-  switch (tagName) {
-    case 'circle': {
-      const cx = num(tag, 'cx'), cy = num(tag, 'cy'), r = num(tag, 'r')
-      return r > 0 ? `M${cx - r},${cy}A${r},${r},0,1,0,${cx + r},${cy}A${r},${r},0,1,0,${cx - r},${cy}Z` : null
-    }
-    case 'ellipse': {
-      const cx = num(tag, 'cx'), cy = num(tag, 'cy'), rx = num(tag, 'rx'), ry = num(tag, 'ry')
-      return rx > 0 && ry > 0 ? `M${cx - rx},${cy}A${rx},${ry},0,1,0,${cx + rx},${cy}A${rx},${ry},0,1,0,${cx - rx},${cy}Z` : null
-    }
-    case 'rect': {
-      const x = num(tag, 'x'), y = num(tag, 'y'), w = num(tag, 'width'), h = num(tag, 'height')
-      if (w <= 0 || h <= 0) return null
-      const rx = Math.min(num(tag, 'rx'), w / 2), ry = Math.min(num(tag, 'ry', rx), h / 2)
-      if (rx > 0 || ry > 0) {
-        const arx = rx || ry, ary = ry || rx
-        return `M${x + arx},${y}H${x + w - arx}A${arx},${ary},0,0,1,${x + w},${y + ary}V${y + h - ary}A${arx},${ary},0,0,1,${x + w - arx},${y + h}H${x + arx}A${arx},${ary},0,0,1,${x},${y + h - ary}V${y + ary}A${arx},${ary},0,0,1,${x + arx},${y}Z`
-      }
-      return `M${x},${y}H${x + w}V${y + h}H${x}Z`
-    }
-    case 'line': {
-      const x1 = num(tag, 'x1'), y1 = num(tag, 'y1'), x2 = num(tag, 'x2'), y2 = num(tag, 'y2')
-      return `M${x1},${y1}L${x2},${y2}`
-    }
-    case 'polygon':
-    case 'polyline': {
-      const points = attrValue(tag, 'points')
-      if (!points) return null
-      const nums = points.trim().split(/[\s,]+/).map(Number)
-      if (nums.length < 4) return null
-      let d = `M${nums[0]},${nums[1]}`
-      for (let i = 2; i < nums.length; i += 2) d += `L${nums[i]},${nums[i + 1]}`
-      if (tagName === 'polygon') d += 'Z'
-      return d
-    }
-    default:
-      return null
-  }
-}
-
-function resolveAttr(explicit: string | null, group: string | null, fallback: string | null): string | null {
-  if (explicit !== null) return explicit === 'none' ? null : explicit
-  if (group !== null) return group === 'none' ? null : group
-  return fallback
-}
-
-function extractPaths(svgBody: string): PathInfo[] {
-  const groupAttrs = { fill: null as string | null, stroke: null as string | null, strokeWidth: null as string | null, strokeCap: null as string | null, strokeJoin: null as string | null }
-  const groupRe = /<g\b[^>]*>/g
-  let gm
-  while ((gm = groupRe.exec(svgBody)) !== null) {
-    groupAttrs.fill ??= attrValue(gm[0], 'fill')
-    groupAttrs.stroke ??= attrValue(gm[0], 'stroke')
-    groupAttrs.strokeWidth ??= attrValue(gm[0], 'stroke-width')
-    groupAttrs.strokeCap ??= attrValue(gm[0], 'stroke-linecap')
-    groupAttrs.strokeJoin ??= attrValue(gm[0], 'stroke-linejoin')
-  }
-
-  const result: PathInfo[] = []
-  const shapeRe = /<(path|circle|ellipse|rect|line|polygon|polyline)\b[^>]*>/g
-  let match
-  while ((match = shapeRe.exec(svgBody)) !== null) {
-    const tag = match[0], tagName = match[1]
-    const d = tagName === 'path' ? attrValue(tag, 'd') : shapeToD(tagName, tag)
-    if (!d) continue
-
-    const fillRuleAttr = attrValue(tag, 'fill-rule')
-    result.push({
-      d,
-      fill: resolveAttr(attrValue(tag, 'fill'), groupAttrs.fill, 'currentColor'),
-      stroke: resolveAttr(attrValue(tag, 'stroke'), groupAttrs.stroke, null),
-      strokeWidth: parseFloat(attrValue(tag, 'stroke-width') ?? groupAttrs.strokeWidth ?? '1'),
-      strokeCap: attrValue(tag, 'stroke-linecap') ?? groupAttrs.strokeCap ?? 'butt',
-      strokeJoin: attrValue(tag, 'stroke-linejoin') ?? groupAttrs.strokeJoin ?? 'miter',
-      fillRule: fillRuleAttr === 'evenodd' ? 'EVENODD' : 'NONZERO'
-    })
-  }
-  return result
 }
 
 function buildIconData(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -146,6 +146,8 @@ export {
 } from './svg-export'
 export { svg, renderSVGNode, type SVGNode } from './svg-node'
 export { parseSVGPath } from './svg-path-parse'
+export { parseSVGFile, extractPaths } from './svg-import'
+export { createIconFromPaths } from './icon-render'
 export { fetchIcon, fetchIcons, searchIcons, searchIconsBatch, clearIconCache, type IconData, type IconPath, type IconSearchResult } from './iconify'
 export { exportFigFile, compressFigData, compressFigDataSync } from './fig-export'
 export {

--- a/packages/core/src/scene-graph.ts
+++ b/packages/core/src/scene-graph.ts
@@ -926,6 +926,46 @@ export class SceneGraph {
     return getInstancesFn(this, componentId)
   }
 
+  getComponentsGroupedByPage(): Array<{ page: SceneNode; components: SceneNode[] }> {
+    const result: Array<{ page: SceneNode; components: SceneNode[] }> = []
+    for (const page of this.getPages()) {
+      const components: SceneNode[] = []
+      const stack = [...page.childIds]
+      while (stack.length > 0) {
+        const id = stack.pop()
+        if (!id) continue
+        const node = this.nodes.get(id)
+        if (!node) continue
+        if (node.type === 'COMPONENT' || node.type === 'COMPONENT_SET') {
+          components.push(node)
+        } else if (node.type !== 'INSTANCE' && CONTAINER_TYPES.has(node.type)) {
+          stack.push(...node.childIds)
+        }
+      }
+      if (components.length > 0) result.push({ page, components })
+    }
+    return result
+  }
+
+  getImageUsages(): Map<string, { hash: string; nodeIds: string[]; names: string[] }> {
+    const usages = new Map<string, { hash: string; nodeIds: string[]; names: string[] }>()
+    for (const hash of this.images.keys()) {
+      usages.set(hash, { hash, nodeIds: [], names: [] })
+    }
+    for (const node of this.nodes.values()) {
+      if (node.type === 'CANVAS') continue
+      for (const fill of node.fills) {
+        if (fill.type !== 'IMAGE' || !fill.imageHash) continue
+        const entry = usages.get(fill.imageHash)
+        if (entry && !entry.nodeIds.includes(node.id)) {
+          entry.nodeIds.push(node.id)
+          entry.names.push(node.name)
+        }
+      }
+    }
+    return usages
+  }
+
   flattenTree(parentId?: string, depth = 0): Array<{ node: SceneNode; depth: number }> {
     const id = parentId ?? this.rootId
     const parent = this.nodes.get(id)

--- a/packages/core/src/svg-import.ts
+++ b/packages/core/src/svg-import.ts
@@ -1,0 +1,148 @@
+import svgpath from 'svgpath'
+
+import { parseSVGPath } from './svg-path-parse'
+
+import type { WindingRule } from './scene-graph'
+import type { IconData, IconPath } from './iconify'
+
+export interface PathInfo {
+  d: string
+  fill: string | null
+  stroke: string | null
+  strokeWidth: number
+  strokeCap: string
+  strokeJoin: string
+  fillRule: WindingRule
+}
+
+function attrValue(tag: string, attr: string): string | null {
+  const re = new RegExp(`\\b${attr}="([^"]*)"`)
+  const m = tag.match(re)
+  return m ? m[1] : null
+}
+
+function num(tag: string, attr: string, fallback = 0): number {
+  const v = attrValue(tag, attr)
+  return v !== null ? parseFloat(v) : fallback
+}
+
+function shapeToD(tagName: string, tag: string): string | null {
+  switch (tagName) {
+    case 'circle': {
+      const cx = num(tag, 'cx'), cy = num(tag, 'cy'), r = num(tag, 'r')
+      return r > 0 ? `M${cx - r},${cy}A${r},${r},0,1,0,${cx + r},${cy}A${r},${r},0,1,0,${cx - r},${cy}Z` : null
+    }
+    case 'ellipse': {
+      const cx = num(tag, 'cx'), cy = num(tag, 'cy'), rx = num(tag, 'rx'), ry = num(tag, 'ry')
+      return rx > 0 && ry > 0 ? `M${cx - rx},${cy}A${rx},${ry},0,1,0,${cx + rx},${cy}A${rx},${ry},0,1,0,${cx - rx},${cy}Z` : null
+    }
+    case 'rect': {
+      const x = num(tag, 'x'), y = num(tag, 'y'), w = num(tag, 'width'), h = num(tag, 'height')
+      if (w <= 0 || h <= 0) return null
+      const rx = Math.min(num(tag, 'rx'), w / 2), ry = Math.min(num(tag, 'ry', rx), h / 2)
+      if (rx > 0 || ry > 0) {
+        const arx = rx || ry, ary = ry || rx
+        return `M${x + arx},${y}H${x + w - arx}A${arx},${ary},0,0,1,${x + w},${y + ary}V${y + h - ary}A${arx},${ary},0,0,1,${x + w - arx},${y + h}H${x + arx}A${arx},${ary},0,0,1,${x},${y + h - ary}V${y + ary}A${arx},${ary},0,0,1,${x + arx},${y}Z`
+      }
+      return `M${x},${y}H${x + w}V${y + h}H${x}Z`
+    }
+    case 'line': {
+      const x1 = num(tag, 'x1'), y1 = num(tag, 'y1'), x2 = num(tag, 'x2'), y2 = num(tag, 'y2')
+      return `M${x1},${y1}L${x2},${y2}`
+    }
+    case 'polygon':
+    case 'polyline': {
+      const points = attrValue(tag, 'points')
+      if (!points) return null
+      const nums = points.trim().split(/[\s,]+/).map(Number)
+      if (nums.length < 4) return null
+      let d = `M${nums[0]},${nums[1]}`
+      for (let i = 2; i < nums.length; i += 2) d += `L${nums[i]},${nums[i + 1]}`
+      if (tagName === 'polygon') d += 'Z'
+      return d
+    }
+    default:
+      return null
+  }
+}
+
+function resolveAttr(explicit: string | null, group: string | null, fallback: string | null): string | null {
+  if (explicit !== null) return explicit === 'none' ? null : explicit
+  if (group !== null) return group === 'none' ? null : group
+  return fallback
+}
+
+export function extractPaths(svgBody: string): PathInfo[] {
+  const groupAttrs = { fill: null as string | null, stroke: null as string | null, strokeWidth: null as string | null, strokeCap: null as string | null, strokeJoin: null as string | null }
+  const groupRe = /<g\b[^>]*>/g
+  let gm
+  while ((gm = groupRe.exec(svgBody)) !== null) {
+    groupAttrs.fill ??= attrValue(gm[0], 'fill')
+    groupAttrs.stroke ??= attrValue(gm[0], 'stroke')
+    groupAttrs.strokeWidth ??= attrValue(gm[0], 'stroke-width')
+    groupAttrs.strokeCap ??= attrValue(gm[0], 'stroke-linecap')
+    groupAttrs.strokeJoin ??= attrValue(gm[0], 'stroke-linejoin')
+  }
+
+  const result: PathInfo[] = []
+  const shapeRe = /<(path|circle|ellipse|rect|line|polygon|polyline)\b[^>]*>/g
+  let match
+  while ((match = shapeRe.exec(svgBody)) !== null) {
+    const tag = match[0], tagName = match[1]
+    const d = tagName === 'path' ? attrValue(tag, 'd') : shapeToD(tagName, tag)
+    if (!d) continue
+
+    const fillRuleAttr = attrValue(tag, 'fill-rule')
+    result.push({
+      d,
+      fill: resolveAttr(attrValue(tag, 'fill'), groupAttrs.fill, 'currentColor'),
+      stroke: resolveAttr(attrValue(tag, 'stroke'), groupAttrs.stroke, null),
+      strokeWidth: parseFloat(attrValue(tag, 'stroke-width') ?? groupAttrs.strokeWidth ?? '1'),
+      strokeCap: attrValue(tag, 'stroke-linecap') ?? groupAttrs.strokeCap ?? 'butt',
+      strokeJoin: attrValue(tag, 'stroke-linejoin') ?? groupAttrs.strokeJoin ?? 'miter',
+      fillRule: fillRuleAttr === 'evenodd' ? 'EVENODD' : 'NONZERO'
+    })
+  }
+  return result
+}
+
+export function parseSVGFile(svgText: string, targetSize?: number): IconData {
+  const svgMatch = svgText.match(/<svg\b[^>]*>/)
+  const svgTag = svgMatch?.[0] ?? ''
+  const vb = attrValue(svgTag, 'viewBox')
+  let minX = 0, minY = 0, vbW = 0, vbH = 0
+  if (vb) {
+    const parts = vb.split(/[\s,]+/).map(Number)
+    ;[minX, minY, vbW, vbH] = parts
+  }
+  if (vbW <= 0) vbW = num(svgTag, 'width', 100)
+  if (vbH <= 0) vbH = num(svgTag, 'height', 100)
+
+  const body = svgText.replace(/<svg\b[^>]*>/, '').replace(/<\/svg\s*>/, '')
+  const pathInfos = extractPaths(body)
+  if (pathInfos.length === 0) {
+    return { prefix: 'svg', name: 'imported', width: vbW, height: vbH, paths: [] }
+  }
+
+  const outW = targetSize ?? vbW
+  const outH = targetSize ?? vbH
+  const sx = outW / vbW
+  const sy = outH / vbH
+
+  const paths: IconPath[] = pathInfos.map((p) => {
+    let d = p.d
+    if (minX !== 0 || minY !== 0 || sx !== 1 || sy !== 1) {
+      d = svgpath(d).translate(-minX, -minY).scale(sx, sy).round(2).toString()
+    }
+    return {
+      vectorNetwork: parseSVGPath(d, p.fillRule),
+      fill: p.fill,
+      stroke: p.stroke,
+      strokeWidth: p.strokeWidth * Math.min(sx, sy),
+      strokeCap: p.strokeCap,
+      strokeJoin: p.strokeJoin
+    }
+  })
+
+  return { prefix: 'svg', name: 'imported', width: outW, height: outH, paths }
+}

--- a/src/components/AssetItem.vue
+++ b/src/components/AssetItem.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import {
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuPortal,
+  ContextMenuRoot,
+  ContextMenuTrigger
+} from 'reka-ui'
+
+import { useEditorStore } from '@/stores/editor'
+
+import type { SceneNode } from '@open-pencil/core'
+
+const { node, thumbnailUrl, indented, isSet } = defineProps<{
+  node: SceneNode
+  thumbnailUrl?: string
+  indented?: boolean
+  isSet?: boolean
+}>()
+
+const store = useEditorStore()
+
+const instanceCount = computed(() => {
+  void store.state.sceneVersion
+  return store.graph.instanceIndex.get(node.id)?.size ?? 0
+})
+
+function resolveInsertableId(): string | undefined {
+  if (node.type === 'COMPONENT_SET') {
+    return store.graph.getChildren(node.id).find((c) => c.type === 'COMPONENT')?.id
+  }
+  return node.id
+}
+
+function onDragStart(e: DragEvent) {
+  if (!e.dataTransfer) return
+  const id = resolveInsertableId()
+  if (!id) return
+  e.dataTransfer.setData('application/x-openpencil-component', id)
+  e.dataTransfer.effectAllowed = 'copy'
+}
+
+function onDblClick() {
+  const id = resolveInsertableId()
+  if (!id) return
+  const { x, y } = store.canvasViewportCenter()
+  store.createInstanceFromComponent(id, x, y, store.state.currentPageId)
+}
+
+function goToComponent() {
+  store.focusNode(node.id)
+}
+</script>
+
+<template>
+  <ContextMenuRoot>
+    <ContextMenuTrigger as-child>
+      <div
+        :class="[
+          'flex cursor-pointer items-center gap-2 rounded px-2 py-1 hover:bg-hover',
+          indented ? 'pl-6' : ''
+        ]"
+        :title="node.description || node.name"
+        :draggable="true"
+        @dragstart="onDragStart"
+        @dblclick="onDblClick"
+      >
+        <div class="size-8 shrink-0 overflow-hidden rounded border border-border bg-canvas">
+          <img
+            v-if="thumbnailUrl"
+            :src="thumbnailUrl"
+            class="size-full object-contain"
+            :alt="node.name"
+          />
+          <div v-else class="flex size-full items-center justify-center">
+            <icon-lucide-component class="size-3.5 text-muted" />
+          </div>
+        </div>
+        <icon-lucide-diamond
+          v-if="node.type === 'COMPONENT'"
+          class="size-3 shrink-0 text-[#9747ff]"
+        />
+        <icon-lucide-layout-grid v-else class="size-3 shrink-0 text-[#9747ff]" />
+        <span class="min-w-0 flex-1 truncate text-xs text-surface">{{ node.name }}</span>
+        <icon-lucide-chevron-down
+          v-if="isSet"
+          class="size-3 shrink-0 text-muted transition-transform [[data-state=closed]>&]:rotate-[-90deg]"
+        />
+        <span v-if="instanceCount > 0" class="shrink-0 text-[10px] text-muted">
+          {{ instanceCount }}×
+        </span>
+      </div>
+    </ContextMenuTrigger>
+    <ContextMenuPortal>
+      <ContextMenuContent class="min-w-40 rounded-lg border border-border bg-panel p-1 shadow-lg">
+        <ContextMenuItem
+          class="cursor-pointer rounded px-2 py-1 text-xs text-surface hover:bg-hover"
+          @select="onDblClick"
+        >
+          Insert instance
+        </ContextMenuItem>
+        <ContextMenuItem
+          class="cursor-pointer rounded px-2 py-1 text-xs text-surface hover:bg-hover"
+          @select="goToComponent"
+        >
+          Go to component
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenuPortal>
+  </ContextMenuRoot>
+</template>

--- a/src/components/AssetsPanel.vue
+++ b/src/components/AssetsPanel.vue
@@ -1,0 +1,182 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { CollapsibleContent, CollapsibleRoot, CollapsibleTrigger } from 'reka-ui'
+
+import { useComponentThumbnails } from '@/composables/use-component-thumbnails'
+import { useEditorStore } from '@/stores/editor'
+
+import AssetItem from './AssetItem.vue'
+import ImageAssetItem from './ImageAssetItem.vue'
+
+import type { SceneNode } from '@open-pencil/core'
+
+const store = useEditorStore()
+const query = ref('')
+
+const allGroups = computed(() => {
+  void store.state.sceneVersion
+  return store.graph.getComponentsGroupedByPage()
+})
+
+const allComponentIds = computed(() => {
+  const ids: string[] = []
+  for (const group of allGroups.value) {
+    for (const comp of group.components) {
+      ids.push(comp.id)
+      if (comp.type === 'COMPONENT_SET') {
+        for (const child of store.graph.getChildren(comp.id)) {
+          if (child.type === 'COMPONENT') ids.push(child.id)
+        }
+      }
+    }
+  }
+  return ids
+})
+
+const thumbnails = useComponentThumbnails(store, allComponentIds)
+
+const totalComponents = computed(() =>
+  allGroups.value.reduce((sum, g) => sum + g.components.length, 0)
+)
+
+const imageUsages = computed(() => {
+  void store.state.sceneVersion
+  return store.graph.getImageUsages()
+})
+
+const imageList = computed(() => {
+  const list: Array<{ hash: string; nodeIds: string[]; names: string[]; url: string }> = []
+  for (const entry of imageUsages.value.values()) {
+    const url = store.imageBlobUrl(entry.hash)
+    if (url) list.push({ ...entry, url })
+  }
+  return list
+})
+
+const filteredGroups = computed(() => {
+  const q = query.value.toLowerCase().trim()
+  if (!q) return allGroups.value
+
+  const result: Array<{ page: SceneNode; components: SceneNode[] }> = []
+  for (const group of allGroups.value) {
+    const filtered = group.components.filter((comp) => {
+      if (comp.name.toLowerCase().includes(q)) return true
+      if (comp.type === 'COMPONENT_SET') {
+        return store.graph
+          .getChildren(comp.id)
+          .some((c) => c.type === 'COMPONENT' && c.name.toLowerCase().includes(q))
+      }
+      return false
+    })
+    if (filtered.length > 0) result.push({ page: group.page, components: filtered })
+  }
+  return result
+})
+
+const filteredImages = computed(() => {
+  const q = query.value.toLowerCase().trim()
+  if (!q) return imageList.value
+  return imageList.value.filter((img) => img.names.some((n) => n.toLowerCase().includes(q)))
+})
+
+const hasAnyAssets = computed(() => totalComponents.value > 0 || imageList.value.length > 0)
+const hasFilteredResults = computed(
+  () => filteredGroups.value.length > 0 || filteredImages.value.length > 0
+)
+</script>
+
+<template>
+  <div class="flex min-h-0 flex-1 flex-col">
+    <div class="flex items-center gap-1.5 border-b border-border px-3 py-1.5">
+      <icon-lucide-search class="size-3 shrink-0 text-muted" />
+      <input
+        v-model="query"
+        placeholder="Search assets..."
+        class="min-w-0 flex-1 bg-transparent text-xs text-surface outline-none placeholder:text-muted"
+      />
+    </div>
+
+    <div
+      v-if="!hasAnyAssets"
+      class="flex flex-1 flex-col items-center justify-center gap-2 px-4 text-center"
+    >
+      <icon-lucide-package class="size-8 text-muted" />
+      <p class="text-xs text-muted">No assets</p>
+      <p class="text-[10px] text-muted">Components: ⌥⌘K · Images: drag onto canvas</p>
+    </div>
+
+    <div
+      v-else-if="query && !hasFilteredResults"
+      class="flex flex-1 items-center justify-center px-4"
+    >
+      <p class="text-xs text-muted">No results for "{{ query }}"</p>
+    </div>
+
+    <div v-else class="scrollbar-thin flex-1 overflow-y-auto px-1 pb-1">
+      <!-- Components section -->
+      <CollapsibleRoot v-if="filteredGroups.length > 0" default-open>
+        <CollapsibleTrigger
+          class="flex w-full items-center gap-1.5 px-2 py-1.5 text-[11px] tracking-wider text-muted uppercase hover:text-surface"
+        >
+          <icon-lucide-chevron-down
+            class="size-3 transition-transform [[data-state=closed]>&]:rotate-[-90deg]"
+          />
+          Components ({{ totalComponents }})
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <CollapsibleRoot v-for="group in filteredGroups" :key="group.page.id" default-open>
+            <CollapsibleTrigger
+              class="flex w-full items-center gap-1.5 px-2 py-1 text-[10px] tracking-wider text-muted hover:text-surface"
+            >
+              <icon-lucide-chevron-down
+                class="size-2.5 transition-transform [[data-state=closed]>&]:rotate-[-90deg]"
+              />
+              {{ group.page.name }}
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <template v-for="comp in group.components" :key="comp.id">
+                <CollapsibleRoot v-if="comp.type === 'COMPONENT_SET'" default-open>
+                  <AssetItem :node="comp" :thumbnail-url="thumbnails.get(comp.id)" is-set />
+                  <CollapsibleContent>
+                    <AssetItem
+                      v-for="variant in store.graph
+                        .getChildren(comp.id)
+                        .filter((c) => c.type === 'COMPONENT')"
+                      :key="variant.id"
+                      :node="variant"
+                      :thumbnail-url="thumbnails.get(variant.id)"
+                      indented
+                    />
+                  </CollapsibleContent>
+                </CollapsibleRoot>
+                <AssetItem v-else :node="comp" :thumbnail-url="thumbnails.get(comp.id)" />
+              </template>
+            </CollapsibleContent>
+          </CollapsibleRoot>
+        </CollapsibleContent>
+      </CollapsibleRoot>
+
+      <!-- Images section -->
+      <CollapsibleRoot v-if="filteredImages.length > 0" default-open>
+        <CollapsibleTrigger
+          class="flex w-full items-center gap-1.5 px-2 py-1.5 text-[11px] tracking-wider text-muted uppercase hover:text-surface"
+        >
+          <icon-lucide-chevron-down
+            class="size-3 transition-transform [[data-state=closed]>&]:rotate-[-90deg]"
+          />
+          Images ({{ imageList.length }})
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <ImageAssetItem
+            v-for="img in filteredImages"
+            :key="img.hash"
+            :hash="img.hash"
+            :names="img.names"
+            :node-ids="img.nodeIds"
+            :thumbnail-url="img.url"
+          />
+        </CollapsibleContent>
+      </CollapsibleRoot>
+    </div>
+  </div>
+</template>

--- a/src/components/ImageAssetItem.vue
+++ b/src/components/ImageAssetItem.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import {
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuPortal,
+  ContextMenuRoot,
+  ContextMenuTrigger
+} from 'reka-ui'
+
+import { useEditorStore } from '@/stores/editor'
+
+const { hash, names, nodeIds, thumbnailUrl } = defineProps<{
+  hash: string
+  names: string[]
+  nodeIds: string[]
+  thumbnailUrl: string
+}>()
+
+const store = useEditorStore()
+
+const displayName = computed(() => {
+  if (names.length === 0) return hash.slice(0, 8) + '…'
+  if (names.length <= 2) return names.join(', ')
+  return `${names[0]}, ${names[1]} +${names.length - 2}`
+})
+
+function currentPageNodeIds() {
+  const descendants = new Set<string>()
+  const stack = store.graph.getChildren(store.state.currentPageId).map((n) => n.id)
+  while (stack.length > 0) {
+    const id = stack.pop()
+    if (!id) continue
+    descendants.add(id)
+    const node = store.graph.getNode(id)
+    if (node) stack.push(...node.childIds)
+  }
+  return nodeIds.filter((id) => descendants.has(id))
+}
+
+function selectUses() {
+  const ids = currentPageNodeIds()
+  if (ids.length > 0) store.state.selectedIds = new Set(ids)
+}
+
+function onDragStart(e: DragEvent) {
+  if (!e.dataTransfer) return
+  e.dataTransfer.setData('application/x-openpencil-image-asset', hash)
+  e.dataTransfer.effectAllowed = 'copy'
+}
+
+function placeAtCenter() {
+  const { x, y } = store.canvasViewportCenter()
+  store.placeImageFromHash(hash, x, y)
+}
+</script>
+
+<template>
+  <ContextMenuRoot>
+    <ContextMenuTrigger as-child>
+      <div
+        class="flex cursor-pointer items-center gap-2 rounded px-2 py-1 hover:bg-hover"
+        :draggable="true"
+        @dragstart="onDragStart"
+        @click="selectUses"
+      >
+        <div class="size-8 shrink-0 overflow-hidden rounded border border-border bg-canvas">
+          <img :src="thumbnailUrl" class="size-full object-cover" :alt="displayName" />
+        </div>
+        <icon-lucide-image class="size-3 shrink-0 text-muted" />
+        <span class="min-w-0 flex-1 truncate text-xs text-surface">{{ displayName }}</span>
+        <span v-if="nodeIds.length > 0" class="shrink-0 text-[10px] text-muted">
+          {{ nodeIds.length }}×
+        </span>
+      </div>
+    </ContextMenuTrigger>
+    <ContextMenuPortal>
+      <ContextMenuContent class="min-w-40 rounded-lg border border-border bg-panel p-1 shadow-lg">
+        <ContextMenuItem
+          class="cursor-pointer rounded px-2 py-1 text-xs text-surface hover:bg-hover"
+          @select="selectUses"
+        >
+          Select all uses
+        </ContextMenuItem>
+        <ContextMenuItem
+          class="cursor-pointer rounded px-2 py-1 text-xs text-surface hover:bg-hover"
+          @select="placeAtCenter"
+        >
+          Place copy on canvas
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenuPortal>
+  </ContextMenuRoot>
+</template>

--- a/src/components/LayerTree.vue
+++ b/src/components/LayerTree.vue
@@ -67,12 +67,22 @@ const COMPONENT_TYPES = new Set(['COMPONENT', 'COMPONENT_SET', 'INSTANCE'])
 
 function toggleNodeVisibility(id: string) {
   const node = store.graph.getNode(id)
-  if (node) store.updateNodeWithUndo(id, { visible: !node.visible }, node.visible ? 'Hide layer' : 'Show layer')
+  if (node)
+    store.updateNodeWithUndo(
+      id,
+      { visible: !node.visible },
+      node.visible ? 'Hide layer' : 'Show layer'
+    )
 }
 
 function toggleNodeLock(id: string) {
   const node = store.graph.getNode(id)
-  if (node) store.updateNodeWithUndo(id, { locked: !node.locked }, node.locked ? 'Unlock layer' : 'Lock layer')
+  if (node)
+    store.updateNodeWithUndo(
+      id,
+      { locked: !node.locked },
+      node.locked ? 'Unlock layer' : 'Lock layer'
+    )
 }
 
 function buildTree(parentId: string): LayerNode[] {
@@ -443,9 +453,7 @@ function updateDropTarget(ev: PointerEvent) {
                       v-if="item.value.locked"
                       class="size-3"
                       :class="
-                        store.state.selectedIds.has(item.value.id)
-                          ? 'text-white'
-                          : 'text-surface'
+                        store.state.selectedIds.has(item.value.id) ? 'text-white' : 'text-surface'
                       "
                     />
                     <icon-lucide-unlock
@@ -468,9 +476,7 @@ function updateDropTarget(ev: PointerEvent) {
                       v-if="!item.value.visible"
                       class="size-3"
                       :class="
-                        store.state.selectedIds.has(item.value.id)
-                          ? 'text-white'
-                          : 'text-surface'
+                        store.state.selectedIds.has(item.value.id) ? 'text-white' : 'text-surface'
                       "
                     />
                     <icon-lucide-eye

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -1,9 +1,22 @@
 <script setup lang="ts">
-import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from 'reka-ui'
+import {
+  SplitterGroup,
+  SplitterPanel,
+  SplitterResizeHandle,
+  TabsContent,
+  TabsList,
+  TabsRoot,
+  TabsTrigger
+} from 'reka-ui'
+
+import { useEditorStore } from '@/stores/editor'
 
 import AppMenu from './AppMenu.vue'
+import AssetsPanel from './AssetsPanel.vue'
 import LayerTree from './LayerTree.vue'
 import PagesPanel from './PagesPanel.vue'
+
+const store = useEditorStore()
 </script>
 
 <template>
@@ -28,13 +41,33 @@ import PagesPanel from './PagesPanel.vue'
         />
       </SplitterResizeHandle>
       <SplitterPanel :default-size="70" :min-size="20" class="flex flex-col overflow-hidden">
-        <header
-          data-test-id="layers-header"
-          class="shrink-0 px-3 py-2 text-[11px] tracking-wider text-muted uppercase"
-        >
-          Layers
-        </header>
-        <LayerTree data-test-id="layers-tree" />
+        <TabsRoot v-model="store.state.leftPanelTab" class="flex min-h-0 flex-1 flex-col">
+          <TabsList data-test-id="layers-header" class="flex shrink-0 items-center gap-2 px-3 py-2">
+            <TabsTrigger
+              value="layers"
+              class="text-[11px] tracking-wider text-muted uppercase hover:text-surface data-[state=active]:font-semibold data-[state=active]:text-surface"
+            >
+              Layers
+            </TabsTrigger>
+            <TabsTrigger
+              value="assets"
+              class="text-[11px] tracking-wider text-muted uppercase hover:text-surface data-[state=active]:font-semibold data-[state=active]:text-surface"
+            >
+              Assets
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent
+            value="layers"
+            class="flex min-h-0 flex-1 flex-col"
+            :force-mount="true"
+            :hidden="store.state.leftPanelTab !== 'layers'"
+          >
+            <LayerTree data-test-id="layers-tree" />
+          </TabsContent>
+          <TabsContent value="assets" class="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <AssetsPanel />
+          </TabsContent>
+        </TabsRoot>
       </SplitterPanel>
     </SplitterGroup>
   </aside>

--- a/src/components/properties/FillSection.vue
+++ b/src/components/properties/FillSection.vue
@@ -22,7 +22,17 @@ import { colorToCSS, colorToHexRaw } from '@open-pencil/core'
 import type { Fill, Variable, Color } from '@open-pencil/core'
 
 const { store } = useNodeProps()
-const { nodes, isMulti, active, activeNode, targetNodes, isArrayMixed, updateArrayItem, removeArrayItem, toggleArrayVisibility } = useMultiProps()
+const {
+  nodes,
+  isMulti,
+  active,
+  activeNode,
+  targetNodes,
+  isArrayMixed,
+  updateArrayItem,
+  removeArrayItem,
+  toggleArrayVisibility
+} = useMultiProps()
 
 const fillsAreMixed = computed(() => isArrayMixed('fills'))
 
@@ -60,7 +70,12 @@ function updateFill(index: number, fill: Fill) {
 }
 
 function updateOpacity(index: number, opacity: number) {
-  updateArrayItem('fills', index, { opacity: Math.max(0, Math.min(1, opacity / 100)) }, 'Change fill')
+  updateArrayItem(
+    'fills',
+    index,
+    { opacity: Math.max(0, Math.min(1, opacity / 100)) },
+    'Change fill'
+  )
 }
 
 function toggleVisibility(index: number) {
@@ -69,7 +84,9 @@ function toggleVisibility(index: number) {
 
 function add() {
   for (const n of targetNodes()) {
-    const fills = isMulti.value ? [{ ...DEFAULT_SHAPE_FILL }] : [...n.fills, { ...DEFAULT_SHAPE_FILL }]
+    const fills = isMulti.value
+      ? [{ ...DEFAULT_SHAPE_FILL }]
+      : [...n.fills, { ...DEFAULT_SHAPE_FILL }]
     store.updateNodeWithUndo(n.id, { fills }, isMulti.value ? 'Set fill' : 'Add fill')
   }
 }

--- a/src/components/properties/StrokeSection.vue
+++ b/src/components/properties/StrokeSection.vue
@@ -20,7 +20,17 @@ import type { Color, SceneNode, Stroke } from '@open-pencil/core'
 type StrokeSides = 'ALL' | 'TOP' | 'BOTTOM' | 'LEFT' | 'RIGHT' | 'CUSTOM'
 
 const { store } = useNodeProps()
-const { nodes, isMulti, active, activeNode, targetNodes, isArrayMixed, updateArrayItem, removeArrayItem, toggleArrayVisibility } = useMultiProps()
+const {
+  nodes,
+  isMulti,
+  active,
+  activeNode,
+  targetNodes,
+  isArrayMixed,
+  updateArrayItem,
+  removeArrayItem,
+  toggleArrayVisibility
+} = useMultiProps()
 
 const strokesAreMixed = computed(() => isArrayMixed('strokes'))
 
@@ -67,7 +77,12 @@ function updateWeight(index: number, weight: number) {
 }
 
 function updateOpacity(index: number, opacity: number) {
-  updateArrayItem('strokes', index, { opacity: Math.max(0, Math.min(1, opacity / 100)) }, 'Change stroke')
+  updateArrayItem(
+    'strokes',
+    index,
+    { opacity: Math.max(0, Math.min(1, opacity / 100)) },
+    'Change stroke'
+  )
 }
 
 function updateAlign(align: Stroke['align']) {

--- a/src/composables/use-canvas-drop.ts
+++ b/src/composables/use-canvas-drop.ts
@@ -3,22 +3,36 @@ import { ref, type Ref } from 'vue'
 
 import type { EditorStore } from '@/stores/editor'
 
-const ACCEPTED_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/avif'])
+const RASTER_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/avif'])
+const SVG_TYPE = 'image/svg+xml'
+const COMPONENT_MIME = 'application/x-openpencil-component'
+const IMAGE_ASSET_MIME = 'application/x-openpencil-image-asset'
+
+function isSVGFile(file: File): boolean {
+  return file.type === SVG_TYPE || file.name.endsWith('.svg')
+}
 
 export function useCanvasDrop(canvasRef: Ref<HTMLCanvasElement | null>, store: EditorStore) {
   const isDraggingOver = ref(false)
 
   useEventListener(canvasRef, 'dragover', (e: DragEvent) => {
-    if (!hasImageFiles(e)) return
+    if (hasComponentData(e) || hasImageAssetData(e)) {
+      e.preventDefault()
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
+      isDraggingOver.value = true
+      return
+    }
+    if (!hasDroppableFiles(e)) return
     e.preventDefault()
     if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
     isDraggingOver.value = true
   })
 
   useEventListener(canvasRef, 'dragenter', (e: DragEvent) => {
-    if (!hasImageFiles(e)) return
-    e.preventDefault()
-    isDraggingOver.value = true
+    if (hasComponentData(e) || hasImageAssetData(e) || hasDroppableFiles(e)) {
+      e.preventDefault()
+      isDraggingOver.value = true
+    }
   })
 
   useEventListener(canvasRef, 'dragleave', () => {
@@ -29,40 +43,83 @@ export function useCanvasDrop(canvasRef: Ref<HTMLCanvasElement | null>, store: E
     e.preventDefault()
     isDraggingOver.value = false
 
-    const files = filterImageFiles(e.dataTransfer?.files ?? null)
-    if (!files.length) return
+    const componentId = e.dataTransfer?.getData(COMPONENT_MIME)
+    if (componentId) {
+      const canvas = canvasRef.value
+      if (!canvas) return
+      const rect = canvas.getBoundingClientRect()
+      const { x, y } = store.screenToCanvas(e.clientX - rect.left, e.clientY - rect.top)
+      store.createInstanceFromComponent(componentId, x, y, store.state.currentPageId)
+      return
+    }
+
+    const imageHash = e.dataTransfer?.getData(IMAGE_ASSET_MIME)
+    if (imageHash) {
+      const canvas = canvasRef.value
+      if (!canvas) return
+      const rect = canvas.getBoundingClientRect()
+      const { x, y } = store.screenToCanvas(e.clientX - rect.left, e.clientY - rect.top)
+      store.placeImageFromHash(imageHash, x, y)
+      return
+    }
+
+    const allFiles = e.dataTransfer?.files
+    if (!allFiles || allFiles.length === 0) return
 
     const canvas = canvasRef.value
     if (!canvas) return
-
     const rect = canvas.getBoundingClientRect()
-    const sx = e.clientX - rect.left
-    const sy = e.clientY - rect.top
-    const { x: cx, y: cy } = store.screenToCanvas(sx, sy)
+    const { x: cx, y: cy } = store.screenToCanvas(e.clientX - rect.left, e.clientY - rect.top)
 
-    void store.placeImageFiles(files, cx, cy)
+    const svgFiles: File[] = []
+    const rasterFiles: File[] = []
+    for (const file of allFiles) {
+      if (isSVGFile(file)) svgFiles.push(file)
+      else if (RASTER_TYPES.has(file.type)) rasterFiles.push(file)
+    }
+
+    if (svgFiles.length > 0) {
+      void (async () => {
+        for (const file of svgFiles) {
+          const text = await file.text()
+          store.placeSVGFile(text, cx, cy, file.name)
+        }
+      })()
+    }
+
+    if (rasterFiles.length > 0) {
+      void store.placeImageFiles(rasterFiles, cx, cy)
+    }
   })
 
   return { isDraggingOver }
 }
 
-function hasImageFiles(e: DragEvent): boolean {
+function hasComponentData(e: DragEvent): boolean {
+  return e.dataTransfer?.types.includes(COMPONENT_MIME) ?? false
+}
+
+function hasImageAssetData(e: DragEvent): boolean {
+  return e.dataTransfer?.types.includes(IMAGE_ASSET_MIME) ?? false
+}
+
+function hasDroppableFiles(e: DragEvent): boolean {
   if (!e.dataTransfer?.types.includes('Files')) return false
   for (const item of e.dataTransfer.items) {
-    if (item.kind === 'file' && ACCEPTED_TYPES.has(item.type)) return true
+    if (item.kind === 'file' && (RASTER_TYPES.has(item.type) || item.type === SVG_TYPE)) return true
   }
   return false
 }
 
-function filterImageFiles(files: FileList | null): File[] {
+function filterRasterFiles(files: FileList | null): File[] {
   if (!files) return []
   const result: File[] = []
   for (const file of files) {
-    if (ACCEPTED_TYPES.has(file.type)) result.push(file)
+    if (RASTER_TYPES.has(file.type)) result.push(file)
   }
   return result
 }
 
 export function extractImageFilesFromClipboard(e: ClipboardEvent): File[] {
-  return filterImageFiles(e.clipboardData?.files ?? null)
+  return filterRasterFiles(e.clipboardData?.files ?? null)
 }

--- a/src/composables/use-canvas-input.ts
+++ b/src/composables/use-canvas-input.ts
@@ -497,9 +497,7 @@ export function useCanvasInput(
 
   function resolveHit(cx: number, cy: number): SceneNode | null {
     const titleHit =
-      hitTestFrameTitle(cx, cy) ??
-      hitTestSectionTitle(cx, cy) ??
-      hitTestComponentLabel(cx, cy)
+      hitTestFrameTitle(cx, cy) ?? hitTestSectionTitle(cx, cy) ?? hitTestComponentLabel(cx, cy)
     if (titleHit) return titleHit
 
     const hit = hitTestInScope(cx, cy, false)
@@ -681,9 +679,7 @@ export function useCanvasInput(
     cursorOverride.value = cursor
 
     const hit =
-      hitTestSectionTitle(cx, cy) ??
-      hitTestComponentLabel(cx, cy) ??
-      hitTestInScope(cx, cy, false)
+      hitTestSectionTitle(cx, cy) ?? hitTestComponentLabel(cx, cy) ?? hitTestInScope(cx, cy, false)
     store.setHoveredNode(hit && !store.state.selectedIds.has(hit.id) ? hit.id : null)
   }
 
@@ -1161,12 +1157,11 @@ export function useCanvasInput(
 
     const { cx, cy } = getCoords(e)
 
-    const selectedId = store.state.selectedIds.size === 1
-      ? [...store.state.selectedIds][0]
-      : undefined
+    const selectedId =
+      store.state.selectedIds.size === 1 ? [...store.state.selectedIds][0] : undefined
     const selectedNode = selectedId ? store.graph.getNode(selectedId) : undefined
-    const canEnter = selectedNode && selectedId
-      && store.graph.isContainer(selectedId) && !selectedNode.locked
+    const canEnter =
+      selectedNode && selectedId && store.graph.isContainer(selectedId) && !selectedNode.locked
 
     if (canEnter) {
       store.enterContainer(selectedId)
@@ -1180,9 +1175,8 @@ export function useCanvasInput(
       return
     }
 
-    const hit = hitTestSectionTitle(cx, cy) ??
-      hitTestComponentLabel(cx, cy) ??
-      hitTestInScope(cx, cy, true)
+    const hit =
+      hitTestSectionTitle(cx, cy) ?? hitTestComponentLabel(cx, cy) ?? hitTestInScope(cx, cy, true)
     if (!hit) return
 
     if (hit.type === 'TEXT') {

--- a/src/composables/use-collab.ts
+++ b/src/composables/use-collab.ts
@@ -12,9 +12,9 @@ import {
   ROOM_ID_CHARS,
   YJS_JSON_FIELDS
 } from '@/constants'
+import { randomIndex } from '@open-pencil/core'
 
 import type { EditorStore } from '@/stores/editor'
-import { randomIndex } from '@open-pencil/core'
 import type { Color, SceneNode } from '@open-pencil/core'
 import type { Room } from 'trystero'
 

--- a/src/composables/use-component-thumbnails.ts
+++ b/src/composables/use-component-thumbnails.ts
@@ -1,0 +1,82 @@
+import { watchDebounced } from '@vueuse/core'
+import { onScopeDispose, shallowRef, type Ref } from 'vue'
+
+import type { EditorStore } from '@/stores/editor'
+
+const BATCH_SIZE = 10
+
+export function useComponentThumbnails(store: EditorStore, componentIds: Ref<string[]>) {
+  const thumbnails = shallowRef(new Map<string, string>())
+  let pending = false
+  let needsRefresh = false
+
+  function refresh() {
+    if (pending) {
+      needsRefresh = true
+      return
+    }
+    pending = true
+
+    const oldMap = thumbnails.value
+    const currentIds = componentIds.value
+    const currentSet = new Set(currentIds)
+    const newMap = new Map<string, string>()
+
+    for (const [id, url] of oldMap) {
+      if (currentSet.has(id)) {
+        newMap.set(id, url)
+      } else {
+        URL.revokeObjectURL(url)
+      }
+    }
+
+    const toRender = currentIds.filter((id) => !newMap.has(id))
+    if (toRender.length === 0) {
+      thumbnails.value = newMap
+      pending = false
+      return
+    }
+
+    let i = 0
+    function renderBatch() {
+      const end = Math.min(i + BATCH_SIZE, toRender.length)
+      for (; i < end; i++) {
+        const id = toRender[i]
+        try {
+          const url = store.renderComponentThumbnail(id)
+          if (url) newMap.set(id, url)
+        } catch (e) {
+          console.warn('Thumbnail render failed:', e)
+        }
+      }
+      if (i < toRender.length) {
+        requestAnimationFrame(renderBatch)
+      } else {
+        thumbnails.value = new Map(newMap)
+        pending = false
+        if (needsRefresh) {
+          needsRefresh = false
+          refresh()
+        }
+      }
+    }
+    renderBatch()
+  }
+
+  function fullRefresh() {
+    for (const url of thumbnails.value.values()) URL.revokeObjectURL(url)
+    thumbnails.value = new Map()
+    pending = false
+    needsRefresh = false
+    refresh()
+  }
+
+  watchDebounced(componentIds, refresh, { debounce: 100, immediate: true })
+  watchDebounced(() => store.state.sceneVersion, fullRefresh, { debounce: 500 })
+
+  onScopeDispose(() => {
+    for (const url of thumbnails.value.values()) URL.revokeObjectURL(url)
+  })
+
+  return thumbnails
+}

--- a/src/composables/use-keyboard.ts
+++ b/src/composables/use-keyboard.ts
@@ -187,6 +187,11 @@ export function useKeyboard() {
   )
 
   // --- Plain keys (no modifiers) ---
+  function isInputFocused() {
+    const el = document.activeElement
+    return el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement
+  }
+
   function plain(key: string): ComputedRef<boolean> {
     return computed(
       () =>
@@ -194,7 +199,8 @@ export function useKeyboard() {
         !keys['meta'].value &&
         !keys['control'].value &&
         !keys['shift'].value &&
-        !keys['alt'].value
+        !keys['alt'].value &&
+        !isInputFocused()
     )
   }
 

--- a/src/composables/use-multi-props.ts
+++ b/src/composables/use-multi-props.ts
@@ -79,7 +79,11 @@ export function useMultiProps() {
       if (!items[index]) continue
       const arr = [...n[key]]
       arr[index] = { ...arr[index], visible: !items[index].visible }
-      store.updateNodeWithUndo(n.id, { [key]: arr } as Partial<SceneNode>, `Toggle ${key} visibility`)
+      store.updateNodeWithUndo(
+        n.id,
+        { [key]: arr } as Partial<SceneNode>,
+        `Toggle ${key} visibility`
+      )
     }
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -144,7 +144,7 @@ export const ACP_PERMISSION_TIMEOUT_MS = 60_000
 
 export const ACP_DESIGN_CONTEXT = `You are inside OpenPencil, an open-source design editor (like Figma). \
 Use the open-pencil MCP tools to create and modify designs on the live canvas. \
-Key tools: render (JSX to design), create_shape, set_fill, set_layout, find_nodes, get_page_tree, export_image. \
+Key tools: render (JSX to design), create_shape, set_fill, set_layout, find_nodes, get_page_tree, export_image, get_components (list reusable components), create_instance (insert component instance). \
 The render tool accepts JSX with components: Frame, Text, Rectangle, Ellipse, Icon, Group, Section. \
 Props: w, h, bg, flex, gap, p, rounded, color, size, weight, items, justify, stroke, opacity, shadow. \
 Do NOT write HTML files or use terminal commands — draw directly on the canvas using the MCP tools.`

--- a/src/stores/editor.ts
+++ b/src/stores/editor.ts
@@ -30,7 +30,9 @@ import {
   SceneGraph,
   setTextMeasurer,
   TextEditor,
-  UndoManager
+  UndoManager,
+  parseSVGFile,
+  createIconFromPaths
 } from '@open-pencil/core'
 
 import type {
@@ -205,7 +207,8 @@ export function createEditorStore() {
     mobileDrawerSnap: 'closed' as 'closed' | 'half' | 'full',
     clipboardHtml: '',
     autosaveEnabled: false,
-    enteredContainerId: null as string | null
+    enteredContainerId: null as string | null,
+    leftPanelTab: 'layers' as 'layers' | 'assets'
   })
 
   const AUTOSAVE_DELAY = 3000
@@ -712,6 +715,8 @@ export function createEditorStore() {
       subscribeToGraph()
       undo.clear()
       pageViewports.clear()
+      for (const url of _imageBlobCache.values()) URL.revokeObjectURL(url)
+      _imageBlobCache.clear()
       fileHandle = handle ?? null
       filePath = path ?? null
       state.documentName = file.name.replace(/\.fig$/i, '')
@@ -918,6 +923,25 @@ export function createEditorStore() {
       nodeIds.length > 0 ? nodeIds : graph.getChildren(state.currentPageId).map((n) => n.id)
     if (ids.length === 0) return null
     return renderNodesToImage(_ck, _renderer, graph, state.currentPageId, ids, { scale, format })
+  }
+
+  function renderComponentThumbnail(nodeId: string, size = 48): string | null {
+    if (!_ck || !_renderer) return null
+    const node = graph.getNode(nodeId)
+    if (!node || node.width <= 0 || node.height <= 0) return null
+    let pageNode: SceneNode | undefined = node
+    while (pageNode && pageNode.type !== 'CANVAS') {
+      pageNode = pageNode.parentId ? graph.getNode(pageNode.parentId) : undefined
+    }
+    if (!pageNode) return null
+    const maxDim = Math.max(node.width, node.height, 1)
+    const scale = Math.min(size / maxDim, 2)
+    const bytes = renderNodesToImage(_ck, _renderer, graph, pageNode.id, [nodeId], {
+      scale,
+      format: 'PNG' as ExportFormat
+    })
+    if (!bytes) return null
+    return URL.createObjectURL(new Blob([bytes.buffer as ArrayBuffer], { type: 'image/png' }))
   }
 
   function exportImageExtension(format: ExportFormat): string {
@@ -1522,11 +1546,16 @@ export function createEditorStore() {
     })
   }
 
-  function createInstanceFromComponent(componentId: string, x?: number, y?: number) {
+  function createInstanceFromComponent(
+    componentId: string,
+    x?: number,
+    y?: number,
+    targetPageId?: string
+  ) {
     const component = graph.getNode(componentId)
     if (component?.type !== 'COMPONENT') return null
 
-    const parentId = component.parentId ?? state.currentPageId
+    const parentId = targetPageId ?? component.parentId ?? state.currentPageId
     const instance = graph.createInstance(componentId, parentId, {
       x: x ?? component.x + component.width + 40,
       y: y ?? component.y
@@ -1571,29 +1600,31 @@ export function createEditorStore() {
     })
   }
 
-  function goToMainComponent() {
-    const node = selectedNode.value
-    if (!node?.componentId) return
-    const main = graph.getMainComponent(node.id)
-    if (!main) return
-
-    // Find which page the main component is on
-    let current: SceneNode | undefined = main
+  function focusNode(nodeId: string) {
+    const node = graph.getNode(nodeId)
+    if (!node) return
+    let current: SceneNode | undefined = node
     while (current && current.type !== 'CANVAS') {
       current = current.parentId ? graph.getNode(current.parentId) : undefined
     }
     if (current && current.id !== state.currentPageId) {
       void switchPage(current.id)
     }
-
-    state.selectedIds = new Set([main.id])
-
-    const abs = graph.getAbsolutePosition(main.id)
-    const viewW = 800
-    const viewH = 600
-    state.panX = viewW / 2 - (abs.x + main.width / 2) * state.zoom
-    state.panY = viewH / 2 - (abs.y + main.height / 2) * state.zoom
+    state.selectedIds = new Set([nodeId])
+    const abs = graph.getAbsolutePosition(nodeId)
+    const viewW = window.innerWidth
+    const viewH = window.innerHeight
+    state.panX = viewW / 2 - (abs.x + node.width / 2) * state.zoom
+    state.panY = viewH / 2 - (abs.y + node.height / 2) * state.zoom
     requestRender()
+  }
+
+  function goToMainComponent() {
+    const node = selectedNode.value
+    if (!node?.componentId) return
+    const main = graph.getMainComponent(node.id)
+    if (!main) return
+    focusNode(main.id)
   }
 
   function ungroupSelected() {
@@ -1791,6 +1822,44 @@ export function createEditorStore() {
     }
   }
 
+  const _imageBlobCache = new Map<string, string>()
+
+  function imageBlobUrl(hash: string): string | null {
+    const cached = _imageBlobCache.get(hash)
+    if (cached) {
+      if (graph.images.has(hash)) return cached
+      URL.revokeObjectURL(cached)
+      _imageBlobCache.delete(hash)
+      return null
+    }
+    const bytes = graph.images.get(hash)
+    if (!bytes) return null
+    const mime = detectImageMime(bytes)
+    const url = URL.createObjectURL(new Blob([bytes.buffer as ArrayBuffer], { type: mime }))
+    _imageBlobCache.set(hash, url)
+    return url
+  }
+
+  function detectImageMime(bytes: Uint8Array): string {
+    if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47)
+      return 'image/png'
+    if (bytes[0] === 0xff && bytes[1] === 0xd8) return 'image/jpeg'
+    if (
+      bytes[0] === 0x52 &&
+      bytes[1] === 0x49 &&
+      bytes[2] === 0x46 &&
+      bytes[3] === 0x46 &&
+      bytes[8] === 0x57 &&
+      bytes[9] === 0x45 &&
+      bytes[10] === 0x42 &&
+      bytes[11] === 0x50
+    )
+      return 'image/webp'
+    if (bytes[4] === 0x66 && bytes[5] === 0x74 && bytes[6] === 0x79 && bytes[7] === 0x70)
+      return 'image/avif'
+    return 'image/png'
+  }
+
   function decodeImageDimensions(bytes: Uint8Array): { w: number; h: number } | null {
     if (!_ck) return null
     const skImg = _ck.MakeImageFromEncoded(bytes)
@@ -1804,6 +1873,89 @@ export function createEditorStore() {
       h = Math.round(h * ratio)
     }
     return { w, h }
+  }
+
+  function placeSVGFile(svgText: string, x: number, y: number, name = 'SVG') {
+    const iconData = parseSVGFile(svgText)
+    if (iconData.paths.length === 0) return null
+    const w = iconData.width
+    const h = iconData.height
+    const color: Color = { r: 0, g: 0, b: 0, a: 1 }
+    const displayName = name.replace(/\.svg$/i, '')
+    const svgBytes = new TextEncoder().encode(svgText)
+    const svgHash = storeImage(svgBytes)
+    const frame = createIconFromPaths(
+      graph,
+      iconData,
+      displayName,
+      Math.max(w, h),
+      color,
+      state.currentPageId,
+      { x: x - w / 2, y: y - h / 2, width: w, height: h }
+    )
+    state.selectedIds = new Set([frame.id])
+    const frameId = frame.id
+    const childSnapshots = graph.getChildren(frame.id).map((c) => structuredClone(c))
+    const frameSnapshot = structuredClone(frame)
+    undo.push({
+      label: 'Place SVG',
+      forward: () => {
+        graph.images.set(svgHash, svgBytes)
+        const f = graph.createNode('FRAME', state.currentPageId, { ...frameSnapshot, childIds: [] })
+        for (const child of childSnapshots) {
+          graph.createNode(child.type, f.id, child)
+        }
+        state.selectedIds = new Set([frameId])
+      },
+      inverse: () => {
+        graph.deleteNode(frameId)
+        graph.images.delete(svgHash)
+        state.selectedIds = new Set()
+      }
+    })
+    requestRender()
+    return frameId
+  }
+
+  function placeImageFromHash(hash: string, x: number, y: number): string | null {
+    const bytes = graph.images.get(hash)
+    if (!bytes) return null
+    const dims = decodeImageDimensions(bytes)
+    const w = dims?.w ?? 200
+    const h = dims?.h ?? 200
+    const fill: Fill = {
+      type: 'IMAGE',
+      imageHash: hash,
+      imageScaleMode: 'FILL',
+      color: { r: 0, g: 0, b: 0, a: 0 },
+      opacity: 1,
+      visible: true
+    }
+    const node = graph.createNode('RECTANGLE', state.currentPageId, {
+      name: 'Image',
+      x: x - w / 2,
+      y: y - h / 2,
+      width: w,
+      height: h,
+      fills: [fill]
+    })
+    state.selectedIds = new Set([node.id])
+    const nodeId = node.id
+    const snapshot = structuredClone(node)
+    undo.push({
+      label: 'Place image',
+      forward: () => {
+        graph.images.set(hash, bytes)
+        graph.createNode('RECTANGLE', state.currentPageId, snapshot)
+        state.selectedIds = new Set([nodeId])
+      },
+      inverse: () => {
+        graph.deleteNode(nodeId)
+        state.selectedIds = new Set()
+      }
+    })
+    requestRender()
+    return nodeId
   }
 
   function storeImage(bytes: Uint8Array): string {
@@ -2038,8 +2190,9 @@ export function createEditorStore() {
           figma.blobs
         )
         if (created.length > 0) {
-          const cx = cursorPos?.x ?? (-state.panX + window.innerWidth / 2) / state.zoom
-          const cy = cursorPos?.y ?? (-state.panY + window.innerHeight / 2) / state.zoom
+          const center = canvasViewportCenter()
+          const cx = cursorPos?.x ?? center.x
+          const cy = cursorPos?.y ?? center.y
           centerNodesAt(created, cx, cy)
           computeAllLayouts(graph, state.currentPageId)
           state.selectedIds = new Set(created)
@@ -2293,6 +2446,15 @@ export function createEditorStore() {
     }
   }
 
+  function canvasViewportCenter() {
+    const el = document.querySelector<HTMLCanvasElement>('[data-test-id="canvas-element"]')
+    if (el) {
+      const rect = el.getBoundingClientRect()
+      return screenToCanvas(rect.width / 2, rect.height / 2)
+    }
+    return screenToCanvas(window.innerWidth / 2, window.innerHeight / 2)
+  }
+
   function applyZoom(delta: number, centerX: number, centerY: number) {
     const factor = Math.min(
       ZOOM_SCALE_MAX,
@@ -2438,6 +2600,12 @@ export function createEditorStore() {
     createInstanceFromComponent,
     detachInstance,
     goToMainComponent,
+    focusNode,
+    canvasViewportCenter,
+    renderComponentThumbnail,
+    imageBlobUrl,
+    placeSVGFile,
+    placeImageFromHash,
     bringToFront,
     sendToBack,
     toggleProfiler,

--- a/tests/engine/scene-graph.test.ts
+++ b/tests/engine/scene-graph.test.ts
@@ -403,3 +403,165 @@ describe('hitTest', () => {
     expect(graph.hitTest(450, 150, pageId(graph))).toBeNull()
   })
 })
+
+describe('getComponentsGroupedByPage', () => {
+  test('empty document returns empty array', () => {
+    const graph = new SceneGraph()
+    expect(graph.getComponentsGroupedByPage()).toEqual([])
+  })
+
+  test('one component on default page', () => {
+    const graph = new SceneGraph()
+    const comp = graph.createNode('COMPONENT', pageId(graph), { name: 'Button' })
+    const result = graph.getComponentsGroupedByPage()
+    expect(result).toHaveLength(1)
+    expect(result[0].page.id).toBe(pageId(graph))
+    expect(result[0].components).toHaveLength(1)
+    expect(result[0].components[0].id).toBe(comp.id)
+  })
+
+  test('components on two pages', () => {
+    const graph = new SceneGraph()
+    const comp1 = graph.createNode('COMPONENT', pageId(graph), { name: 'A' })
+    const page2 = graph.addPage('Page 2')
+    const comp2 = graph.createNode('COMPONENT', page2.id, { name: 'B' })
+    const result = graph.getComponentsGroupedByPage()
+    expect(result).toHaveLength(2)
+    expect(result[0].components[0].id).toBe(comp1.id)
+    expect(result[1].page.id).toBe(page2.id)
+    expect(result[1].components[0].id).toBe(comp2.id)
+  })
+
+  test('component nested inside a frame is found', () => {
+    const graph = new SceneGraph()
+    const frame = graph.createNode('FRAME', pageId(graph), { name: 'Container' })
+    const comp = graph.createNode('COMPONENT', frame.id, { name: 'Nested' })
+    const result = graph.getComponentsGroupedByPage()
+    expect(result).toHaveLength(1)
+    expect(result[0].components[0].id).toBe(comp.id)
+  })
+
+  test('COMPONENT_SET appears but not its children', () => {
+    const graph = new SceneGraph()
+    const set = graph.createNode('COMPONENT_SET', pageId(graph), { name: 'ButtonSet' })
+    graph.createNode('COMPONENT', set.id, { name: 'Button/Primary' })
+    graph.createNode('COMPONENT', set.id, { name: 'Button/Secondary' })
+    const result = graph.getComponentsGroupedByPage()
+    expect(result).toHaveLength(1)
+    expect(result[0].components).toHaveLength(1)
+    expect(result[0].components[0].id).toBe(set.id)
+  })
+
+  test('INSTANCE nodes are excluded', () => {
+    const graph = new SceneGraph()
+    const comp = graph.createNode('COMPONENT', pageId(graph), { name: 'Comp' })
+    graph.createInstance(comp.id, pageId(graph))
+    const result = graph.getComponentsGroupedByPage()
+    expect(result).toHaveLength(1)
+    expect(result[0].components).toHaveLength(1)
+    expect(result[0].components[0].type).toBe('COMPONENT')
+  })
+
+  test('page with only rectangles is omitted', () => {
+    const graph = new SceneGraph()
+    rect(graph, 'R1')
+    rect(graph, 'R2')
+    expect(graph.getComponentsGroupedByPage()).toEqual([])
+  })
+
+  test('component inside an instance is not found', () => {
+    const graph = new SceneGraph()
+    const comp = graph.createNode('COMPONENT', pageId(graph), { name: 'Comp' })
+    graph.createNode('RECTANGLE', comp.id, { name: 'Child' })
+    const inst = graph.createInstance(comp.id, pageId(graph))
+    if (inst) {
+      graph.createNode('COMPONENT', inst.id, { name: 'NestedInInstance' })
+    }
+    const result = graph.getComponentsGroupedByPage()
+    expect(result[0].components).toHaveLength(1)
+    expect(result[0].components[0].name).toBe('Comp')
+  })
+})
+
+describe('getImageUsages', () => {
+  const imgBytes = new Uint8Array([0x89, 0x50, 0x4E, 0x47])
+
+  function addImageFill(graph: SceneGraph, nodeId: string, hash: string) {
+    const node = graph.getNode(nodeId)
+    if (!node) return
+    graph.updateNode(nodeId, {
+      fills: [{ type: 'IMAGE', imageHash: hash, imageScaleMode: 'FILL', color: { r: 0, g: 0, b: 0, a: 0 }, opacity: 1, visible: true }]
+    })
+  }
+
+  test('no images returns empty map', () => {
+    const graph = new SceneGraph()
+    expect(graph.getImageUsages().size).toBe(0)
+  })
+
+  test('one image used by one node', () => {
+    const graph = new SceneGraph()
+    graph.images.set('hash1', imgBytes)
+    const r = rect(graph, 'Photo')
+    addImageFill(graph, r, 'hash1')
+    const usages = graph.getImageUsages()
+    expect(usages.size).toBe(1)
+    const entry = usages.get('hash1')
+    expect(entry?.nodeIds).toHaveLength(1)
+    expect(entry?.names).toEqual(['Photo'])
+  })
+
+  test('one image used by 3 nodes', () => {
+    const graph = new SceneGraph()
+    graph.images.set('hash1', imgBytes)
+    const r1 = rect(graph, 'A')
+    const r2 = rect(graph, 'B')
+    const r3 = rect(graph, 'C')
+    addImageFill(graph, r1, 'hash1')
+    addImageFill(graph, r2, 'hash1')
+    addImageFill(graph, r3, 'hash1')
+    const entry = graph.getImageUsages().get('hash1')
+    expect(entry?.nodeIds).toHaveLength(3)
+    expect(entry?.names).toEqual(['A', 'B', 'C'])
+  })
+
+  test('image stored but not referenced', () => {
+    const graph = new SceneGraph()
+    graph.images.set('unused', imgBytes)
+    rect(graph, 'Plain')
+    const entry = graph.getImageUsages().get('unused')
+    expect(entry?.nodeIds).toHaveLength(0)
+  })
+
+  test('two different images', () => {
+    const graph = new SceneGraph()
+    graph.images.set('h1', imgBytes)
+    graph.images.set('h2', imgBytes)
+    const r1 = rect(graph, 'A')
+    const r2 = rect(graph, 'B')
+    addImageFill(graph, r1, 'h1')
+    addImageFill(graph, r2, 'h2')
+    const usages = graph.getImageUsages()
+    expect(usages.size).toBe(2)
+    expect(usages.get('h1')?.nodeIds).toHaveLength(1)
+    expect(usages.get('h2')?.nodeIds).toHaveLength(1)
+  })
+
+  test('node with SOLID + IMAGE fill counts only IMAGE', () => {
+    const graph = new SceneGraph()
+    graph.images.set('hash1', imgBytes)
+    const r = rect(graph, 'Mixed')
+    const node = graph.getNode(r)
+    if (node) {
+      graph.updateNode(r, {
+        fills: [
+          { type: 'SOLID', color: { r: 1, g: 0, b: 0, a: 1 }, opacity: 1, visible: true },
+          { type: 'IMAGE', imageHash: 'hash1', imageScaleMode: 'FILL', color: { r: 0, g: 0, b: 0, a: 0 }, opacity: 1, visible: true }
+        ]
+      })
+    }
+    const entry = graph.getImageUsages().get('hash1')
+    expect(entry?.nodeIds).toHaveLength(1)
+    expect(entry?.names).toEqual(['Mixed'])
+  })
+})

--- a/tests/engine/svg-import.test.ts
+++ b/tests/engine/svg-import.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'bun:test'
+
+import { parseSVGFile } from '@open-pencil/core'
+
+describe('parseSVGFile', () => {
+  test('SVG with single path and viewBox', () => {
+    const svg = '<svg viewBox="0 0 100 100"><path d="M10 10L90 90"/></svg>'
+    const result = parseSVGFile(svg)
+    expect(result.width).toBe(100)
+    expect(result.height).toBe(100)
+    expect(result.paths).toHaveLength(1)
+    expect(result.paths[0].vectorNetwork.vertices.length).toBeGreaterThan(0)
+  })
+
+  test('SVG with circle and rect', () => {
+    const svg = '<svg viewBox="0 0 200 200"><circle cx="50" cy="50" r="30"/><rect x="100" y="100" width="50" height="50"/></svg>'
+    const result = parseSVGFile(svg)
+    expect(result.paths).toHaveLength(2)
+  })
+
+  test('SVG without viewBox uses width/height', () => {
+    const svg = '<svg width="64" height="64"><path d="M0 0L64 64"/></svg>'
+    const result = parseSVGFile(svg)
+    expect(result.width).toBe(64)
+    expect(result.height).toBe(64)
+    expect(result.paths).toHaveLength(1)
+  })
+
+  test('SVG with no shapes returns empty paths', () => {
+    const svg = '<svg viewBox="0 0 100 100"><text>Hello</text></svg>'
+    const result = parseSVGFile(svg)
+    expect(result.paths).toHaveLength(0)
+    expect(result.width).toBe(100)
+  })
+
+  test('SVG with viewBox offset translates paths', () => {
+    const svg = '<svg viewBox="10 10 80 80"><path d="M20 20L70 70"/></svg>'
+    const result = parseSVGFile(svg)
+    expect(result.paths).toHaveLength(1)
+    const v = result.paths[0].vectorNetwork.vertices
+    expect(v[0].x).toBe(10)
+    expect(v[0].y).toBe(10)
+  })
+
+  test('parseSVGFile with targetSize scales paths', () => {
+    const svg = '<svg viewBox="0 0 100 100"><path d="M0 0L100 100"/></svg>'
+    const result = parseSVGFile(svg, 50)
+    expect(result.width).toBe(50)
+    expect(result.height).toBe(50)
+    const v = result.paths[0].vectorNetwork.vertices
+    expect(v[v.length - 1].x).toBe(50)
+  })
+})


### PR DESCRIPTION
Fixes #152

Assets tab in the left sidebar — browse, search, and reuse components and images.

**Components section**
- Grouped by page, COMPONENT_SET variant expansion
- 48×48 CanvasKit thumbnails (batched rendering, blob URL lifecycle)
- Instance count badges, description tooltips
- Drag-to-canvas, double-click insert at viewport center, context menu

**Images section**
- All unique images from graph.images with thumbnails from raw bytes
- Usage count, click-to-select referencing nodes, drag-to-canvas

**SVG import**
- Drag .svg files from OS → parsed into FRAME+VECTOR nodes
- Extracted `extractPaths`/`parseSVGFile` pipeline from iconify.ts to shared `svg-import.ts`

**Viewport center fix**
- `canvasViewportCenter()` uses canvas element bounds, not window — accounts for sidebars

**Store additions:** focusNode, renderComponentThumbnail, imageBlobUrl, placeImageFromHash, placeSVGFile, canvasViewportCenter
**Core additions:** getComponentsGroupedByPage, getImageUsages, parseSVGFile, createIconFromPaths export

---

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [x] Tests added or updated
- [x] CHANGELOG.md updated (if user-facing)