### PR TITLE
Use `KeyboardEvent.code` instead of `KeyboardEvent.key` across editor and input handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- Fix shortcuts, now work on non-English keyboard layouts.
 - Fix imported `.fig` file open and page-switch regressions — loaded documents now keep graph/store state in sync, remap imported canvas/page children correctly, and recompute imported auto-layout descendants when switching pages
 - Fix imported text rendering in browser and headless export — preserve stored bounds until fonts are ready, restore missing font-loaded guards, use natural width for `WIDTH_AND_HEIGHT` text, and clip text to node bounds
 - Fix browser/headless rendering mismatch for imported toolbar/instance content by correcting runtime imported layout recomputation instead of diverging browser rendering behavior

--- a/packages/core/src/editor/types.ts
+++ b/packages/core/src/editor/types.ts
@@ -41,15 +41,15 @@ export const EDITOR_TOOLS: EditorToolDef[] = [
 ]
 
 export const TOOL_SHORTCUTS: Partial<Record<string, Tool>> = {
-  v: 'SELECT',
-  f: 'FRAME',
-  s: 'SECTION',
-  r: 'RECTANGLE',
-  o: 'ELLIPSE',
-  l: 'LINE',
-  t: 'TEXT',
-  p: 'PEN',
-  h: 'HAND'
+  KeyV: 'SELECT',
+  KeyF: 'FRAME',
+  KeyS: 'SECTION',
+  KeyR: 'RECTANGLE',
+  KeyO: 'ELLIPSE',
+  KeyL: 'LINE',
+  KeyT: 'TEXT',
+  KeyP: 'PEN',
+  KeyH: 'HAND'
 }
 
 export interface EditorState {

--- a/packages/vue/src/Canvas/useTextEdit.ts
+++ b/packages/vue/src/Canvas/useTextEdit.ts
@@ -115,11 +115,11 @@ export function useTextEdit(canvasRef: Ref<HTMLCanvasElement | null>, store: Edi
   function handleHorizontalArrow(e: KeyboardEvent, editor: NonNullable<typeof store.textEditor>) {
     const select = e.shiftKey
     const isMeta = e.metaKey || e.ctrlKey
-    if (e.key === 'ArrowLeft') {
+    if (e.code === 'ArrowLeft') {
       if (isMeta) editor.moveToLineStart(select)
       else if (e.altKey) editor.moveWordLeft(select)
       else editor.moveLeft(select)
-    } else {
+    } else if (e.code === 'ArrowRight') {
       if (isMeta) editor.moveToLineEnd(select)
       else if (e.altKey) editor.moveWordRight(select)
       else editor.moveRight(select)
@@ -132,7 +132,7 @@ export function useTextEdit(canvasRef: Ref<HTMLCanvasElement | null>, store: Edi
     node: SceneNode
   ) {
     const isMeta = e.metaKey || e.ctrlKey
-    const forward = e.key === 'Delete'
+    const forward = e.code === 'Delete'
     if (forward) {
       if (isMeta) editor.moveToLineEnd(true)
       else if (e.altKey) editor.moveWordRight(true)
@@ -145,13 +145,13 @@ export function useTextEdit(canvasRef: Ref<HTMLCanvasElement | null>, store: Edi
 
   type MetaAction = (node: SceneNode) => void
   const metaKeyActions: Partial<Record<string, MetaAction>> = {
-    a: () => store.textEditor?.selectAll(),
-    c: () => handleCopy(),
-    x: (node) => handleCut(node),
-    v: (node) => void handlePaste(node),
-    b: (node) => toggleBold(node),
-    i: (node) => toggleItalic(node),
-    u: (node) => toggleUnderline(node)
+    KeyA: () => store.textEditor?.selectAll(),
+    KeyC: () => handleCopy(),
+    KeyX: (node) => handleCut(node),
+    KeyV: (node) => void handlePaste(node),
+    KeyB: (node) => toggleBold(node),
+    KeyI: (node) => toggleItalic(node),
+    KeyU: (node) => toggleUnderline(node)
   }
 
   function onKeyDown(e: KeyboardEvent) {
@@ -163,7 +163,7 @@ export function useTextEdit(canvasRef: Ref<HTMLCanvasElement | null>, store: Edi
     const isMeta = e.metaKey || e.ctrlKey
     let textChanged = false
 
-    switch (e.key) {
+    switch (e.code) {
       case 'Escape':
         store.commitTextEdit()
         canvasRef.value?.focus()
@@ -196,7 +196,7 @@ export function useTextEdit(canvasRef: Ref<HTMLCanvasElement | null>, store: Edi
         break
       default: {
         if (!isMeta) return
-        const action = metaKeyActions[e.key]
+        const action = metaKeyActions[e.code]
         if (!action) return
         action(node)
         e.preventDefault()

--- a/packages/vue/src/ScrubInput/ScrubInputRoot.vue
+++ b/packages/vue/src/ScrubInput/ScrubInputRoot.vue
@@ -93,8 +93,8 @@ function commitEdit(e: Event) {
 }
 
 function onKeydown(e: KeyboardEvent) {
-  if (e.key === 'Enter') commitEdit(e)
-  else if (e.key === 'Escape') editing.value = false
+  if (e.code === 'Enter') commitEdit(e)
+  else if (e.code === 'Escape') editing.value = false
 }
 
 const ctx = {

--- a/packages/vue/src/shared/useInlineRename.ts
+++ b/packages/vue/src/shared/useInlineRename.ts
@@ -44,12 +44,12 @@ export function useInlineRename<T extends string>(onCommit: (id: T, newName: str
   }
 
   function onKeydown(e: KeyboardEvent) {
-    if (e.key === 'Enter') {
+    if (e.code === 'Enter') {
       ;(e.target as HTMLInputElement).blur()
       return
     }
 
-    if (e.key === 'Escape') {
+    if (e.code === 'Escape') {
       cancel()
     }
   }

--- a/src/composables/use-keyboard.ts
+++ b/src/composables/use-keyboard.ts
@@ -38,7 +38,7 @@ const PREVENT_MOD_ONLY = new Set([
   'KeyG'
 ])
 const PREVENT_SHIFT_ONLY = new Set(['Digit1', 'Digit2', 'KeyA'])
-const PREVENT_PLAIN_KEY = new Set(['[', ']'])
+const PREVENT_PLAIN_KEY = new Set(['BracketLeft', 'BracketRight'])
 const PREVENT_DELETE_KEY = new Set(['Backspace', 'Delete'])
 
 function shouldPreventDefault(e: KeyboardEvent, hasPenState: boolean): boolean {
@@ -50,10 +50,10 @@ function shouldPreventDefault(e: KeyboardEvent, hasPenState: boolean): boolean {
     if (!e.shiftKey && !e.altKey && PREVENT_MOD_ONLY.has(e.code)) return true
   } else {
     if (e.shiftKey && PREVENT_SHIFT_ONLY.has(e.code)) return true
-    if (!e.shiftKey && PREVENT_PLAIN_KEY.has(e.key)) return true
+    if (!e.shiftKey && PREVENT_PLAIN_KEY.has(e.code)) return true
   }
 
-  return PREVENT_DELETE_KEY.has(e.key) || (e.key === 'Enter' && hasPenState)
+  return PREVENT_DELETE_KEY.has(e.code) || (e.code === 'Enter' && hasPenState)
 }
 
 export function useKeyboard() {
@@ -95,7 +95,7 @@ export function useKeyboard() {
   })
 
   // Spacebar hold → temporary Hand tool (Figma-style canvas pan)
-  let toolBeforeSpace: (typeof store.state.activeTool) | null = null
+  let toolBeforeSpace: typeof store.state.activeTool | null = null
 
   useEventListener(window, 'keydown', (e: KeyboardEvent) => {
     if (isEditing(e)) return
@@ -124,7 +124,7 @@ export function useKeyboard() {
       if (store.state.editingTextId) return
 
       if (!e.metaKey && !e.ctrlKey && !e.altKey) {
-        const tool = TOOL_SHORTCUTS[e.key.toLowerCase()]
+        const tool = TOOL_SHORTCUTS[e.code]
         if (tool) {
           store.setTool(tool)
           return
@@ -226,14 +226,14 @@ export function useKeyboard() {
     )
   }
 
-  whenever(plain('bracketright'), () => runCommand('selection.bringToFront'))
-  whenever(plain('bracketleft'), () => runCommand('selection.sendToBack'))
-  whenever(plain('backspace'), () => runCommand('selection.delete'))
-  whenever(plain('delete'), () => runCommand('selection.delete'))
-  whenever(plain('enter'), () => {
+  whenever(plain('BracketRight'), () => runCommand('selection.bringToFront'))
+  whenever(plain('BracketLeft'), () => runCommand('selection.sendToBack'))
+  whenever(plain('Backspace'), () => runCommand('selection.delete'))
+  whenever(plain('Delete'), () => runCommand('selection.delete'))
+  whenever(plain('Enter'), () => {
     if (store.state.penState) store.penCommit(false)
   })
-  whenever(plain('escape'), () => {
+  whenever(plain('Escape'), () => {
     if (store.state.penState) {
       store.penCancel()
       return


### PR DESCRIPTION
Fixes #
Fix shortcuts, now work on non-English keyboard layouts.

---

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [ ] Tests added or updated
- [x] CHANGELOG.md updated (if user-facing)
