### PR TITLE
Add GLM-5.1 model id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Close open paths by dragging one endpoint to the other
 - Align selected anchor points relative to each other in vector edit mode — the standard alignment buttons in the position panel now operate on selected vertices when 2 or more are selected
 - Add GLM-5.1 model id to the z.ai provider
+- Add MiniMax M2.7 model id to the minimax provider
 
 ### Fixes
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -222,7 +222,9 @@ export const AI_PROVIDERS: AIProviderDef[] = [
     keyURL: 'https://platform.minimax.io/user-center/basic-information/interface-key',
     defaultModel: 'MiniMax-M2.5',
     models: [
-      { id: 'MiniMax-M2.5', name: 'MiniMax-M2.5', tag: 'Best' },
+      { id: 'MiniMax-M2.7', name: 'MiniMax-M2.7', tag: 'Best' },
+      { id: 'MiniMax-M2.7-highspeed', name: 'MiniMax-M2.7-highspeed', tag: 'Fast' },
+      { id: 'MiniMax-M2.5', name: 'MiniMax-M2.5' },
       { id: 'MiniMax-M2.5-highspeed', name: 'MiniMax-M2.5 Highspeed', tag: 'Fast' },
       { id: 'MiniMax-M2.1', name: 'MiniMax-M2.1' },
       { id: 'MiniMax-M2.1-highspeed', name: 'MiniMax-M2.1 Highspeed', tag: 'Fast' },


### PR DESCRIPTION
Adds the newly released models:
- GLM-5.1 (As of now the model only works on the Anthropic-compatible endpoint, so the model will not work right now)
- MiniMax-M2.7
- MiniMax-M2.7-highspeed
---

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [x] Tests added or updated
- [x] CHANGELOG.md updated (if user-facing)
