### PR TITLE
fix: add missing StackWrap enum and fields to kiwi schema

### DIFF
--- a/packages/core/src/kiwi/schema.ts
+++ b/packages/core/src/kiwi/schema.ts
@@ -314,6 +314,7 @@ enum StackAlign {
   CENTER = 1;
   MAX = 2;
   BASELINE = 3;
+  STRETCH = 4;
 }
 
 enum StackCounterAlign {
@@ -341,6 +342,11 @@ enum StackSize {
 enum StackPositioning {
   AUTO = 0;
   ABSOLUTE = 1;
+}
+
+enum StackWrap {
+  NO_WRAP = 0;
+  WRAP = 1;
 }
 
 enum ConnectionType {
@@ -1506,6 +1512,8 @@ message NodeChange {
   float gridColumnGap = 438;
   GridTrackSize[] gridColumnSizes = 474;
   GridTrackSize[] gridRowSizes = 475;
+  StackWrap stackWrap = 476;
+  float stackCounterSpacing = 477;
 }
 
 message VideoPlayback {


### PR DESCRIPTION
## Summary

- Add `StackWrap` enum (`NO_WRAP`, `WRAP`) to kiwi schema
- Add `stackWrap` (field 476) and `stackCounterSpacing` (field 477) to `NodeChange` message
- Add `STRETCH` value (4) to `StackAlign` enum

## Problem

`layoutWrap` (flex-wrap) and `counterAxisSpacing` (row-gap) are silently dropped when saving to `.fig` format. The serialize/deserialize code in `kiwi-serialize.ts` and `kiwi-convert.ts` already handles these fields correctly, but the kiwi binary schema didn't define them — so the encoder ignores them during encoding.

Any `.fig` file saved with wrap-enabled auto-layout frames loses wrap and row-gap on reload.

## Test plan

- [ ] Create a frame with `layoutWrap: 'WRAP'` and `counterAxisSpacing > 0`
- [ ] Save as `.fig`, reload, verify wrap and spacing are preserved
- [ ] Run `bun run test:unit` — existing tests should pass

Fixes #165