### PR TITLE
fix(vue): batch color picker drag updates into one undo entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix color picker dragging flooding the undo stack — fill/stroke/effect color and opacity drags now collapse into a single undo entry per interaction via debounced batching in `PropertyListRoot`
+
 ## 0.11.6 — 2026-04-08
 
 ### Fixes

--- a/packages/vue/src/PropertyList/PropertyListRoot.vue
+++ b/packages/vue/src/PropertyList/PropertyListRoot.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onBeforeUnmount } from 'vue'
 
 import { useEditor } from '@open-pencil/vue/context/editorContext'
 import { useNodeProps } from '@open-pencil/vue/controls/useNodeProps'
@@ -51,7 +51,35 @@ function targetNodes(): SceneNode[] {
   return activeNode.value ? [activeNode.value] : []
 }
 
+const BATCH_IDLE_MS = 300
+let batchKey: string | null = null
+let batchTimer: ReturnType<typeof setTimeout> | null = null
+
+function flushBatch() {
+  if (batchTimer !== null) {
+    clearTimeout(batchTimer)
+    batchTimer = null
+  }
+  if (batchKey !== null) {
+    editor.undo.commitBatch()
+    batchKey = null
+  }
+}
+
+function ensureBatch(key: string, label: string) {
+  if (batchKey !== key) {
+    flushBatch()
+    editor.undo.beginBatch(label)
+    batchKey = key
+  }
+  if (batchTimer !== null) clearTimeout(batchTimer)
+  batchTimer = setTimeout(flushBatch, BATCH_IDLE_MS)
+}
+
+onBeforeUnmount(flushBatch)
+
 function add(defaults: ArrayItemType) {
+  flushBatch()
   emit('add', defaults)
   for (const n of targetNodes()) {
     const arr = isMulti.value ? [defaults] : [...n[propKey], defaults]
@@ -64,6 +92,7 @@ function add(defaults: ArrayItemType) {
 }
 
 function remove(index: number) {
+  flushBatch()
   emit('remove', index)
   for (const n of targetNodes()) {
     editor.updateNodeWithUndo(
@@ -78,7 +107,11 @@ function remove(index: number) {
 
 function update(index: number, item: ArrayItemType) {
   emit('update', index, item)
-  for (const n of targetNodes()) {
+  const nodes = targetNodes()
+  if (nodes.length === 0) return
+  const key = `update:${propKey}:${index}:${nodes.map((n) => n.id).join(',')}`
+  ensureBatch(key, `Change ${propKey}`)
+  for (const n of nodes) {
     const arr = [...n[propKey]] as ArrayItemType[]
     arr[index] = item
     editor.updateNodeWithUndo(n.id, { [propKey]: arr } as Partial<SceneNode>, `Change ${propKey}`)
@@ -87,7 +120,11 @@ function update(index: number, item: ArrayItemType) {
 
 function patch(index: number, changes: Record<string, unknown>) {
   emit('patch', index, changes)
-  for (const n of targetNodes()) {
+  const nodes = targetNodes()
+  if (nodes.length === 0) return
+  const key = `patch:${propKey}:${index}:${nodes.map((n) => n.id).join(',')}`
+  ensureBatch(key, `Change ${propKey}`)
+  for (const n of nodes) {
     const arr = [...n[propKey]] as ArrayItemType[]
     arr[index] = { ...arr[index], ...changes } as ArrayItemType
     editor.updateNodeWithUndo(n.id, { [propKey]: arr } as Partial<SceneNode>, `Change ${propKey}`)
@@ -95,6 +132,7 @@ function patch(index: number, changes: Record<string, unknown>) {
 }
 
 function toggleVisibility(index: number) {
+  flushBatch()
   emit('toggleVisibility', index)
   const nodes = targetNodes()
   if (nodes.length === 0) return


### PR DESCRIPTION
Fixes #186

## Summary

Dragging a slider or the HSB color area in the fill/stroke/effect color picker currently pushes a new undo entry on every intermediate event, so a single conceptual color change produces dozens of entries and `Cmd+Z` no longer reverts it in one press.

`PropertyListRoot`'s `update()` and `patch()` call `editor.updateNodeWithUndo()` unconditionally. This PR wraps those two methods in a debounced begin/commit batch so rapid events collapse into a single undo entry per interaction.

## Approach

- Added an idle-timer-driven batch in `PropertyListRoot.vue` keyed by `(op, propKey, index, nodeIds)`.
- `ensureBatch(key, label)`: if the key differs from the active batch, flush the previous batch, call `editor.undo.beginBatch(label)`, and start a 300 ms idle timer. Subsequent calls with the same key reset the timer.
- `flushBatch()`: clears the timer and calls `editor.undo.commitBatch()`.
- Idle commit happens automatically after 300 ms of no new events, so a drag-and-release collapses into one entry.
- Key invalidation happens when `propKey`, index, or node selection changes mid-interaction, so two distinct color changes never merge.
- `add()`, `remove()`, and `toggleVisibility()` call `flushBatch()` before running, so button actions never get mixed into a pending drag batch.
- `onBeforeUnmount(flushBatch)` guarantees any pending batch is committed if the panel closes mid-drag.
- The existing explicit multi-node `beginBatch` in `toggleVisibility` is preserved. Its upfront `flushBatch()` ensures no nesting.

## Why `PropertyListRoot` and not the color picker components

- `fills`, `strokes`, and `effects` all share this same slot-provided `update`/`patch`, so a single fix covers every array-property color drag instead of threading debounce state down through `FillPicker` / `ColorPickerPanel` / `PickerSlider`.
- `toggleVisibility` already uses `beginBatch`/`commitBatch` in this file, so the pattern is consistent with existing code.
- The Reka UI color primitives don't need any changes.

## Testing

- `bun run check` — passes (lint + typecheck + vue-tsc). No new warnings or errors introduced.
- `bun test ./tests/engine/undo.test.ts ./tests/engine/undo-redo-sequence.test.ts ./tests/engine/undo-create-shape.test.ts ./tests/engine/mutation.test.ts` — 43 pass / 0 fail.
- No automated unit test added: the debounce/batch logic lives in the Vue component layer and there is currently no Vue component test harness under `tests/`. Happy to add one if the maintainers point me at a preferred setup.

### Manual test steps

1. **Single drag → single undo**: drag the hue or alpha slider across its range, release, wait > 300 ms, press `Cmd+Z`. The fill should snap back to its pre-drag color.
2. **HSB area drag → single undo**: drag the 2-D color area in a loop, release, `Cmd+Z`. Fully reverted.
3. **Two consecutive color changes → two undo entries**: drag to color A, wait > 300 ms, drag to color B, wait > 300 ms. `Cmd+Z` undoes B; another `Cmd+Z` undoes A.
4. **Different fill indexes don't merge**: with multiple fills on a node, drag `fills[0]` then immediately drag `fills[1]` (no wait). Each produces its own undo entry because the batch key changes.
5. **Fills vs strokes don't merge**: drag a fill color, then drag a stroke color. Separate undo entries.
6. **Buttons flush pending drag**: drag a fill, then within 300 ms click the eye icon (toggle visibility) or the remove button. The drag commits as its own entry and the click is separate.
7. **Multi-node selection**: select multiple nodes, drag a fill color. One `Cmd+Z` reverts the color on all selected nodes.

## Known trade-off

If a user presses `Cmd+Z` within 300 ms of releasing a drag, the batch may not have committed yet, so the undo is delayed by up to 300 ms. Human reaction time after releasing a pointer drag is typically well above this, so it shouldn't be perceptible, and the idle window can be shortened or the keyboard undo handler can explicitly flush if this proves to be an issue in practice.

## Images
<h3>before</h3>
<img width="844" height="467" alt="SCR-20260410-msza" src="https://github.com/user-attachments/assets/3bdc6dbd-4e0e-4862-9707-50880e96d919" />
<img width="794" height="495" alt="SCR-20260410-mtzv" src="https://github.com/user-attachments/assets/189ce767-5adb-40da-871d-1cf471495b21" />
<img width="819" height="512" alt="SCR-20260410-mucn" src="https://github.com/user-attachments/assets/b5d8abf6-e14b-4d23-9e83-0dd5f9f10a19" />



<h3>after<h3/>
<img width="844" height="467" alt="SCR-20260410-msza" src="https://github.com/user-attachments/assets/3bdc6dbd-4e0e-4862-9707-50880e96d919" />
<img width="828" height="479" alt="SCR-20260410-mtgt" src="https://github.com/user-attachments/assets/55bf178c-abb8-4c00-b0c7-1d6db1b2e23b" />


**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [ ] Tests added or updated — N/A, see note above
- [x] CHANGELOG.md updated (Unreleased → Fixes)