### PR TITLE
fix: provider settings popover not opening on Windows

### DIFF
--- a/src/components/chat/ProviderSettings.vue
+++ b/src/components/chat/ProviderSettings.vue
@@ -95,14 +95,13 @@ function clearUnsplashKey() {
 
 <template>
   <PopoverRoot>
-    <Tip label="Provider settings">
       <PopoverTrigger
         data-test-id="provider-settings-trigger"
         class="rounded p-0.5 text-muted hover:bg-hover hover:text-surface"
+        title="Provider settings"
       >
         <icon-lucide-settings class="size-3" />
       </PopoverTrigger>
-    </Tip>
 
     <PopoverPortal>
       <PopoverContent


### PR DESCRIPTION
Fixes #171

## Problem

Clicking the gear icon (⚙️) in the AI chat panel does not open the provider settings popover on Windows 11 (Tauri / WebView2). The popover state changes to `data-state="open"` in the DOM, but it's positioned off-screen (`translate(0px, -200%)`).

## Root Cause

The `<PopoverTrigger>` is wrapped in a `<Tip>` component, which renders a reka-ui `TooltipRoot > TooltipTrigger as-child` around it. Two interactive reka-ui components (Tooltip + Popover) compete for the same DOM element — the tooltip intercepts pointer events before the popover can properly open, and the popper fails to calculate the trigger's position.

This works on macOS WebKit by coincidence due to different event propagation, but fails on Windows WebView2 (Edge-based).

## Fix

Remove the `<Tip>` wrapper from `ProviderSettings.vue` and use a native `title` attribute instead. This eliminates the component conflict — only the Popover handles the trigger element.