### PR TITLE
fix(app): support cmd/ctrl+click for layers panel multi-select

### DIFF
--- a/src/components/LayerTree.vue
+++ b/src/components/LayerTree.vue
@@ -66,7 +66,10 @@ function onLayerRightClick(e: MouseEvent) {
                 @select="
                   (e: CustomEvent) => {
                     e.preventDefault()
-                    selectNode(!!e.detail.originalEvent?.shiftKey)
+                    const orig = e.detail.originalEvent as
+                      | (MouseEvent & { metaKey?: boolean; ctrlKey?: boolean })
+                      | undefined
+                    selectNode(!!(orig?.shiftKey || orig?.metaKey || orig?.ctrlKey))
                   }
                 "
                 @toggle="


### PR DESCRIPTION
## Summary

Layers panel only treated **Shift+click** as additive (toggle) selection. **Cmd+click** (macOS) and **Ctrl+click** (Windows/Linux) had no effect — they replaced the selection with the single clicked layer, even when the user clearly intended to add to an existing selection.

This PR treats Shift / Cmd / Ctrl modifiers equally as additive toggle, matching common design tool conventions (Figma, Sketch).

## Change

`src/components/LayerTree.vue` — `TreeItem`'s `@select` handler now reads `metaKey` and `ctrlKey` in addition to `shiftKey`:

```diff
 @select="
   (e: CustomEvent) => {
     e.preventDefault()
-    selectNode(!!e.detail.originalEvent?.shiftKey)
+    const orig = e.detail.originalEvent as
+      | (MouseEvent & { metaKey?: boolean; ctrlKey?: boolean })
+      | undefined
+    selectNode(!!(orig?.shiftKey || orig?.metaKey || orig?.ctrlKey))
   }
 "
```

No changes to `packages/vue` — `LayerTreeItem`'s slot already accepts an `additive` flag from the caller, so the fix is a one-line behavioral change at the consumer.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://github.com/greekr4/open-pencil/releases/download/pr-assets-layer-multi-select/before.png) | ![after](https://github.com/greekr4/open-pencil/releases/download/pr-assets-layer-multi-select/after.png) |

## Test plan

- [x] `bun run check` — passes (pre-existing warnings unrelated)
- [x] `bun run format` — applied
- [x] `bun run test:dupes` — passes (0.81%, well under 3%)
- [x] `bun run test:unit` — 1 unrelated failure (`material3.fig variables roundtrip` timeout, pre-existing, unrelated to LayerTree)
- [x] Manual: Shift+click toggles, Cmd+click toggles (macOS), single click still replaces selection and enters container scope

## Notes

- Ctrl+click on macOS still triggers the OS-level context menu (expected/unchanged); Cmd is the macOS-native modifier.
- No new dependencies, no API changes.