### PR TITLE
feat(canvas): respect prefers-color-scheme: dark for new pages

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -11,6 +11,28 @@ export const SELECTION_COLOR = { r: 0.23, g: 0.51, b: 0.96, a: 1 } satisfies Col
 export const COMPONENT_COLOR = { r: 0.592, g: 0.278, b: 1, a: 1 } satisfies Color
 export const SNAP_COLOR = { r: 1.0, g: 0.0, b: 0.56, a: 1 } satisfies Color
 export const CANVAS_BG_COLOR = { r: 0.96, g: 0.96, b: 0.96, a: 1 } satisfies Color
+export const CANVAS_BG_COLOR_DARK = { r: 0.173, g: 0.173, b: 0.173, a: 1 } satisfies Color // #2c2c2c, Figma-ish dark canvas
+
+/**
+ * Returns the canvas background to initialize new pages with. Defers
+ * to the OS `prefers-color-scheme` so users on a dark desktop don't
+ * get a white flash every time they open a document.
+ *
+ * NOTE: this is deliberately the runtime/new-page path only. The
+ * `.fig` serialization path continues to write the static light
+ * `CANVAS_BG_COLOR` so files stay portable — a dark-theme user saving
+ * a file must not force darkness on recipients.
+ */
+export function getDefaultCanvasBgColor(): Color {
+  if (
+    IS_BROWSER &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  ) {
+    return CANVAS_BG_COLOR_DARK
+  }
+  return CANVAS_BG_COLOR
+}
 
 export const SNAP_THRESHOLD = 5
 

--- a/packages/core/src/editor/create.ts
+++ b/packages/core/src/editor/create.ts
@@ -1,5 +1,5 @@
 import { prefetchFigmaSchema } from '../clipboard'
-import { CANVAS_BG_COLOR, IS_BROWSER } from '../constants'
+import { getDefaultCanvasBgColor, IS_BROWSER } from '../constants'
 import { computeAllLayouts, computeLayout, setTextMeasurer } from '../layout'
 import { SceneGraph } from '../scene-graph'
 import { UndoManager } from '../scene-graph/undo'
@@ -42,7 +42,7 @@ export function createDefaultEditorState(pageId: string): EditorState {
     remoteCursors: [],
     documentName: 'Untitled',
     panX: 0,
-    pageColor: { ...CANVAS_BG_COLOR },
+    pageColor: { ...getDefaultCanvasBgColor() },
     panY: 0,
     zoom: 1,
     renderVersion: 0,

--- a/packages/core/src/editor/pages.ts
+++ b/packages/core/src/editor/pages.ts
@@ -1,4 +1,4 @@
-import { CANVAS_BG_COLOR } from '../constants'
+import { getDefaultCanvasBgColor } from '../constants'
 import { computeAllLayouts } from '../layout'
 import { collectFontKeys } from '../text/fonts'
 
@@ -40,7 +40,7 @@ export function createPageActions(ctx: EditorContext) {
       ctx.state.panX = 0
       ctx.state.panY = 0
       ctx.state.zoom = 1
-      ctx.state.pageColor = { ...CANVAS_BG_COLOR }
+      ctx.state.pageColor = { ...getDefaultCanvasBgColor() }
     }
 
     const toLoad = collectFontKeys(


### PR DESCRIPTION
## User Story

> As a designer working in low-light or with a dark OS theme, I want OpenPencil to start new pages with a dark canvas instead of pure white, so I'm not blinded every time I open the app and so OpenPencil visually fits into my desktop the way Figma's dark mode does.

## Acceptance Criteria

- [ ] Given my OS has `prefers-color-scheme: dark`, when I launch OpenPencil and a new page is created, then the canvas background renders at `#2c2c2c` (Figma dark-mode parity).
- [ ] Given my OS has `prefers-color-scheme: light` (or no preference), when I launch OpenPencil, then the canvas is unchanged from today (`#f5f5f5`).
- [ ] Given a dark-mode user saves a `.fig` file, when a light-mode user opens it later, then their canvas renders light — the file's `backgroundColor` is unchanged from current behaviour.
- [ ] The per-page `ColorInput` in the Properties panel still works as a manual override.

## Problem (today)

Launching OpenPencil on a dark desktop gets a pure-white `#f5f5f5` canvas flash into the user's dark environment — visually jarring, eye-straining in low light, and inconsistent with how Figma (and most modern design tools) behave. Upstream has no theme system at all: no user toggle, no `prefers-color-scheme` handling, no theme store. The canvas is always light regardless of the surrounding OS.

For a tool that competes on UX with Figma — which has shipped dark canvas for years — this is an immediate first-impression cost on every launch.

## Solution

Defer the initial canvas background of **newly-created pages** to the OS `prefers-color-scheme`. On dark systems, new pages start at `#2c2c2c` (matching Figma dark mode). On light systems, nothing changes.

Serialization stays untouched: the exported `.fig` `backgroundColor` continues to write the static light value, so files remain portable across users with different OS themes.

## Changes

| File | Change |
|---|---|
| `packages/core/src/constants.ts` | Add `CANVAS_BG_COLOR_DARK` (`#2c2c2c`) and `getDefaultCanvasBgColor()` helper. Existing `CANVAS_BG_COLOR` unchanged. |
| `packages/core/src/editor/create.ts` | Initial editor state now uses the helper. |
| `packages/core/src/editor/pages.ts` | Page-switch reset path now uses the helper. |

Deliberately untouched:

- `io/formats/fig/export.ts` — still writes the static light `CANVAS_BG_COLOR`. A dark-theme user's exports must not force darkness on recipients.
- `canvas/renderer.ts` fallback — only used when state is missing `pageColor`; effectively dead once `create.ts` runs.
- Per-page `ColorInput` in `PageSection.vue` remains the manual override.

## Why this approach

Considered alternatives:

- **Hard-flip the default to dark.** Simplest, but breaks every existing user's expectation. Unlikely to land upstream and not what they asked for anyway.
- **Add a full theme toggle in Settings.** Right answer eventually but a much bigger change (no Settings panel exists today). Defers solving the immediate first-impression pain. Reasonable as follow-on once a Settings panel lands.
- **Apply to every page color reset, including loaded files.** Would mutate the canvas of files saved on a light system when opened on a dark system, hiding the user's actual saved preference. Limited the change to *new* page initialization for that reason.

The split between "initial state" and "serialization" is the load-bearing decision: it lets us respect the user's OS without leaking that preference into shared files.

## How to verify

1. Set OS theme to dark (KDE: System Settings → Appearance → Global Theme; macOS: System Settings → Appearance → Dark).
2. Launch OpenPencil — new page canvas should render `#2c2c2c`.
3. `File → New` (when implemented) or page-switch — canvas is dark.
4. Toggle OS theme to light, relaunch — canvas is `#f5f5f5`.
5. On dark system, save a `.fig` file. Open it on a light-themed machine — canvas renders light (file's stored `backgroundColor` unaffected).
6. Open the per-page color picker in `PageSection.vue` — manual override still works.

Companion colors verified to read well on both backgrounds:

| Constant | Value | On dark |
|---|---|---|
| `RULER_BG_COLOR` (0.14) | ~`#242424` | ✓ slightly lighter, visible |
| `RULER_TICK_COLOR` (0.4) | mid-grey | ✓ high contrast |
| `RULER_TEXT_COLOR` (0.55) | light-grey | ✓ readable |
| `SELECTION_COLOR` | bright blue | ✓ high contrast |
| `SNAP_COLOR` | bright magenta | ✓ high contrast |
| `DEFAULT_FRAME_FILL` | white | ✓ artboards stay white as intended |

Tested on Arch Linux + KDE Plasma (dark + light) + WebKit2GTK 2.52.

## Out of scope

- User-facing theme toggle (no Settings panel exists yet — separate user story).
- Theming of the rest of the app chrome (header/panels) — already inherits from system GTK/WebKit and follows OS theme correctly.
- Aligning the dark value to a specific palette (we picked `#2c2c2c` for Figma muscle-memory parity; a maintainer may prefer a different shade — easy to tweak).