### PR TITLE
fix(toast): error toasts auto-dismiss + dedupe + cap stack

### DIFF
--- a/src/components/AppToast.vue
+++ b/src/components/AppToast.vue
@@ -16,7 +16,7 @@ const { copy, copied } = useClipboard({ copiedDuring: 1500 })
       v-for="t in toast.toasts.value"
       :key="t.id"
       data-test-id="toast-item"
-      :duration="t.variant === 'error' ? 0 : toast.TOAST_DURATION"
+      :duration="t.variant === 'error' ? toast.ERROR_TOAST_DURATION : toast.TOAST_DURATION"
       :class="useToastUI({ tone: t.variant }).base"
       @update:open="
         (open) => {
@@ -26,7 +26,9 @@ const { copy, copied } = useClipboard({ copiedDuring: 1500 })
     >
       <icon-lucide-check v-if="t.variant === 'default'" class="mt-0.5 size-3 shrink-0" />
       <icon-lucide-triangle-alert v-else class="mt-0.5 size-3 shrink-0" />
-      <ToastDescription class="min-w-0 flex-1 select-text">{{ t.message }}</ToastDescription>
+      <ToastDescription class="min-w-0 flex-1 select-text">
+        {{ t.message }}<span v-if="t.count > 1" class="ml-1.5 opacity-70">×{{ t.count }}</span>
+      </ToastDescription>
       <Tip v-if="t.variant === 'error'" :label="copied ? 'Copied!' : 'Copy error'">
         <button
           data-test-id="toast-copy-error"

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -7,24 +7,48 @@ export interface Toast {
   id: number
   message: string
   variant: ToastVariant
+  /** Number of times this message has been raised since it appeared. */
+  count: number
 }
 
 const TOAST_DURATION = 3000
+// Errors stay long enough to read but always self-clean, so a
+// stuck/repeating error source can't pile up over the canvas.
+const ERROR_TOAST_DURATION = 10000
+// Hard cap on stacked toasts. Older toasts drop off when a new one would
+// exceed this. Belt-and-suspenders against any error source we missed.
+const TOAST_STACK_LIMIT = 5
 
 const toasts = ref<Toast[]>([])
 let nextId = 0
 let errorHandlersInitialized = false
 
+function push(message: string, variant: ToastVariant) {
+  // Dedupe: if the same message+variant is already visible, increment
+  // its repeat count instead of stacking a duplicate. Prevents the
+  // cascade-on-every-frame failure mode where a single unhealthy
+  // event source floods the viewport.
+  const existing = toasts.value.find((t) => t.message === message && t.variant === variant)
+  if (existing) {
+    existing.count += 1
+    return
+  }
+  toasts.value.push({ id: ++nextId, message, variant, count: 1 })
+  if (toasts.value.length > TOAST_STACK_LIMIT) {
+    toasts.value.splice(0, toasts.value.length - TOAST_STACK_LIMIT)
+  }
+}
+
 function info(message: string) {
-  toasts.value.push({ id: ++nextId, message, variant: 'default' })
+  push(message, 'default')
 }
 
 function warning(message: string) {
-  toasts.value.push({ id: ++nextId, message, variant: 'warning' })
+  push(message, 'warning')
 }
 
 function error(message: string) {
-  toasts.value.push({ id: ++nextId, message, variant: 'error' })
+  push(message, 'error')
 }
 
 function remove(id: number) {
@@ -51,5 +75,6 @@ export const toast = {
   remove,
   toasts,
   setupGlobalErrorHandler,
-  TOAST_DURATION
+  TOAST_DURATION,
+  ERROR_TOAST_DURATION
 }


### PR DESCRIPTION
## User Story

> As a user driving the app through a long session, I want error toasts to clear themselves after I've had time to read them, and I never want a flood of identical errors to obscure my canvas — so a single repeating fault doesn't degrade the editor into an unrecoverable state requiring a restart.

## Acceptance Criteria

- [ ] Given an error is raised, when 10 seconds pass without user interaction, then the toast auto-dismisses (today: pinned forever).
- [ ] Given the same error message is raised N times in succession, when N > 1, then exactly **one** toast is shown with a count badge `×N` (today: N stacked duplicate toasts).
- [ ] Given more than 5 distinct errors are raised in quick succession, when a 6th would land, then the oldest visible toast is dropped so the stack never exceeds 5.
- [ ] Existing behaviour preserved: `info` / `warning` toasts auto-dismiss after `TOAST_DURATION` (3s); `error` toasts retain copy-error and close-button affordances; the close button works at any time before auto-dismiss.

## Problem (today)

`AppToast.vue:19`:

```ts
:duration=\"t.variant === 'error' ? 0 : toast.TOAST_DURATION\"
```

In `reka-ui` (Radix Toast), `duration: 0` means **never auto-dismiss**. Combined with `toast.ts:34-45`'s `setupGlobalErrorHandler` — which converts every `window.error` and `unhandledrejection` event into a toast — any error-emitting source can pile up indefinitely:

- A render-loop callback that throws on every frame creates a toast per frame.
- A wheel/zoom math error fires several toasts per scroll.
- Even one transient error sticks until the user precisely clicks a 12px × close button.

Real user report from a single session: two pinned errors (`forbidden path: ...`, `TypeError: undefined is not an object (evaluating 'o.x')`) covering the canvas, with the user reporting follow-on inability to zoom, pan, or backspace in the chat input. Those follow-on symptoms are likely cascade effects of the original render-loop exception re-firing into a swelling toast stack.

## Solution

Three small changes that compose:

1. **Errors auto-dismiss after 10 s** (`ERROR_TOAST_DURATION`). Long enough to read; short enough that a stuck error source self-cleans.
2. **Dedupe by `(message, variant)`**. Repeating the same error increments a `count` field on the existing toast and renders a `×N` badge instead of stacking duplicates. Prevents the cascade-on-every-frame failure mode.
3. **Hard cap at 5 stacked toasts**. Older toasts drop off when a 6th would arrive. Belt-and-suspenders for any error source the dedupe doesn't catch (e.g. errors with subtly-different messages from a single buggy code path).

## Changes

| File | Change |
|---|---|
| `src/utils/toast.ts` | Add `ERROR_TOAST_DURATION` (10 s) + `TOAST_STACK_LIMIT` (5). Extract `push()` helper that dedupes by `(message, variant)` and enforces the cap. `info`/`warning`/`error` route through it. `Toast.count: number` added (defaults to 1). |
| `src/components/AppToast.vue` | Use `ERROR_TOAST_DURATION` instead of `0` for error variant. Render `×N` badge when `count > 1`. |

## Why this approach

Considered alternatives:

- **Just give errors a long-but-finite duration without dedupe.** Solves the 'forever' part but a render-loop firing 60 errors/s would still pile to dozens before the first one clears. Dedupe is load-bearing.
- **Disable `setupGlobalErrorHandler` instead.** Removes the symptom but loses a real diagnostic — users *do* want to know when something silently broke. Keep the handler, just make it well-behaved.
- **Per-source rate limiting (token bucket).** More precise but heavier and harder to reason about. Dedupe-by-message + a hard cap captures the same intent with 30 lines.
- **Stop pinning `error`-variant toasts globally; emit them through a notification center / log panel instead.** Right answer eventually but a bigger product change. This PR is the minimal harm-reduction change while a full notification UX is designed.

## How to verify

**Reproduce the original failure first:**

1. Raise an unhandled rejection from inside the WebView (e.g. via WebKit Inspector console: `Promise.reject(new Error('test'))`).
2. Confirm a toast appears at top-center.
3. Wait 30 s without interacting. **Today:** toast still pinned. **After this PR:** toast auto-dismisses at 10 s.

**Verify dedupe:**

4. Raise the same error 5× in a row from the console: `for (let i = 0; i < 5; i++) Promise.reject(new Error('test'))`.
5. **Today:** 5 identical toasts stacked. **After this PR:** 1 toast with `×5` badge.

**Verify stack cap:**

6. Raise 7 *distinct* errors: `for (let i = 0; i < 7; i++) Promise.reject(new Error('err ' + i))`.
7. **After this PR:** at most 5 toasts visible; the 2 oldest were dropped.

**No regression:**

8. `info('hello')` / `warning('careful')` toasts still auto-dismiss at `TOAST_DURATION` (3 s).
9. The close-`×` button on error toasts still dismisses immediately.
10. The copy-error button on error toasts still copies the message.

### What I personally verified

- Code review of the diff (myself).
- `bun run lint` clean (no new errors).
- TypeScript narrowing handled correctly (`Toast.count` non-optional; `existing.count += 1` rather than `?? 1`).
- Built and ran the patched binary on Arch + KDE Plasma + WebKit2GTK 2.52 + Mesa 26 — no regression in normal use (canvas pan / zoom / save still work; clean MCP-driven session shows no spurious toasts).

### What I could not verify locally

I could not synthesise a `window.error` event from outside the WebView (Wayland blocks input synthesis without an installed `ydotool`/`wtype`, and the Tauri WebView's release-mode Inspector didn't expose evaluable targets at the JSON endpoint on my setup). The above test plan is the reproducible path; happy to add a Vitest unit test for `push()` if maintainers prefer in-tree verification.

## Out of scope

- Full notification-center UX (errors → log panel with history, badge in toolbar). Reasonable follow-on; not required for the immediate harm reduction.
- Source-aware error filtering (e.g. silence repeated WebKit warnings vs surface real Tauri-bridge failures). Would benefit from real telemetry on which errors are noise vs signal.
- The underlying `'o.x'` and `'tangentStart.x'` errors that triggered this discovery — those are real bugs and warrant their own issues. This PR is purely about the toast UX so the editor remains usable while those bugs exist.