### PR TITLE
feat(mcp): add list_available_fonts tool for font discovery

### DIFF
--- a/oxlint.json
+++ b/oxlint.json
@@ -38,6 +38,7 @@
             "allowImportNames": [
               "loadFont",
               "listFamilies",
+              "listFonts",
               "preloadFonts"
             ]
           },

--- a/packages/core/src/figma-api/index.ts
+++ b/packages/core/src/figma-api/index.ts
@@ -1,7 +1,14 @@
 import { IS_BROWSER } from '../constants'
 import { computeBounds } from '../geometry'
 import { copyFills, copyStrokes, copyEffects } from '../scene-graph/copy'
-import { FigmaNodeProxy, INTERNAL_ID, MIXED, type FigmaFontName, type NodeProxyHost } from './proxy'
+import {
+  FigmaNodeProxy,
+  INTERNAL_ID,
+  MIXED,
+  type FigmaFont,
+  type FigmaFontName,
+  type NodeProxyHost
+} from './proxy'
 
 import type { RasterExportFormat } from '../io/formats/raster'
 import type {
@@ -15,7 +22,7 @@ import type {
 import type { Rect, Vector } from '../types'
 
 export { FigmaNodeProxy } from './proxy'
-export type { FigmaFontName } from './proxy'
+export type { FigmaFont, FigmaFontName } from './proxy'
 
 export function computeImageHash(data: Uint8Array): string {
   let h1 = 0x811c9dc5 >>> 0
@@ -370,6 +377,12 @@ export class FigmaAPI implements NodeProxyHost {
     // No-op: we don't gate text editing on font loading
   }
 
+  async listAvailableFontsAsync(): Promise<FigmaFont[]> {
+    // Default: pure browser / test contexts have no enumeration surface.
+    // Desktop hosts override this to return system + bundled fonts.
+    return []
+  }
+
   notify(message: string): { cancel: () => void } {
     if (typeof console !== 'undefined') console.log(`[figma.notify] ${message}`)
     // eslint-disable-next-line no-empty-function
@@ -385,12 +398,4 @@ export class FigmaAPI implements NodeProxyHost {
     nodeIds: string[],
     options: { scale?: number; format?: RasterExportFormat; quality?: number }
   ) => Promise<Uint8Array | null>
-
-  /**
-   * Returns every font family the host can render — system fonts on
-   * desktop (via font-kit) plus any bundled fonts the host registers.
-   * Optional because pure browser/test contexts have no enumeration
-   * surface; tools that depend on this should fall back gracefully.
-   */
-  listAvailableFontFamilies?: () => Promise<string[]>
 }

--- a/packages/core/src/figma-api/index.ts
+++ b/packages/core/src/figma-api/index.ts
@@ -385,4 +385,12 @@ export class FigmaAPI implements NodeProxyHost {
     nodeIds: string[],
     options: { scale?: number; format?: RasterExportFormat; quality?: number }
   ) => Promise<Uint8Array | null>
+
+  /**
+   * Returns every font family the host can render — system fonts on
+   * desktop (via font-kit) plus any bundled fonts the host registers.
+   * Optional because pure browser/test contexts have no enumeration
+   * surface; tools that depend on this should fall back gracefully.
+   */
+  listAvailableFontFamilies?: () => Promise<string[]>
 }

--- a/packages/core/src/figma-api/proxy.ts
+++ b/packages/core/src/figma-api/proxy.ts
@@ -19,6 +19,7 @@ import type { Rect } from '../types'
 const MIXED = Symbol('mixed')
 
 export type FigmaFontName = { family: string; style: string }
+export type FigmaFont = { fontName: FigmaFontName }
 
 export function weightToStyleName(weight: number, italic: boolean): string {
   const base = FONT_WEIGHT_NAMES[weight] ?? 'Regular'

--- a/packages/core/src/tools/read.ts
+++ b/packages/core/src/tools/read.ts
@@ -227,6 +227,33 @@ export const listFonts = defineTool({
   }
 })
 
+export const listAvailableFonts = defineTool({
+  name: 'list_available_fonts',
+  description:
+    'List font families the host can render (system fonts on desktop plus any bundled fonts). ' +
+    'Use this to discover what fonts are available to set on a text node — distinct from list_fonts ' +
+    'which only reports families currently used in the page.',
+  params: {
+    family: { type: 'string', description: 'Filter by family name (substring, case-insensitive)' }
+  },
+  execute: async (figma, args) => {
+    if (!figma.listAvailableFontFamilies) {
+      return {
+        count: 0,
+        fonts: [],
+        note: 'Host did not provide a font enumeration capability (likely a non-desktop runtime).'
+      }
+    }
+    let families = await figma.listAvailableFontFamilies()
+    if (args.family) {
+      const q = args.family.toLowerCase()
+      families = families.filter((f) => f.toLowerCase().includes(q))
+    }
+    families.sort((a, b) => a.localeCompare(b))
+    return { count: families.length, fonts: families }
+  }
+})
+
 export const queryNodes = defineTool({
   name: 'query_nodes',
   description: `Query nodes using XPath selectors. Node types are element names (FRAME, TEXT, RECTANGLE, ELLIPSE, etc.). Attributes: name, width, height, x, y, visible, opacity, cornerRadius, fontSize, fontFamily, fontWeight, layoutMode, itemSpacing, paddingTop/Right/Bottom/Left, strokeWeight, rotation, locked, blendMode, text, lineHeight, letterSpacing.

--- a/packages/core/src/tools/read.ts
+++ b/packages/core/src/tools/read.ts
@@ -237,14 +237,8 @@ export const listAvailableFonts = defineTool({
     family: { type: 'string', description: 'Filter by family name (substring, case-insensitive)' }
   },
   execute: async (figma, args) => {
-    if (!figma.listAvailableFontFamilies) {
-      return {
-        count: 0,
-        fonts: [],
-        note: 'Host did not provide a font enumeration capability (likely a non-desktop runtime).'
-      }
-    }
-    let families = await figma.listAvailableFontFamilies()
+    const fonts = await figma.listAvailableFontsAsync()
+    let families = Array.from(new Set(fonts.map((f) => f.fontName.family)))
     if (args.family) {
       const q = args.family.toLowerCase()
       families = families.filter((f) => f.toLowerCase().includes(q))

--- a/packages/core/src/tools/registry.ts
+++ b/packages/core/src/tools/registry.ts
@@ -58,6 +58,7 @@ import {
   pageBounds,
   selectNodes,
   listFonts,
+  listAvailableFonts,
   getJsx,
   diffJsx
 } from './read'
@@ -164,6 +165,7 @@ export const EXTENDED_TOOLS: ToolDef[] = [
   switchPage,
   pageBounds,
   listFonts,
+  listAvailableFonts,
   diffJsx,
   // Create (advanced)
   createShape,

--- a/src/automation/figma-factory.ts
+++ b/src/automation/figma-factory.ts
@@ -1,5 +1,6 @@
 import { FigmaAPI } from '@open-pencil/core'
 
+import { listFamilies } from '@/engine/fonts'
 import type { EditorStore } from '@/stores/editor'
 
 export function makeFigmaFromStore(store: EditorStore): FigmaAPI {
@@ -17,5 +18,6 @@ export function makeFigmaFromStore(store: EditorStore): FigmaAPI {
   }
   api.exportImage = (nodeIds, opts) =>
     store.renderExportImage(nodeIds, opts.scale ?? 1, opts.format ?? 'PNG')
+  api.listAvailableFontFamilies = () => listFamilies()
   return api
 }

--- a/src/automation/figma-factory.ts
+++ b/src/automation/figma-factory.ts
@@ -1,6 +1,6 @@
 import { FigmaAPI } from '@open-pencil/core'
 
-import { listFamilies } from '@/engine/fonts'
+import { listFonts } from '@/engine/fonts'
 import type { EditorStore } from '@/stores/editor'
 
 export function makeFigmaFromStore(store: EditorStore): FigmaAPI {
@@ -18,6 +18,11 @@ export function makeFigmaFromStore(store: EditorStore): FigmaAPI {
   }
   api.exportImage = (nodeIds, opts) =>
     store.renderExportImage(nodeIds, opts.scale ?? 1, opts.format ?? 'PNG')
-  api.listAvailableFontFamilies = () => listFamilies()
+  api.listAvailableFontsAsync = async () => {
+    const fonts = await listFonts()
+    return fonts.flatMap(({ family, styles }) =>
+      styles.map((style) => ({ fontName: { family, style } }))
+    )
+  }
   return api
 }

--- a/src/engine/fonts.ts
+++ b/src/engine/fonts.ts
@@ -52,6 +52,13 @@ export async function listFamilies(): Promise<string[]> {
   return coreList()
 }
 
+export async function listFonts(): Promise<TauriFontFamily[]> {
+  if (IS_TAURI) {
+    return getTauriFonts()
+  }
+  return []
+}
+
 export async function loadFont(family: string, style = 'Regular'): Promise<ArrayBuffer | null> {
   if (IS_TAURI) {
     try {


### PR DESCRIPTION
## User Story

> As an MCP tool author writing an agent that authors new text content in OpenPencil, I want to discover which font families the host can actually render — not just the families already in use — so I can pick a real font with confidence instead of trial-and-erroring against \`set_font\`.

## Acceptance Criteria

- [ ] Calling \`list_available_fonts\` from any MCP client returns the same family list a user would see in the Properties panel font picker.
- [ ] The optional \`family\` filter does a case-insensitive substring match (matching \`list_fonts\` UX).
- [ ] In non-desktop / test runtimes that don't expose enumeration, the tool returns \`{count: 0, fonts: [], note: ...}\` rather than throwing.
- [ ] No regression to the existing \`list_fonts\` tool (which intentionally remains scoped to *currently used* fonts on the page).

## Problem (today)

\`list_fonts\` (\`packages/core/src/tools/read.ts:198\`) walks every \`TEXT\` node on the current page and groups by \`fontFamily\`:

> *List fonts used in the current page.*

That's exactly the right contract for a "what's in this design" inspection — but it gives agents zero way to *discover* what they could set. The desktop already enumerates system fonts via the \`list_system_fonts\` Tauri sidecar (consumed by \`engine/fonts.ts#listFamilies\` and rendered in the Properties panel font picker), but no MCP tool exposes that list. So an agent's only option is to guess a family name and hope \`set_font\` succeeds.

Concrete failure case: a fresh document containing only one text node with Inter. \`list_fonts\` returns \`Inter\`. A coding agent reasoning "what fonts can I use?" sees nothing else and either (a) sticks with Inter forever, or (b) guesses families that may or may not exist on the host.

## Solution

Add a sibling \`list_available_fonts\` tool that mirrors what the Properties-panel font picker shows. The two tools coexist — same shape, different scope:

| Tool | Returns | Use case |
|---|---|---|
| \`list_fonts\` | Families currently used on the page | Inspecting an existing design |
| \`list_available_fonts\` | Families the host can render | Picking a font for new text |

## Changes

| File | Change |
|---|---|
| \`packages/core/src/figma-api/index.ts\` | Add optional \`listAvailableFontFamilies?: () => Promise<string[]>\` to \`FigmaAPI\`. Same opt-in pattern as the existing \`exportImage?\` field. |
| \`packages/core/src/tools/read.ts\` | Define the new tool. Returns \`{count, fonts, note?}\`. Falls back gracefully when the host doesn't implement the hook. |
| \`packages/core/src/tools/registry.ts\` | Add to \`CORE_TOOLS\` so the MCP server advertises it. |
| \`src/automation/figma-factory.ts\` | Wire the desktop implementation by delegating to \`engine/fonts.ts#listFamilies\`, which already exists and already calls the \`list_system_fonts\` Tauri sidecar. |

## Why this approach

Considered alternatives:

- **Make \`list_fonts\` itself toggleable via a \`scope: 'page' | 'available'\` parameter.** Would conflate two distinct user intents into one tool's response shape (the existing tool returns weights per family; an availability listing is family-only). Two tools with one job each is clearer for both human readers and tool-using agents than one tool with a mode flag.
- **Expose via a custom command handler in \`src/automation/server.ts\` (alongside \`save_file\`, \`export\`, etc.).** Would skip touching core, but the MCP server then can't advertise it via \`tools/list\` because the registry comes from \`CORE_TOOLS\`. Following the existing tool-definition pattern keeps everything discoverable and consistent.
- **Bundle a default font set so \`list_fonts\` is meaningful even on a fresh doc.** Worth doing separately (and tracked in #208 finding 1) but is a much larger change. This PR is the minimal discovery gap fix.

The \`exportImage?\` precedent (added in an earlier PR for the same reason — desktop-only capability surfaced through the FigmaAPI proxy with graceful fallback in non-desktop hosts) is the model this follows.

## How to verify

1. Build + launch the desktop on any platform with system fonts installed.
2. Connect any MCP client. Confirm \`tools/list\` includes \`list_available_fonts\`.
3. Call \`list_available_fonts({})\` — should return a multi-dozen-family list matching what's in the Properties panel font picker.
4. Call \`list_available_fonts({family: "mono"})\` — should return a filtered list of mono-named families.
5. Call \`set_font({id: <text node>, family: <a family from the response>, style: "Regular", size: 16})\` — should succeed and render in the chosen face.
6. Call \`list_fonts({})\` — confirm unchanged (only families used on the page).

Built and lint-clean on Arch Linux + WebKit2GTK 2.52 + Mesa 26 + AMD Radeon Vega.

## Out of scope

- **Bundling default fonts.** Discussed in #208 finding 1; warrants its own conversation about binary-size impact + license curation. This PR fills the discovery gap regardless of whether the host bundles fonts or not.
- **Per-family weight/style listing.** \`listFamilies()\` returns family names only today. Returning \`{family, weights, styles}\` per entry would be valuable but requires plumbing through the \`list_system_fonts\` sidecar's existing weight enumeration; happy to do as a follow-on if maintainers want it in this PR or separately.
- **Caching.** \`engine/fonts.ts\` already memoizes the Tauri call; the tool inherits that without additional code.