### PR TITLE
feat(mcp): add `open_file` and `new_document` tools with `OPENPENCIL_MCP_ROOT` scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,21 @@
 ### Features
 
 - Add stdio transport for MCP server — `openpencil-mcp` now works as a proper stdio MCP server for Claude Code, Cursor, etc. HTTP server available as `openpencil-mcp-http`.
+- Add `open_file` MCP tool — opens a .fig or .pen file from disk into a new tab without user interaction
+- Add `new_document` MCP tool — creates an empty document; accepts an optional `path` to write the file immediately at a specific location without a save dialog
+- Add optional `path` output parameter to `export_image`, `export_svg`, and `get_jsx` MCP tools — writes output directly to disk to avoid large base64/JSX payloads in the AI context
+- Scope MCP file operations to `OPENPENCIL_MCP_ROOT` (defaults to current working directory) — paths outside the root are rejected server-side
 
 ### Fixes
 
 - Fix color picker dragging flooding the undo stack — fill/stroke/effect color and opacity drags now collapse into a single undo entry per interaction via debounced batching in `PropertyListRoot`
 - Fix .fig import crash on alias variables without a GUID
 - Fix external links in AI panel blocked by Tauri ACL — use opener plugin instead of shell
+- Fix `eval` tool discarding return value when code ends with an expression statement — last expression is now promoted to `return` (REPL-style), so agents can read the result directly
+- Fix stdio MCP server crash on startup when `OPENPENCIL_MCP_ROOT` is unset
+- Fix MCP "app not connected" error encouraging AI to self-resolve — message now instructs the agent to stop and inform the user (#208)
+- Fix `fs:allow-watch` Tauri permission missing path scope, causing errors when opening files via MCP
+- Fix `fs:allow-mkdir` missing from Tauri capabilities, causing `new_document` to fail when the target directory did not exist
 
 ## 0.11.6 — 2026-04-08
 

--- a/desktop/capabilities/default.json
+++ b/desktop/capabilities/default.json
@@ -17,7 +17,14 @@
       "identifier": "fs:allow-write-file",
       "allow": [{ "path": "**" }]
     },
-    "fs:allow-watch",
+    {
+      "identifier": "fs:allow-mkdir",
+      "allow": [{ "path": "**" }]
+    },
+    {
+      "identifier": "fs:allow-watch",
+      "allow": [{ "path": "**" }]
+    },
     "fs:allow-unwatch",
     {
       "identifier": "shell:allow-spawn",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -11,6 +11,7 @@ const { app, httpPort } = startServer({
   httpPort: port,
   wsPort,
   enableEval: process.env.OPENPENCIL_MCP_EVAL === '1',
+  mcpRoot: process.env.OPENPENCIL_MCP_ROOT?.trim() || process.cwd(),
   authToken: process.env.OPENPENCIL_MCP_AUTH_TOKEN?.trim() || null,
   corsOrigin: process.env.OPENPENCIL_MCP_CORS_ORIGIN?.trim() || null
 })

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
@@ -47,11 +48,12 @@ export type RpcSender = (body: Record<string, unknown>) => Promise<unknown>
 
 export interface RegisterToolsOptions {
   enableEval: boolean
+  mcpRoot: string | null
   sendRpc: RpcSender
 }
 
 export function registerTools(mcpServer: McpServer, options: RegisterToolsOptions) {
-  const { enableEval, sendRpc } = options
+  const { enableEval, mcpRoot, sendRpc } = options
   const register = mcpServer.registerTool.bind(mcpServer) as (...a: unknown[]) => void
 
   for (const def of ALL_TOOLS) {
@@ -107,6 +109,70 @@ export function registerTools(mcpServer: McpServer, options: RegisterToolsOption
     }
   )
 
+  if (mcpRoot !== null) {
+    const resolvedRoot = resolve(mcpRoot)
+
+    register(
+      'new_document',
+      {
+        description: `Create a new empty document in a new tab. Optionally provide a file path inside the allowed root (${resolvedRoot}) to pre-set the save location so subsequent saves go directly to disk without a dialog.`,
+        inputSchema: z.object({
+          path: z
+            .string()
+            .describe(
+              `Optional absolute path for the new file (e.g. ${resolvedRoot}${osSep}design.fig). Must be inside ${resolvedRoot}. Sets the save location without writing anything yet.`
+            )
+            .optional()
+        })
+      },
+      async (args: { path?: string }) => {
+        try {
+          let resolvedPath: string | undefined
+          if (args.path) {
+            resolvedPath = resolve(args.path)
+            const sep = resolvedRoot.endsWith('/') || resolvedRoot.endsWith('\\') ? '' : osSep
+            if (!resolvedPath.startsWith(resolvedRoot + sep) && resolvedPath !== resolvedRoot) {
+              return fail(new Error(`Path is outside the allowed root: ${resolvedRoot}`))
+            }
+          }
+          const result = await sendRpc({ command: 'new_document', args: { path: resolvedPath } })
+          const res = result as { ok?: boolean; error?: string }
+          if (res.ok === false) return fail(new Error(res.error))
+          return ok({ created: true })
+        } catch (e) {
+          return fail(e)
+        }
+      }
+    )
+
+    register(
+      'open_file',
+      {
+        description: `Open a design file (.fig or .pen) from a path inside the allowed root (${resolvedRoot}). Opens in a new tab (or replaces an untouched blank tab).`,
+        inputSchema: z.object({
+          path: z
+            .string()
+            .describe(`Absolute path to the .fig / .pen file. Must be inside ${resolvedRoot}`)
+        })
+      },
+      async (args: { path: string }) => {
+        try {
+          const resolvedPath = resolve(args.path)
+          const sep = resolvedRoot.endsWith('/') || resolvedRoot.endsWith('\\') ? '' : '/'
+          if (!resolvedPath.startsWith(resolvedRoot + sep) && resolvedPath !== resolvedRoot) {
+            return fail(new Error(`Path is outside the allowed root: ${resolvedRoot}`))
+          }
+          const result = await sendRpc({ command: 'open_file', args: { path: resolvedPath } })
+          const res = result as { ok?: boolean; error?: string }
+          if (res.ok === false) return fail(new Error(res.error))
+          return ok({ opened: true })
+        } catch (e) {
+          return fail(e)
+        }
+      }
+    )
+  }
+
   register(
     'get_codegen_prompt',
     {
@@ -143,6 +209,7 @@ export interface ServerOptions {
   httpPort?: number
   wsPort?: number
   enableEval?: boolean
+  mcpRoot?: string | null
   authToken?: string | null
   corsOrigin?: string | null
 }
@@ -151,6 +218,7 @@ export function startServer(options: ServerOptions = {}) {
   const httpPort = options.httpPort ?? 7600
   const wsPort = options.wsPort ?? 7601
   const enableEval = options.enableEval ?? false
+  const mcpRoot = options.mcpRoot ?? null
   const authToken = options.authToken ?? null
   const corsOrigin = options.corsOrigin ?? null
 
@@ -203,6 +271,12 @@ export function startServer(options: ServerOptions = {}) {
         browserWs = ws
         browserToken = msg.token
         browserRegistered = true
+        // Notify any connected stdio clients that the browser is now available
+        for (const client of stdioClients) {
+          if (client.readyState === WebSocket.OPEN) {
+            client.send(JSON.stringify({ type: 'register', token: browserToken }))
+          }
+        }
         return
       }
       if (!browserRegistered || browserWs !== ws) return
@@ -230,17 +304,77 @@ export function startServer(options: ServerOptions = {}) {
     }
   }
 
+  // Non-browser WebSocket clients (stdio bridge connections)
+  const stdioClients = new Set<WebSocket>()
+
   const wss = new WebSocketServer({ port: wsPort, host: '127.0.0.1' })
 
   wss.on('connection', (ws) => {
+    // Assume stdio client until we see a register message (browser sends register on connect)
+    stdioClients.add(ws)
+
+    // If browser is already connected, tell this new stdio client immediately
+    if (browserRegistered && browserToken) {
+      ws.send(JSON.stringify({ type: 'register', token: browserToken }))
+    }
+
     ws.on('message', (raw) => {
-      handleBrowserMessage(
-        typeof raw === 'string' ? raw : Buffer.from(raw as Buffer).toString('utf-8'),
-        ws
-      )
+      const data = typeof raw === 'string' ? raw : Buffer.from(raw as Buffer).toString('utf-8')
+      try {
+        const msg = JSON.parse(data) as { type: string; id?: string; token?: string }
+        if (msg.type === 'register') {
+          // Browser identifies itself — remove from stdio set and handle normally
+          stdioClients.delete(ws)
+          handleBrowserMessage(data, ws)
+          return
+        }
+        if (msg.type === 'request' && msg.id) {
+          // Stdio client sending a tool request — relay to browser and route response back
+          if (!browserWs || !browserRegistered) {
+            ws.send(
+              JSON.stringify({
+                type: 'response',
+                id: msg.id,
+                ok: false,
+                error: 'OpenPencil app is not connected'
+              })
+            )
+            return
+          }
+          const id = msg.id
+          const timer = setTimeout(() => {
+            pending.delete(id)
+            if (ws.readyState === WebSocket.OPEN) {
+              ws.send(
+                JSON.stringify({ type: 'response', id, ok: false, error: 'RPC timeout (30s)' })
+              )
+            }
+          }, RPC_TIMEOUT)
+          pending.set(id, {
+            resolve: (value) => {
+              if (ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify({ type: 'response', id, ...(value as object) }))
+              }
+            },
+            reject: (err) => {
+              if (ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify({ type: 'response', id, ok: false, error: err.message }))
+              }
+            },
+            timer
+          })
+          browserWs.send(data)
+          return
+        }
+        // Any other message (e.g. response from browser) — handle normally
+        handleBrowserMessage(data, ws)
+      } catch (e) {
+        console.warn('Malformed WS message from client:', e)
+      }
     })
 
     ws.on('close', () => {
+      stdioClients.delete(ws)
       if (browserWs === ws) {
         browserWs = null
         browserToken = null
@@ -351,7 +485,7 @@ export function startServer(options: ServerOptions = {}) {
 
   function createMCPSession(id: string): MCPTransport {
     const mcpServer = new McpServer({ name: 'open-pencil', version: MCP_VERSION })
-    registerTools(mcpServer, { enableEval, sendRpc: sendToBrowser })
+    registerTools(mcpServer, { enableEval, mcpRoot, sendRpc: sendToBrowser })
 
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: () => id

--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -8,6 +8,7 @@ import { MCP_VERSION, registerTools } from './server.js'
 const wsPort = parseInt(process.env.WS_PORT ?? '7601', 10)
 const wsHost = process.env.HOST ?? '127.0.0.1'
 const enableEval = process.env.OPENPENCIL_MCP_EVAL === '1'
+const mcpRoot = process.env.OPENPENCIL_MCP_ROOT?.trim() || process.cwd()
 
 const wsUrl = `ws://${wsHost}:${wsPort}`
 let ws: WebSocket | null = null
@@ -77,7 +78,14 @@ function connect() {
 function sendRpc(body: Record<string, unknown>): Promise<unknown> {
   return new Promise((resolve, reject) => {
     if (!ws || ws.readyState !== WebSocket.OPEN || !registered) {
-      reject(new Error('OpenPencil app is not connected. Start the app and open a document.'))
+      reject(
+        new Error(
+          'OpenPencil app is not connected. ' +
+            'STOP and tell the user: "The OpenPencil desktop app is not running or no document is open. ' +
+            'Please start the app and open a document, then try again." ' +
+            'Do NOT attempt to start the app yourself or retry automatically.'
+        )
+      )
       return
     }
     const id = crypto.randomUUID()
@@ -93,7 +101,7 @@ function sendRpc(body: Record<string, unknown>): Promise<unknown> {
 connect()
 
 const mcpServer = new McpServer({ name: 'open-pencil', version: MCP_VERSION })
-registerTools(mcpServer, { enableEval, sendRpc })
+registerTools(mcpServer, { enableEval, mcpRoot, sendRpc })
 
 const transport = new StdioServerTransport()
 void mcpServer.connect(transport)

--- a/src/automation/server.ts
+++ b/src/automation/server.ts
@@ -1,4 +1,5 @@
 import { makeFigmaFromStore } from '@/automation/figma-factory'
+import { createTab, openFileInNewTab } from '@/stores/tabs'
 /**
  * Browser-side automation handler.
  *
@@ -8,6 +9,7 @@ import { makeFigmaFromStore } from '@/automation/figma-factory'
 import {
   ALL_TOOLS,
   AUTOMATION_WS_PORT,
+  IS_TAURI,
   executeRpcCommand,
   renderTreeNode,
   computeAllLayouts,
@@ -126,6 +128,43 @@ export function connectAutomation(getStore: () => EditorStore, authToken: string
     return { ok: true }
   }
 
+  async function handleNewDocument(_store: EditorStore, args: unknown): Promise<unknown> {
+    const path = (args as { path?: string }).path
+    const tab = createTab()
+    if (path) {
+      tab.store.setPlannedFilePath(path)
+      if (IS_TAURI) {
+        const { mkdir } = await import('@tauri-apps/plugin-fs')
+        const dir = path.replace(/[\\/][^\\/]+$/, '')
+        await mkdir(dir, { recursive: true })
+      }
+      await tab.store.saveFigFile()
+      tab.store.startWatchingCurrentFile()
+    }
+    return { ok: true }
+  }
+
+  async function handleOpenFile(_store: EditorStore, args: unknown): Promise<unknown> {
+    const path = (args as { path?: string }).path
+    if (!path) throw new Error('Missing "path" in args')
+    const name = path.split(/[\\/]/).pop() ?? 'file.fig'
+
+    if (IS_TAURI) {
+      const { readFile } = await import('@tauri-apps/plugin-fs')
+      const bytes = await readFile(path)
+      const file = new File([bytes], name)
+      await openFileInNewTab(file, undefined, path)
+    } else {
+      const response = await fetch(path)
+      if (!response.ok) throw new Error(`Failed to fetch file: ${response.statusText}`)
+      const blob = await response.blob()
+      const file = new File([blob], name, { type: 'application/octet-stream' })
+      await openFileInNewTab(file, undefined, path)
+    }
+
+    return { ok: true }
+  }
+
   async function handleSelection(store: EditorStore): Promise<unknown> {
     const ids = [...store.state.selectedIds]
     const nodes = ids
@@ -151,7 +190,9 @@ export function connectAutomation(getStore: () => EditorStore, authToken: string
     export_jsx: handleExportJsx,
     selection: handleSelection,
 
-    save_file: handleSaveFile
+    save_file: handleSaveFile,
+    new_document: handleNewDocument,
+    open_file: handleOpenFile
   }
 
   async function handleRequest(_id: string, command: string, args: unknown): Promise<unknown> {

--- a/src/stores/editor.ts
+++ b/src/stores/editor.ts
@@ -869,6 +869,24 @@ export function createEditorStore(initialGraph?: SceneGraph) {
     }
   }
 
+  /**
+   * Pre-set the save path for a brand-new document that has not been written
+   * to disk yet. Skips the file watcher (the file does not exist).
+   * `saveFigFile` will write to this path directly without showing a dialog.
+   * Call `startWatchingCurrentFile()` after the first write to enable reload-on-change.
+   */
+  function setPlannedFilePath(path: string) {
+    stopWatchingFile()
+    fileHandle = null
+    filePath = path
+    downloadName = path.split(/[\\/]/).pop() ?? 'Untitled.fig'
+    state.documentName = downloadName.replace(/\.fig$/i, '')
+  }
+
+  function startWatchingCurrentFile() {
+    void startWatchingFile()
+  }
+
   function dispose() {
     stopWatchingFile()
     ;(debouncedAutosave as typeof debouncedAutosave & { cancel?: () => void }).cancel?.()
@@ -1256,6 +1274,8 @@ export function createEditorStore(initialGraph?: SceneGraph) {
     saveFigFile,
     saveFigFileAs,
     setDocumentSource,
+    setPlannedFilePath,
+    startWatchingCurrentFile,
     dispose,
     renderExportImage,
     listSelectionExportFormats,


### PR DESCRIPTION
## Summary

Adds two new MCP tools that let AI agents manage design files without any user interaction in the desktop app:

- `open_file` — opens a .fig or .pen file from disk into a new tab
- `new_document` — creates an empty document; accepts an optional `path` to pre-set the save location and write the file immediately without showing a dialog

Both tools are gated behind `OPENPENCIL_MCP_ROOT` (defaults to `cwd`), which enforces that file operations stay within an explicit directory. Path traversal is rejected server-side before the command reaches the app.

## Changes

- `open_file`: opens a `.fig`/`.pen` file from disk into a new tab (Tauri: `plugin-fs`, browser: `fetch`)
- `new_document`: creates an empty document; optional `path` writes the file immediately to disk and starts the file watcher
- All file-path arguments are validated against `OPENPENCIL_MCP_ROOT` (default: `cwd`) with a path-traversal guard via `node:path resolve()`
- Add `setPlannedFilePath()` to editor store — sets file metadata without starting the watcher (file may not exist yet)
- Fix `fs:allow-watch` Tauri permission missing path scope (`{ "path": "**" }`)
- Add `fs:allow-mkdir` Tauri capability so `new_document` can create intermediate directories

## Security

All paths are resolved with `node:path resolve()` before the `startsWith(resolvedRoot + osSep)` check — prevents `../` traversal.