### PR TITLE
fix(tauri): correctly configure NSAllowsLocalNetworking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,9 @@ bun install
 ```bash
 bun run dev          # Vite dev server on localhost:1420
 bun run tauri dev    # Tauri desktop app with hot reload
+
+# For macOS release builds with ad-hoc signing (no Apple Developer account, local testing only):
+APPLE_SIGNING_IDENTITY=- bun run tauri build
 ```
 
 ## Quality checks

--- a/desktop/Info.plist
+++ b/desktop/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>NSAppTransportSecurity</key>
+        <dict>
+            <key>NSAllowsLocalNetworking</key>
+            <true/>
+        </dict>
+    </dict>
+</plist>

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -32,12 +32,7 @@
       "icons/icon.ico"
     ],
     "macOS": {
-      "signingIdentity": "Developer ID Application: Danila Poyarkov (N7D7M3Q3CD)",
-      "info": {
-        "NSAppTransportSecurity": {
-          "NSAllowsLocalNetworking": true
-        }
-      }
+      "signingIdentity": "Developer ID Application: Danila Poyarkov (N7D7M3Q3CD)"
     }
   }
 }


### PR DESCRIPTION
The commit https://github.com/open-pencil/open-pencil/commit/837c09bd78511dae14df41c9650756d145fc53b9 introduced outright broken configuration.

This change reverts the broken fix and introduces what that commit attempted to.

Fixes #213