### PR TITLE
Fix Windows MCP bridge spawn

### DIFF
--- a/desktop/capabilities/default.json
+++ b/desktop/capabilities/default.json
@@ -32,7 +32,8 @@
         { "name": "claude-agent-acp", "cmd": "claude-agent-acp", "args": true },
         { "name": "codex-acp", "cmd": "codex-acp", "args": true },
         { "name": "gemini", "cmd": "gemini", "args": true },
-        { "name": "openpencil-mcp-http", "cmd": "openpencil-mcp-http", "args": true }
+        { "name": "openpencil-mcp-http", "cmd": "openpencil-mcp-http", "args": true },
+        { "name": "openpencil-mcp-http-cmd", "cmd": "cmd", "args": true }
       ]
     },
     "shell:allow-stdin-write",

--- a/src/automation/spawn-mcp.ts
+++ b/src/automation/spawn-mcp.ts
@@ -17,6 +17,25 @@ const noop = () => undefined
 
 let runtimeAutomationAuthToken: string | null = DEV_AUTOMATION_AUTH_TOKEN
 
+interface AutomationCommandSpec {
+  name: string
+  args: string[]
+}
+
+export function buildAutomationCommandSpec(userAgent = ''): AutomationCommandSpec {
+  const isWindows = /\bWindows\b/i.test(userAgent)
+  if (isWindows) {
+    return {
+      name: 'openpencil-mcp-http-cmd',
+      args: ['/d', '/c', 'openpencil-mcp-http']
+    }
+  }
+  return {
+    name: 'openpencil-mcp-http',
+    args: []
+  }
+}
+
 async function readHealth(): Promise<AutomationHealth | null> {
   try {
     const res = await fetch(`http://127.0.0.1:${AUTOMATION_HTTP_PORT}/health`, {
@@ -66,7 +85,8 @@ export async function spawnMCPIfNeeded(): Promise<AutomationServerHandle | null>
   runtimeAutomationAuthToken = authToken
 
   const { Command } = await import('@tauri-apps/plugin-shell')
-  const command = Command.create('openpencil-mcp-http', [], {
+  const commandSpec = buildAutomationCommandSpec(globalThis.navigator?.userAgent ?? '')
+  const command = Command.create(commandSpec.name, commandSpec.args, {
     env: {
       OPENPENCIL_MCP_AUTH_TOKEN: authToken,
       OPENPENCIL_MCP_CORS_ORIGIN: window.location.origin
@@ -96,6 +116,7 @@ export async function spawnMCPIfNeeded(): Promise<AutomationServerHandle | null>
 
   await child.kill()
   throw new Error(
-    'Failed to start MCP server. Is openpencil-mcp-http installed? Run: npm i -g @open-pencil/mcp'
+    'Failed to start MCP server. Ensure @open-pencil/mcp is installed globally. ' +
+      'On Windows, the desktop app may need to launch it via cmd.exe so the npm wrapper can resolve correctly.'
   )
 }

--- a/tests/engine/spawn-mcp.test.ts
+++ b/tests/engine/spawn-mcp.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test'
+
+import { buildAutomationCommandSpec } from '../../src/automation/spawn-mcp'
+
+describe('buildAutomationCommandSpec', () => {
+  test('uses bare command on non-Windows platforms', () => {
+    expect(buildAutomationCommandSpec('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')).toEqual({
+      name: 'openpencil-mcp-http',
+      args: []
+    })
+  })
+
+  test('uses cmd wrapper on Windows', () => {
+    expect(buildAutomationCommandSpec('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')).toEqual({
+      name: 'openpencil-mcp-http-cmd',
+      args: ['/d', '/c', 'openpencil-mcp-http']
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- make desktop automation bridge startup more robust on Windows by launching the npm wrapper via cmd /d /c
- add a small helper so the platform-specific command path is explicit and testable
- allow the Windows command alias in desktop shell capabilities

## Testing
- bun test tests/engine/spawn-mcp.test.ts
- bun test tests/engine/mcp-stdio.test.ts