### PR TITLE
Support MCP root saves on Unicode Windows paths

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -47,6 +47,12 @@ export function fail(e: unknown): MCPResult {
 
 export type RpcSender = (body: Record<string, unknown>) => Promise<unknown>
 
+interface RpcEnvelope {
+  ok?: boolean
+  result?: unknown
+  error?: string
+}
+
 export interface RegisterToolsOptions {
   enableEval: boolean
   mcpRoot?: string | null
@@ -90,6 +96,21 @@ export function registerTools(mcpServer: McpServer, options: RegisterToolsOption
     return null
   }
 
+  async function exportCurrentFig(root: string, filePath: string): Promise<MCPResult> {
+    const resolved = resolveSafePath(filePath, root)
+    const result = await sendRpc({ command: 'export_fig' })
+    const res = result as RpcEnvelope
+    if (res.ok === false) return fail(new Error(res.error))
+    const payload = res.result as { base64?: string } | undefined
+    if (!payload?.base64) {
+      return fail(new Error('OpenPencil app did not return fig data'))
+    }
+    await mkdir(dirname(resolved), { recursive: true })
+    const bytes = Buffer.from(payload.base64, 'base64')
+    await writeFile(resolved, bytes)
+    return ok({ written: resolved, byteLength: bytes.byteLength, saved: true })
+  }
+
   for (const def of ALL_TOOLS) {
     if (!enableEval && def.name === 'eval') continue
     const shape: Record<string, z.ZodType> = {}
@@ -102,7 +123,7 @@ export function registerTools(mcpServer: McpServer, options: RegisterToolsOption
       async (args: Record<string, unknown>) => {
         try {
           const result = await sendRpc({ command: 'tool', args: { name: def.name, args } })
-          const res = result as { ok?: boolean; result?: unknown; error?: string }
+          const res = result as RpcEnvelope
           if (res.ok === false) return fail(new Error(res.error))
           const r = res.result as Record<string, unknown> | undefined
           const filePath = typeof args.path === 'string' ? args.path : null
@@ -133,13 +154,22 @@ export function registerTools(mcpServer: McpServer, options: RegisterToolsOption
     'save_file',
     {
       description:
-        'Save the current document to disk. Uses the existing file path if available, otherwise prompts for a location.',
-      inputSchema: z.object({})
+        resolvedRoot
+          ? `Save the current document. If path is provided, write the .fig file inside ${resolvedRoot} using the MCP host filesystem.`
+          : 'Save the current document to disk. Uses the existing file path if available, otherwise prompts for a location.',
+      inputSchema: resolvedRoot
+        ? z.object({
+            path: z.string().describe('Optional absolute path for the .fig file').optional()
+          })
+        : z.object({})
     },
-    async () => {
+    async (args: { path?: string }) => {
       try {
+        if (resolvedRoot && args.path) {
+          return await exportCurrentFig(resolvedRoot, args.path)
+        }
         const result = await sendRpc({ command: 'save_file' })
-        const res = result as { ok?: boolean; error?: string }
+        const res = result as RpcEnvelope
         if (res.ok === false) return fail(new Error(res.error))
         return ok({ saved: true })
       } catch (e) {
@@ -182,8 +212,11 @@ export function registerTools(mcpServer: McpServer, options: RegisterToolsOption
         try {
           const safePath = args.path ? resolveSafePath(args.path, resolvedRoot) : undefined
           const result = await sendRpc({ command: 'new_document', args: { path: safePath } })
-          const res = result as { ok?: boolean; error?: string }
+          const res = result as RpcEnvelope
           if (res.ok === false) return fail(new Error(res.error))
+          if (safePath) {
+            return await exportCurrentFig(resolvedRoot, safePath)
+          }
           return ok({ created: true })
         } catch (e) {
           return fail(e)

--- a/src/automation/server.ts
+++ b/src/automation/server.ts
@@ -129,18 +129,18 @@ export function connectAutomation(getStore: () => EditorStore, authToken: string
     return { ok: true }
   }
 
+  async function handleExportFig(store: EditorStore): Promise<unknown> {
+    const data = await store.buildFigFile()
+    let binary = ''
+    for (const byte of data) binary += String.fromCharCode(byte)
+    return { ok: true, result: { base64: btoa(binary) } }
+  }
+
   async function handleNewDocument(_store: EditorStore, args: unknown): Promise<unknown> {
     const path = (args as { path?: string }).path
     const tab = createTab()
     if (path) {
       tab.store.setPlannedFilePath(path)
-      if (IS_TAURI) {
-        const { mkdir } = await import('@tauri-apps/plugin-fs')
-        const dir = path.replace(/[\\/][^\\/]+$/, '')
-        await mkdir(dir, { recursive: true })
-      }
-      await tab.store.saveFigFile()
-      tab.store.startWatchingCurrentFile()
     }
     return { ok: true }
   }
@@ -182,6 +182,7 @@ export function connectAutomation(getStore: () => EditorStore, authToken: string
     eval: handleEval,
     tool: handleTool,
     export: handleExport,
+    export_fig: handleExportFig,
     export_jsx: handleExportJsx,
     selection: handleSelection,
 

--- a/src/stores/editor.ts
+++ b/src/stores/editor.ts
@@ -1265,6 +1265,7 @@ export function createEditorStore(initialGraph?: SceneGraph) {
     nodeEditDeleteSelected,
     nodeEditBreakAtVertex,
     openFigFile,
+    buildFigFile,
     saveFigFile,
     saveFigFileAs,
     setDocumentSource,

--- a/tests/engine/mcp-server.test.ts
+++ b/tests/engine/mcp-server.test.ts
@@ -13,6 +13,9 @@ import {
   executeRpcCommand
 } from '@open-pencil/core'
 import { serve } from '@hono/node-server'
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import type { AddressInfo } from 'node:net'
 
@@ -51,9 +54,13 @@ function connectMockBrowser(port: number, graph: SceneGraph): Promise<MockBrowse
             api.currentPage = api.wrapNode(graph.getPages()[0].id)
             result = await def.execute(api, args.args ?? {})
             if (def.mutates) computeAllLayouts(graph)
-          } else {
-            result = executeRpcCommand(graph, command, args ?? {})
-          }
+        } else if (command === 'export_fig') {
+          result = { base64: Buffer.from('fig-bytes').toString('base64') }
+        } else if (command === 'new_document' || command === 'save_file' || command === 'open_file') {
+          result = {}
+        } else {
+          result = executeRpcCommand(graph, command, args ?? {})
+        }
 
           ws.send(JSON.stringify({ type: 'response', id: msg.id, ok: true, result }))
         } catch (e) {
@@ -249,6 +256,58 @@ describe('MCP server with mcpRoot', () => {
     const names = tools.map((t) => t.name)
     expect(names).toContain('open_file')
     expect(names).toContain('new_document')
+
+    await client.close()
+    browser.close()
+    closeServer()
+    httpServer.close()
+  })
+
+  test('new_document writes through the MCP host filesystem when path is provided', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-pencil-mcp-'))
+    const { app, wss, close: closeServer } = startServer({ httpPort: 0, wsPort: 0, mcpRoot: root })
+    const httpServer = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' })
+    const actualWsPort = await waitForWsListening(wss)
+
+    const graph = new SceneGraph()
+    const browser = await connectMockBrowser(actualWsPort, graph)
+
+    const client = new Client({ name: 'test-root-write', version: '0.0.0' })
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${(httpServer.address() as AddressInfo).port}/mcp`)
+    )
+    await client.connect(transport)
+
+    const filePath = join(root, 'nested', 'draft.fig')
+    const result = await client.callTool({ name: 'new_document', arguments: { path: filePath } })
+    expect(result.isError).not.toBe(true)
+    expect(await readFile(filePath, 'utf8')).toBe('fig-bytes')
+
+    await client.close()
+    browser.close()
+    closeServer()
+    httpServer.close()
+  })
+
+  test('save_file supports writing to an explicit MCP root path', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-pencil-mcp-'))
+    const { app, wss, close: closeServer } = startServer({ httpPort: 0, wsPort: 0, mcpRoot: root })
+    const httpServer = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' })
+    const actualWsPort = await waitForWsListening(wss)
+
+    const graph = new SceneGraph()
+    const browser = await connectMockBrowser(actualWsPort, graph)
+
+    const client = new Client({ name: 'test-root-save', version: '0.0.0' })
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${(httpServer.address() as AddressInfo).port}/mcp`)
+    )
+    await client.connect(transport)
+
+    const filePath = join(root, 'exports', 'saved.fig')
+    const result = await client.callTool({ name: 'save_file', arguments: { path: filePath } })
+    expect(result.isError).not.toBe(true)
+    expect(await readFile(filePath, 'utf8')).toBe('fig-bytes')
 
     await client.close()
     browser.close()


### PR DESCRIPTION
## Summary
- route MCP-root saves through the host filesystem instead of Tauri file writes
- add an automation command that exports the current .fig bytes directly from the live document
- make 
ew_document(path) and save_file(path) work in MCP-root workflows even when Windows desktop file APIs struggle with Unicode paths

## Why
On Windows, the desktop/Tauri file-writing path can fail for MCP automation when the target path contains non-ASCII characters. This patch keeps the design automation flow in the live app, but performs the actual file write in the MCP host process, which already handles Unicode paths correctly.

## Testing
- bun test tests/engine/mcp-server.test.ts