### PR TITLE
fix(canvas): apply dashPattern on VECTOR node strokes

### DIFF
--- a/packages/core/src/canvas/scene.ts
+++ b/packages/core/src/canvas/scene.ts
@@ -352,6 +352,18 @@ function drawVectorPathStrokes(
   stroke: SceneNode['strokes'][0],
   sc: Color
 ): void {
+  if (stroke.dashPattern && stroke.dashPattern.length > 0) {
+    r.strokePaint.setColor(r.ck.Color4f(sc.r, sc.g, sc.b, sc.a))
+    r.strokePaint.setAlphaf(stroke.opacity)
+    r.strokePaint.setStrokeWidth(stroke.weight)
+    r.strokePaint.setStrokeCap(getCapEntity(r, stroke.cap ?? 'NONE'))
+    r.strokePaint.setStrokeJoin(getJoinEntity(r, stroke.join ?? 'MITER'))
+    r.strokePaint.setShader(null)
+    r.strokePaint.setPathEffect(r.ck.PathEffect.MakeDash(stroke.dashPattern, 0))
+    for (const vp of vectorPaths) canvas.drawPath(vp, r.strokePaint)
+    r.strokePaint.setPathEffect(null)
+    return
+  }
   const strokeOpts = {
     width: stroke.weight,
     miter_limit: 4,
@@ -414,11 +426,12 @@ function drawNodeStroke(
   vectorPaths: Path[] | null,
   vectorStroke: Path[] | null
 ): void {
-  if (vectorStroke && stroke.align === 'CENTER' && node.cornerRadius === 0) {
+  const dashed = !!(stroke.dashPattern && stroke.dashPattern.length > 0)
+  if (vectorStroke && (dashed || (stroke.align === 'CENTER' && node.cornerRadius === 0))) {
     drawVectorPathStrokes(r, canvas, vectorStroke, stroke, sc)
     return
   }
-  if (!sg) {
+  if (!sg || (dashed && vectorPaths)) {
     if (vectorPaths) drawVectorPathStrokes(r, canvas, vectorPaths, stroke, sc)
     else drawRegularStroke(r, canvas, node, rect, hasRadius, stroke, sc)
     return


### PR DESCRIPTION
## Summary

`<Vector>` 노드에 `stroke.dashPattern`을 지정해도 캔버스에 항상 실선으로만 렌더되는 문제 수정.

## Root cause

일반 사각형 stroke 경로(`drawRegularStroke`)는 이미 `PathEffect.MakeDash`로 dashPattern을 적용한다 (`packages/core/src/canvas/scene.ts:392`). 그러나 VECTOR 노드는 별도의 두 경로를 탄다:

- `drawVectorStrokeGeometry` — precomputed `strokeGeometry`(이미 outline → fill로 변환된 path)를 fill로 그림
- `drawVectorPathStrokes` — `vp.copy().stroke(strokeOpts)`로 outline path를 만들어 fill로 그림

두 경로 모두 **stroke를 fill로 변환한 뒤 그리기 때문에** dash가 적용될 자리가 없다. Skia에서 dash는 stroke 스타일 paint의 PathEffect에 걸어야 동작한다.

## Fix

1. `drawVectorPathStrokes`에 dashPattern 분기 추가 — outline 변환을 건너뛰고 `strokePaint` + `PathEffect.MakeDash`로 `drawPath` 직접 호출.
2. `drawNodeStroke`에서 dashed면 precomputed strokeGeometry 경로를 우회하고 `vectorStroke`/`vectorPaths` 경로로 강제. (sg는 이미 fill이라 dash 불가.)

## Verification

`bun run check` (oxlint + tsgo + vue-tsc) 통과. `stroke.dashPattern`이 설정된 VECTOR 노드가 점선으로 렌더됨을 로컬 캔버스에서 확인.

## Scope

`packages/core/src/canvas/scene.ts` 한 파일, +15 / -2.