### PR TITLE
fix(vector): render dashPattern strokes correctly on closed crescents

### DIFF
--- a/packages/core/src/canvas/scene.ts
+++ b/packages/core/src/canvas/scene.ts
@@ -1,4 +1,5 @@
 import { DROP_HIGHLIGHT_ALPHA, DROP_HIGHLIGHT_STROKE, SECTION_CORNER_RADIUS } from '../constants'
+import { vectorNetworkToCenterlinePath } from '../vector'
 
 import type { SceneNode, SceneGraph } from '../scene-graph'
 import type { Color } from '../types'
@@ -352,6 +353,19 @@ function drawVectorPathStrokes(
   stroke: SceneNode['strokes'][0],
   sc: Color
 ): void {
+  const dash = stroke.dashPattern
+  if (dash && dash.length > 0) {
+    r.strokePaint.setColor(r.ck.Color4f(sc.r, sc.g, sc.b, sc.a))
+    r.strokePaint.setAlphaf(stroke.opacity)
+    r.strokePaint.setStrokeWidth(stroke.weight)
+    r.strokePaint.setStrokeCap(getCapEntity(r, stroke.cap ?? 'NONE'))
+    r.strokePaint.setStrokeJoin(getJoinEntity(r, stroke.join ?? 'MITER'))
+    r.strokePaint.setShader(null)
+    r.strokePaint.setPathEffect(r.ck.PathEffect.MakeDash(dash, 0))
+    for (const vp of vectorPaths) canvas.drawPath(vp, r.strokePaint)
+    r.strokePaint.setPathEffect(null)
+    return
+  }
   const strokeOpts = {
     width: stroke.weight,
     miter_limit: 4,
@@ -472,6 +486,18 @@ export function renderShapeUncached(
     const stroke = node.strokes[si]
     if (!stroke.visible) continue
     const sc = r.resolveStrokeColor(stroke, si, node, graph)
+
+    if (
+      stroke.dashPattern &&
+      stroke.dashPattern.length > 0 &&
+      node.type === 'VECTOR' &&
+      node.vectorNetwork
+    ) {
+      const centerline = vectorNetworkToCenterlinePath(r.ck, node.vectorNetwork)
+      drawVectorPathStrokes(r, canvas, [centerline], stroke, sc)
+      centerline.delete()
+      continue
+    }
 
     drawNodeStroke(r, canvas, node, rect, hasRadius, stroke, sc, sg, vectorPaths, vectorStroke)
   }

--- a/packages/core/src/design-jsx/renderer.ts
+++ b/packages/core/src/design-jsx/renderer.ts
@@ -79,6 +79,27 @@ function parseStroke(value: string, width: number): Stroke {
   }
 }
 
+function resolveDashPattern(value: unknown, strokeWidth: number): number[] | null {
+  if (Array.isArray(value)) {
+    const out = value.map((n) => Number(n)).filter((n) => Number.isFinite(n) && n > 0)
+    return out.length > 0 ? out : null
+  }
+  if (value === true) {
+    const d = Math.max(Math.round(strokeWidth * 2), 4)
+    return [d, d]
+  }
+  return null
+}
+
+function applyStrokeOverrides(props: Record<string, unknown>, o: Partial<SceneNode>): void {
+  if (typeof props.stroke !== 'string') return
+  const strokeWidth = (props.strokeWidth as number | undefined) ?? 1
+  const stroke = parseStroke(props.stroke, strokeWidth)
+  const dashPattern = resolveDashPattern(props.strokeDash, strokeWidth)
+  if (dashPattern) stroke.dashPattern = dashPattern
+  o.strokes = [stroke]
+}
+
 interface RenderOptions {
   x?: number
   y?: number
@@ -233,10 +254,7 @@ function applyVisualOverrides(props: Record<string, unknown>, o: Partial<SceneNo
     o.fills = [colorToFill(bg)]
   }
 
-  if (typeof props.stroke === 'string') {
-    const strokeWidth = (props.strokeWidth as number | undefined) ?? 1
-    o.strokes = [parseStroke(props.stroke, strokeWidth)]
-  }
+  applyStrokeOverrides(props, o)
 
   const rounded = props.rounded ?? props.cornerRadius
   if (typeof rounded === 'number') {

--- a/packages/core/src/design-jsx/tree.ts
+++ b/packages/core/src/design-jsx/tree.ts
@@ -115,6 +115,7 @@ export type StyleProps = {
   stroke?: string
   strokeWidth?: number
   strokeAlign?: 'inside' | 'outside' | 'center'
+  strokeDash?: number[] | boolean
   rounded?: number
   roundedTL?: number
   roundedTR?: number

--- a/packages/core/src/io/formats/jsx/export.ts
+++ b/packages/core/src/io/formats/jsx/export.ts
@@ -68,12 +68,16 @@ function solidFillColor(fills: Fill[]): string | null {
   return formatColor(visible[0].color, visible[0].opacity)
 }
 
-function solidStroke(strokes: Stroke[]): { color: string; weight: number } | null {
+function solidStroke(
+  strokes: Stroke[]
+): { color: string; weight: number; dash: number[] | null } | null {
   const visible = strokes.filter((s) => s.visible)
   if (visible.length !== 1) return null
+  const s = visible[0]
   return {
-    color: formatColor(visible[0].color, visible[0].opacity),
-    weight: visible[0].weight
+    color: formatColor(s.color, s.opacity),
+    weight: s.weight,
+    dash: s.dashPattern && s.dashPattern.length > 0 ? [...s.dashPattern] : null
   }
 }
 
@@ -284,6 +288,7 @@ function collectAppearanceProps(node: SceneNode, props: [string, unknown][]): vo
   if (stroke) {
     props.push(['stroke', stroke.color])
     if (stroke.weight !== 1) props.push(['strokeWidth', stroke.weight])
+    if (stroke.dash) props.push(['strokeDash', stroke.dash])
   }
 
   collectCornerRadiiProps(node, props)

--- a/packages/core/src/vector/index.ts
+++ b/packages/core/src/vector/index.ts
@@ -8,7 +8,7 @@ import type {
   VectorVertex,
   WindingRule
 } from '../scene-graph'
-import type { Rect } from '../types'
+import type { Rect, Vector } from '../types'
 import type { CanvasKit, Path } from 'canvaskit-wasm'
 
 // --- vectorNetworkBlob binary format ---
@@ -201,6 +201,212 @@ export function encodeVectorNetworkBlob(
   }
 
   return new Uint8Array(buf)
+}
+
+function fitCircleArc(
+  pts: Vector[]
+): { cx: number; cy: number; r: number; startAngleDeg: number; sweepDeg: number } | null {
+  if (pts.length < 3) return null
+  const p1 = pts[0]
+  const p2 = pts[Math.floor(pts.length / 2)]
+  const p3 = pts[pts.length - 1]
+  const ax = p2.x - p1.x
+  const ay = p2.y - p1.y
+  const bx = p3.x - p1.x
+  const by = p3.y - p1.y
+  const d = 2 * (ax * by - ay * bx)
+  if (Math.abs(d) < 1e-6) return null
+  const sqA = ax * ax + ay * ay
+  const sqB = bx * bx + by * by
+  const ux = (by * sqA - ay * sqB) / d
+  const uy = (ax * sqB - bx * sqA) / d
+  const cx = p1.x + ux
+  const cy = p1.y + uy
+  const r = Math.hypot(ux, uy)
+  if (!Number.isFinite(r) || r <= 0) return null
+
+  const tol = Math.max(0.5, r * 0.01)
+  for (const p of pts) {
+    if (Math.abs(Math.hypot(p.x - cx, p.y - cy) - r) > tol) return null
+  }
+
+  const startAngleDeg = (Math.atan2(p1.y - cy, p1.x - cx) * 180) / Math.PI
+  const endAngleDeg = (Math.atan2(p3.y - cy, p3.x - cx) * 180) / Math.PI
+  const midAngleDeg = (Math.atan2(p2.y - cy, p2.x - cx) * 180) / Math.PI
+
+  const norm = (a: number): number => ((a % 360) + 360) % 360
+  const sweepCW = norm(endAngleDeg - startAngleDeg)
+  const sweepCCW = -norm(startAngleDeg - endAngleDeg)
+  const midOnCW = norm(midAngleDeg - startAngleDeg) <= sweepCW
+  const sweepDeg = midOnCW ? sweepCW : sweepCCW
+
+  return { cx, cy, r, startAngleDeg, sweepDeg }
+}
+
+function isClosedThinCrescent(network: VectorNetwork): { ordered: number[] } | null {
+  const { vertices, segments } = network
+  const n = vertices.length
+  if (n < 6 || n % 2 !== 0 || segments.length !== n) return null
+
+  const adj = new Map<number, number[]>()
+  const ensure = (k: number): number[] => {
+    let v = adj.get(k)
+    if (!v) {
+      v = []
+      adj.set(k, v)
+    }
+    return v
+  }
+  for (let i = 0; i < segments.length; i++) {
+    const s = segments[i]
+    ensure(s.start).push(i)
+    ensure(s.end).push(i)
+  }
+  if (adj.size !== n) return null
+  for (const segs of adj.values()) {
+    if (segs.length !== 2) return null
+  }
+
+  const ordered: number[] = [0]
+  const visited = new Set<number>()
+  let current = 0
+  while (ordered.length < n) {
+    const segs = adj.get(current)
+    if (!segs) return null
+    const nextSeg = segs.find((s) => !visited.has(s))
+    if (nextSeg === undefined) return null
+    visited.add(nextSeg)
+    const seg = segments[nextSeg]
+    const next = seg.start === current ? seg.end : seg.start
+    ordered.push(next)
+    current = next
+  }
+
+  const half = n / 2
+  const paired: number[] = []
+  let alongSum = 0
+  for (let i = 0; i < half; i++) {
+    const a = vertices[ordered[i]]
+    const b = vertices[ordered[n - 1 - i]]
+    paired.push(Math.hypot(a.x - b.x, a.y - b.y))
+  }
+  for (let i = 0; i < half - 1; i++) {
+    const a = vertices[ordered[i]]
+    const b = vertices[ordered[i + 1]]
+    alongSum += Math.hypot(a.x - b.x, a.y - b.y)
+  }
+  if (alongSum <= 0) return null
+
+  const pairedAvg = paired.reduce((s, v) => s + v, 0) / half
+  if (pairedAvg > alongSum * 0.5) return null
+
+  const variance = paired.reduce((s, v) => s + (v - pairedAvg) ** 2, 0) / half
+  const stdDev = Math.sqrt(variance)
+  if (pairedAvg > 0 && stdDev / pairedAvg > 0.5) return null
+
+  return { ordered }
+}
+
+export function vectorNetworkToCenterlinePath(ck: CanvasKit, network: VectorNetwork): Path {
+  const { vertices, segments } = network
+
+  const crescent = isClosedThinCrescent(network)
+  if (crescent) {
+    const { ordered } = crescent
+    const cycleLen = ordered.length
+
+    const segDir = (i: number): Vector => {
+      const a = vertices[ordered[i]]
+      const b = vertices[ordered[(i + 1) % cycleLen]]
+      const dx = b.x - a.x
+      const dy = b.y - a.y
+      const m = Math.hypot(dx, dy) || 1
+      return { x: dx / m, y: dy / m }
+    }
+    const angleChangeAtVertex = (i: number): number => {
+      const dIn = segDir((i - 1 + cycleLen) % cycleLen)
+      const dOut = segDir(i)
+      const dot = dIn.x * dOut.x + dIn.y * dOut.y
+      return Math.acos(Math.max(-1, Math.min(1, dot)))
+    }
+    const cornerThreshold = Math.PI / 3
+    const isCorner: boolean[] = []
+    for (let i = 0; i < cycleLen; i++) {
+      isCorner.push(angleChangeAtVertex(i) > cornerThreshold)
+    }
+
+    const caps: number[] = []
+    for (let i = 0; i < cycleLen; i++) {
+      const next = (i + 1) % cycleLen
+      if (isCorner[i] && isCorner[next]) caps.push(i)
+    }
+    if (caps.length === 2) {
+      const [cap1, cap2] = caps
+      const buildSubchain = (afterCap: number, beforeCap: number): number[] => {
+        const verts: number[] = []
+        let i = (afterCap + 1) % cycleLen
+        verts.push(ordered[i])
+        while (i !== beforeCap) {
+          i = (i + 1) % cycleLen
+          verts.push(ordered[i])
+        }
+        return verts
+      }
+      const chainA = buildSubchain(cap1, cap2)
+      const chainB = buildSubchain(cap2, cap1)
+
+      const pairCount = Math.min(chainA.length, chainB.length)
+      if (pairCount >= 2) {
+        const midpoints: Vector[] = []
+        for (let i = 0; i < pairCount; i++) {
+          const a = vertices[chainA[i]]
+          const b = vertices[chainB[chainB.length - 1 - i]]
+          midpoints.push({ x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 })
+        }
+
+        const arcParams = fitCircleArc(midpoints)
+        if (arcParams) {
+          const { cx, cy, r, startAngleDeg, sweepDeg } = arcParams
+          const path = new ck.Path()
+          path.addArc(ck.LTRBRect(cx - r, cy - r, cx + r, cy + r), startAngleDeg, sweepDeg)
+          return path
+        }
+
+        const path = new ck.Path()
+        path.moveTo(midpoints[0].x, midpoints[0].y)
+        for (let i = 1; i < midpoints.length; i++) {
+          path.lineTo(midpoints[i].x, midpoints[i].y)
+        }
+        return path
+      }
+    }
+  }
+
+  const path = new ck.Path()
+  const visited = new Set<number>()
+  const chains = buildChains(segments, vertices.length)
+
+  for (const chain of chains) {
+    if (chain.length === 0) continue
+    let current = findChainStart(chain, segments)
+    path.moveTo(vertices[current].x, vertices[current].y)
+    for (const segIdx of chain) {
+      visited.add(segIdx)
+      const seg = segments[segIdx]
+      const forward = seg.start === current
+      addSegmentDirected(path, seg, vertices, forward)
+      current = forward ? seg.end : seg.start
+    }
+  }
+
+  for (let i = 0; i < segments.length; i++) {
+    if (visited.has(i)) continue
+    const seg = segments[i]
+    path.moveTo(vertices[seg.start].x, vertices[seg.start].y)
+    addSegmentDirected(path, seg, vertices, true)
+  }
+
+  return path
 }
 
 export function vectorNetworkToPath(ck: CanvasKit, network: VectorNetwork): Path[] {

--- a/src/components/properties/StrokeSection.vue
+++ b/src/components/properties/StrokeSection.vue
@@ -44,6 +44,29 @@ function onToggleSides(activeNode: SceneNode) {
     strokeCtx.selectSide('ALL', activeNode)
   }
 }
+
+type StrokePatch = (i: number, partial: Partial<Stroke>) => void
+
+function dashState(stroke: Stroke | undefined): { dash: number; gap: number; on: boolean } {
+  const p = stroke?.dashPattern
+  if (!p || p.length === 0) return { dash: 6, gap: 6, on: false }
+  return { dash: p[0] ?? 6, gap: p[1] ?? p[0] ?? 6, on: true }
+}
+
+function toggleDash(stroke: Stroke | undefined, patch: StrokePatch) {
+  const { dash, gap, on } = dashState(stroke)
+  patch(0, { dashPattern: on ? [] : [Math.max(dash, 1), Math.max(gap, 1)] })
+}
+
+function setDash(stroke: Stroke | undefined, patch: StrokePatch, value: number) {
+  const { gap } = dashState(stroke)
+  patch(0, { dashPattern: [Math.max(1, value), gap] })
+}
+
+function setGap(stroke: Stroke | undefined, patch: StrokePatch, value: number) {
+  const { dash } = dashState(stroke)
+  patch(0, { dashPattern: [dash, Math.max(1, value)] })
+}
 </script>
 
 <template>
@@ -147,6 +170,74 @@ function onToggleSides(activeNode: SceneNode) {
             </svg>
           </button>
         </Tip>
+      </div>
+
+      <div
+        v-if="!isMixed && (items as unknown[]).length > 0"
+        class="mt-1.5 flex items-center gap-1.5"
+      >
+        <button
+          data-test-id="stroke-dash-toggle"
+          class="flex h-[26px] shrink-0 cursor-pointer items-center gap-1 rounded border bg-input px-1.5 text-[11px]"
+          :class="
+            dashState((items as Stroke[])[0]).on
+              ? '!border-accent !text-accent'
+              : 'border-border text-muted hover:bg-hover hover:text-surface'
+          "
+          @click="toggleDash((items as Stroke[])[0], patch)"
+        >
+          <svg
+            class="size-3"
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <line x1="1" y1="6" x2="11" y2="6" stroke-dasharray="3 2" />
+          </svg>
+        </button>
+        <template v-if="dashState((items as Stroke[])[0]).on">
+          <ScrubInput
+            class="flex-1"
+            :model-value="dashState((items as Stroke[])[0]).dash"
+            :min="1"
+            data-test-id="stroke-dash-length"
+            @update:model-value="setDash((items as Stroke[])[0], patch, $event)"
+          >
+            <template #icon>
+              <svg
+                class="size-3"
+                viewBox="0 0 12 12"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+              >
+                <line x1="1" y1="6" x2="5" y2="6" />
+                <line x1="7" y1="6" x2="11" y2="6" />
+              </svg>
+            </template>
+          </ScrubInput>
+          <ScrubInput
+            class="flex-1"
+            :model-value="dashState((items as Stroke[])[0]).gap"
+            :min="1"
+            data-test-id="stroke-dash-gap"
+            @update:model-value="setGap((items as Stroke[])[0], patch, $event)"
+          >
+            <template #icon>
+              <svg
+                class="size-3"
+                viewBox="0 0 12 12"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+              >
+                <line x1="1" y1="6" x2="3" y2="6" />
+                <line x1="9" y1="6" x2="11" y2="6" />
+              </svg>
+            </template>
+          </ScrubInput>
+        </template>
       </div>
 
       <div


### PR DESCRIPTION
## Summary

Vector nodes with `stroke.dashPattern` were rendering as solid lines, and even when the dash pattern was applied through brute outline-stroke conversion, closed crescent shapes (e.g. annular wedges) showed two parallel dashed arcs instead of a single dashed arc along the centerline. After the fix, a dashed `<Vector>` renders the same way as in Figma.

## Repro

```jsx
<Vector
  name="Arc"
  x={28} y={26}
  w={227} h={116}
  stroke="#7A7A7A"
  strokeDash={[6, 6]}
/>
```

## Screenshots

**Figma (source of truth):**

![figma-original](https://raw.githubusercontent.com/greekr4/open-pencil/assets/pr-238/screenshots/figma-original.png)

**open-pencil before — pasted closed crescent renders as two parallel solid arcs (no dash):**

![before](https://raw.githubusercontent.com/greekr4/open-pencil/assets/pr-238/screenshots/before.png)

**open-pencil after — single smooth dashed arc along the centerline, matching Figma:**

![after](https://raw.githubusercontent.com/greekr4/open-pencil/assets/pr-238/screenshots/after.png)

## Root cause

Two independent bugs combined.

1. `drawVectorPathStrokes` in `packages/core/src/canvas/scene.ts` converts the stroke into a fill outline (`vp.copy().stroke(strokeOpts)`) and then draws that outline with `fillPaint`. There is no place left for `PathEffect.MakeDash` to apply, so the dash never appears.
2. A closed crescent (e.g. `annularWedge`) is one closed cycle that visits the outer arc and then the inner arc. Even when the dash effect is applied to the raw path, both arcs receive dashes, producing two parallel dashed arcs.

## Fix

### 1. `packages/core/src/canvas/scene.ts`

- `drawVectorPathStrokes`: when `stroke.dashPattern` is non-empty, skip the outline conversion and call `canvas.drawPath` with `strokePaint` configured with `PathEffect.MakeDash`. This keeps the original (non-dashed) outline path for normal strokes.
- `renderShapeUncached`: for dashed `VECTOR` nodes that have a `vectorNetwork`, route through the new centerline path instead of the precomputed `strokeGeometry`. The precomputed geometry is already a fill outline and cannot be dashed.

### 2. `packages/core/src/vector/index.ts` — `vectorNetworkToCenterlinePath`

For closed thin crescents:

1. **Detection** (`isClosedThinCrescent`): vertex count `n >= 6 && n % 2 === 0`, every vertex has degree 2, and the cycle has small thickness — `pairedAvg <= alongSum * 0.5` and the paired distances are consistent (`stdDev / pairedAvg <= 0.5`). This rejects rectangles, hexagons, and other regular polygons.
2. **Cap detection by direction change**: along an arc, segment-to-segment turns are smooth (~7.5°); at a cap they are sharp (~90°). A vertex is a "corner" if the angle between its incoming and outgoing segment directions exceeds 60°. A cap segment has both endpoints corners.
3. **Subchain split**: with the two cap indices known, walk the cycle from one cap to the other to get two subchains (outer arc, inner arc). The two chains run in opposite directions around the cycle; reversing one aligns vertices by angle.
4. **Centerline midpoints**: pair `chainA[i]` with `chainB[len-1-i]` and take midpoints. For an `annularWedge(rIn=80, rOut=100)` these land exactly on the midradius=90 circle.
5. **Smooth arc**: `fitCircleArc` runs a 3-point circle construction on first/middle/last midpoints, verifies all midpoints lie on the resulting circle within tolerance, and returns `{cx, cy, r, startAngleDeg, sweepDeg}`. The path is then a single `Path.addArc` call — no polyline kinks. If the midpoints are not co-circular, the function falls back to a midpoint polyline.

For open paths and other shapes the function uses the existing chain walk via `buildChains`, so dashing an open arc continues to work.

### 3. JSX prop wiring (so users can author dashed vectors)

- `packages/core/src/design-jsx/tree.ts`: add `strokeDash?: number[] | boolean` to `StyleProps`.
- `packages/core/src/design-jsx/renderer.ts`: new `applyStrokeOverrides` that delegates to `parseStroke` and then assigns `stroke.dashPattern` from `resolveDashPattern(props.strokeDash, strokeWidth)`. `true` expands to `[w*2, w*2]` (clamped to a min of 4); arrays are filtered to positive finite numbers.
- `packages/core/src/io/formats/jsx/export.ts`: `solidStroke` now also returns `dash`, and `collectAppearanceProps` emits a `strokeDash` prop when present, so JSX export round-trips dashed strokes.

### 4. Editor UI — `src/components/properties/StrokeSection.vue`

Adds a dash toggle button plus dash-length and gap `ScrubInput`s. The toggle stores `[]` when off and `[dash, gap]` when on, matching the `Stroke.dashPattern` model. Helper functions `dashState`/`toggleDash`/`setDash`/`setGap` keep the template thin. No localized strings — icon-only, consistent with existing rows.

## Verification

- `bun run check` passes (oxlint, tsgo, vue-tsc). Two `max-lines` warnings are pre-existing for `scene.ts` (706 lines, was already over 600) and `vector/index.ts` (632 lines after additions).
- `bun test ./tests/engine` shows 3 failing tests on this branch — all 3 also fail on a clean `upstream/master` checkout and are unrelated to this change (`drop shadow has TEXT-specific branch`, `drop shadow uses spread for shape expansion`, `imported nested instance layout recomputes hidden sibling offsets`).
- Visually verified against the Figma original for `<Vector strokeDash={[6,6]}>` rendering of a closed crescent (semicircle annular wedge) — single smooth dashed arc along the centerline, matching Figma.

## Approaches that were tried and rejected

| Approach | Why it failed |
| --- | --- |
| Outline conversion then dash | Outline is a fill — `PathEffect.MakeDash` does not apply. |
| Outline kept, dash on raw path | Closed crescent dashes both outer and inner arc — visible as two parallel dashed arcs. |
| Use the two shortest segments as caps | Fails on thick crescents where `R - r > pi*r/n` and the cap can be the longest segment. |
| Centroid-based clustering | The centroid of an arc is not at the arc center, so cluster boundaries land in the wrong place. |
| Closest non-adjacent vertex pairing | When outer-step is shorter than crescent thickness, the partner becomes an adjacent same-arc vertex. |
| Use the outer subchain itself | Result sits on the outer edge; the user expects the centerline. |
| Midpoint polyline (`lineTo`) | ~7.5° kinks per segment make the arc look like a polygon. |

Direction-change cap detection plus 3-point circle fit is the only approach that holds across thin/thick crescents and synthetic/real shapes.

## Files

- `packages/core/src/canvas/scene.ts`
- `packages/core/src/vector/index.ts`
- `packages/core/src/design-jsx/tree.ts`
- `packages/core/src/design-jsx/renderer.ts`
- `packages/core/src/io/formats/jsx/export.ts`
- `src/components/properties/StrokeSection.vue`