### PR TITLE
Fixed the issue of Chinese fonts not displaying on UI drafts.

### DIFF
--- a/packages/core/src/canvaskit.ts
+++ b/packages/core/src/canvaskit.ts
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import CanvasKitInit, { type CanvasKit } from 'canvaskit-wasm'
 
 import { IS_BROWSER } from './constants'
@@ -12,8 +13,10 @@ export async function getCanvasKit(options?: CanvasKitOptions): Promise<CanvasKi
   if (instance) return instance
 
   const defaultLocate = (file: string) => {
-    if (IS_BROWSER) return `/${file}`
-    return file
+    if (!IS_BROWSER) return file
+    const base = import.meta.env.BASE_URL
+    const prefix = base === '/' ? '' : base.replace(/\/$/, '')
+    return `${prefix}/${file}`.replace(/\/{2,}/g, '/')
   }
 
   instance = await CanvasKitInit({

--- a/packages/core/src/canvaskit.ts
+++ b/packages/core/src/canvaskit.ts
@@ -14,9 +14,9 @@ export async function getCanvasKit(options?: CanvasKitOptions): Promise<CanvasKi
 
   const defaultLocate = (file: string) => {
     if (!IS_BROWSER) return file
-    const base = import.meta.env.BASE_URL
+    const base = 'env' in import.meta ? import.meta.env.BASE_URL : '/'
     const prefix = base === '/' ? '' : base.replace(/\/$/, '')
-    return `${prefix}/${file}`.replace(/\/{2,}/g, '/')
+    return `${prefix}/${file}`
   }
 
   instance = await CanvasKitInit({

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -331,10 +331,12 @@ export const CJK_FALLBACK_FAMILIES_MACOS = [
 
 export const CJK_FALLBACK_FAMILIES_WINDOWS = [
   'Microsoft YaHei',
+  'Microsoft YaHei UI',
   'Microsoft JhengHei',
   'Yu Gothic',
   'Malgun Gothic',
-  'SimHei'
+  'SimHei',
+  'SimSun'
 ]
 
 export const CJK_FALLBACK_FAMILIES_LINUX = [

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -25,9 +25,8 @@ export const CANVAS_BG_COLOR_DARK = { r: 0.173, g: 0.173, b: 0.173, a: 1 } satis
  */
 export function getDefaultCanvasBgColor(): Color {
   if (IS_BROWSER) {
-    const env = (import.meta as ImportMeta & { env?: { DEV?: boolean } }).env
     const params = new URLSearchParams(window.location.search)
-    if (env?.DEV === true && params.has('test')) {
+    if ('env' in import.meta && import.meta.env.DEV && params.has('test')) {
       return CANVAS_BG_COLOR
     }
   }

--- a/packages/core/src/text/fonts.ts
+++ b/packages/core/src/text/fonts.ts
@@ -349,17 +349,15 @@ export async function ensureCJKFallback(): Promise<string[]> {
       }
     }
 
-    // Always try remote Noto fonts too: supplements locals, covers Google-API-only
-    // installs, and fixes cases where a local face matched but lacked SC glyphs.
-    const results = await Promise.allSettled(
-      CJK_GOOGLE_FONTS.map(async (family) => {
-        const data = await loadFont(family, 'Regular')
-        return data ? family : null
-      })
-    )
-    for (const result of results) {
-      if (result.status === 'fulfilled' && result.value) {
-        if (!cjkFallbackFamilies.includes(result.value)) {
+    if (cjkFallbackFamilies.length === 0) {
+      const results = await Promise.allSettled(
+        CJK_GOOGLE_FONTS.map(async (family) => {
+          const data = await loadFont(family, 'Regular')
+          return data ? family : null
+        })
+      )
+      for (const result of results) {
+        if (result.status === 'fulfilled' && result.value) {
           cjkFallbackFamilies.push(result.value)
         }
       }

--- a/packages/core/src/text/fonts.ts
+++ b/packages/core/src/text/fonts.ts
@@ -105,7 +105,9 @@ async function fetchGoogleFontFiles(family: string): Promise<Record<string, stri
   }
   if (!response.ok) return retryWithNormalizedFamily(family)
 
-  const data = (await response.json()) as { items?: Array<{ files?: Record<string, string> }> }
+  const data = (await response.json()) as {
+    items?: Array<{ files?: Record<string, string> }>
+  }
   const files = data.items?.[0]?.files
   if (!files) return retryWithNormalizedFamily(family)
 
@@ -135,7 +137,13 @@ async function fetchGoogleFont(family: string, style: string): Promise<ArrayBuff
   return response.arrayBuffer()
 }
 
-async function findLocalFont(family: string, style?: string): Promise<ArrayBuffer | null> {
+type FindLocalFontOptions = { allowVariable?: boolean }
+
+async function findLocalFont(
+  family: string,
+  style?: string,
+  options: FindLocalFontOptions = {}
+): Promise<ArrayBuffer | null> {
   if (!IS_BROWSER || !window.queryLocalFonts) return null
   try {
     const fonts = await window.queryLocalFonts()
@@ -153,9 +161,10 @@ async function findLocalFont(family: string, style?: string): Promise<ArrayBuffe
     if (!match) return null
     const blob: Blob = await match.blob()
     const buffer = await blob.arrayBuffer()
-    // Variable fonts (fvar table) cause CanvasKit to render all text at the
-    // default weight. Skip them — Google Fonts serves per-weight static files.
-    if (isVariableFont(buffer)) return null
+    // Variable fonts (fvar table) can skew weight for Latin UI fonts. CJK system
+    // faces (e.g. Microsoft YaHei) are often variable — still prefer them over
+    // missing glyphs (tofu) when explicitly loading CJK fallbacks.
+    if (!options.allowVariable && isVariableFont(buffer)) return null
     return buffer
   } catch (e) {
     console.warn(`Local font access failed for "${family}" ${style ?? ''}:`, e)
@@ -330,24 +339,27 @@ export async function ensureCJKFallback(): Promise<string[]> {
   if (cjkFallbackPromise) return cjkFallbackPromise
 
   cjkFallbackPromise = (async () => {
-    // Try local system fonts first
+    // Try local system fonts first (allow variable fonts — common for 微软雅黑 / PingFang).
     for (const family of getCJKCandidates()) {
-      const buffer = await findLocalFont(family)
+      const buffer = await findLocalFont(family, undefined, {
+        allowVariable: true
+      })
       if (buffer && registerAndCache(family, 'Regular', buffer)) {
         cjkFallbackFamilies.push(family)
       }
     }
 
-    // Load all CJK Google Fonts in parallel for full coverage
-    if (cjkFallbackFamilies.length === 0) {
-      const results = await Promise.allSettled(
-        CJK_GOOGLE_FONTS.map(async (family) => {
-          const data = await loadFont(family, 'Regular')
-          return data ? family : null
-        })
-      )
-      for (const result of results) {
-        if (result.status === 'fulfilled' && result.value) {
+    // Always try remote Noto fonts too: supplements locals, covers Google-API-only
+    // installs, and fixes cases where a local face matched but lacked SC glyphs.
+    const results = await Promise.allSettled(
+      CJK_GOOGLE_FONTS.map(async (family) => {
+        const data = await loadFont(family, 'Regular')
+        return data ? family : null
+      })
+    )
+    for (const result of results) {
+      if (result.status === 'fulfilled' && result.value) {
+        if (!cjkFallbackFamilies.includes(result.value)) {
           cjkFallbackFamilies.push(result.value)
         }
       }

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+/canvaskit.wasm
+  Content-Type: application/wasm
+
+/canvaskit-webgpu/canvaskit.wasm
+  Content-Type: application/wasm

--- a/vite/canvaskit-assets.ts
+++ b/vite/canvaskit-assets.ts
@@ -1,27 +1,66 @@
-import { copyFileSync, existsSync, mkdirSync } from 'fs'
+import { copyFileSync, createReadStream, existsSync, mkdirSync } from 'fs'
+import { resolve } from 'node:path'
 
+import type { Connect } from 'vite'
 import type { Plugin } from 'vite'
 
-function copyIfMissing(source: string, destination: string) {
-  if (!existsSync(source) || existsSync(destination)) return
+/** Always copy when source exists so public/ never keeps a stale or empty wasm. */
+function syncWasmFromNodeModules(source: string, destination: string) {
+  if (!existsSync(source)) {
+    console.warn(`[copy-canvaskit-wasm] Missing source (run \`bun install\`): ${source}`)
+    return
+  }
   const directory = destination.slice(0, destination.lastIndexOf('/'))
   if (directory) mkdirSync(directory, { recursive: true })
   copyFileSync(source, destination)
 }
 
+function serveCanvasKitWasm(root: string): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    const pathname = req.url?.split('?')[0] ?? ''
+    if (pathname !== '/canvaskit.wasm' && pathname !== '/canvaskit-webgpu/canvaskit.wasm') {
+      next()
+      return
+    }
+
+    const publicPath = resolve(root, pathname.slice(1))
+    const fallbackPath =
+      pathname === '/canvaskit.wasm'
+        ? resolve(root, 'node_modules/canvaskit-wasm/bin/canvaskit.wasm')
+        : resolve(root, 'packages/core/vendor/canvaskit-webgpu/canvaskit.wasm')
+
+    const file = existsSync(publicPath) ? publicPath : fallbackPath
+    if (!existsSync(file)) {
+      next()
+      return
+    }
+
+    res.setHeader('Content-Type', 'application/wasm')
+    res.setHeader('Cache-Control', 'no-cache')
+    createReadStream(file).on('error', next).pipe(res)
+  }
+}
+
 export function copyCanvasKitAssetsPlugin(): Plugin {
   return {
     name: 'copy-canvaskit-wasm',
+    enforce: 'pre',
     buildStart() {
-      copyIfMissing('node_modules/canvaskit-wasm/bin/canvaskit.wasm', 'public/canvaskit.wasm')
-      copyIfMissing(
+      syncWasmFromNodeModules('node_modules/canvaskit-wasm/bin/canvaskit.wasm', 'public/canvaskit.wasm')
+      syncWasmFromNodeModules(
         'packages/core/vendor/canvaskit-webgpu/canvaskit.wasm',
         'public/canvaskit-webgpu/canvaskit.wasm',
       )
-      copyIfMissing(
+      syncWasmFromNodeModules(
         'packages/core/vendor/canvaskit-webgpu/canvaskit.js',
         'public/canvaskit-webgpu/canvaskit.js',
       )
+    },
+    configureServer(server) {
+      server.middlewares.use(serveCanvasKitWasm(process.cwd()))
+    },
+    configurePreviewServer(server) {
+      server.middlewares.use(serveCanvasKitWasm(process.cwd()))
     },
   }
 }

--- a/vite/canvaskit-assets.ts
+++ b/vite/canvaskit-assets.ts
@@ -1,18 +1,18 @@
 import { copyFileSync, createReadStream, existsSync, mkdirSync } from 'fs'
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
 
-import type { Connect } from 'vite'
+import type { Connect, ResolvedConfig } from 'vite'
 import type { Plugin } from 'vite'
 
-/** Always copy when source exists so public/ never keeps a stale or empty wasm. */
-function syncWasmFromNodeModules(source: string, destination: string) {
-  if (!existsSync(source)) {
-    console.warn(`[copy-canvaskit-wasm] Missing source (run \`bun install\`): ${source}`)
+function syncWasmFromNodeModules(root: string, source: string, destination: string) {
+  const sourcePath = resolve(root, source)
+  const destinationPath = resolve(root, destination)
+  if (!existsSync(sourcePath)) {
+    console.warn(`[copy-canvaskit-wasm] Missing source (run \`bun install\`): ${sourcePath}`)
     return
   }
-  const directory = destination.slice(0, destination.lastIndexOf('/'))
-  if (directory) mkdirSync(directory, { recursive: true })
-  copyFileSync(source, destination)
+  mkdirSync(dirname(destinationPath), { recursive: true })
+  copyFileSync(sourcePath, destinationPath)
 }
 
 function serveCanvasKitWasm(root: string): Connect.NextHandleFunction {
@@ -42,25 +42,32 @@ function serveCanvasKitWasm(root: string): Connect.NextHandleFunction {
 }
 
 export function copyCanvasKitAssetsPlugin(): Plugin {
+  let root = process.cwd()
+
   return {
     name: 'copy-canvaskit-wasm',
     enforce: 'pre',
+    configResolved(config: ResolvedConfig) {
+      root = config.root
+    },
     buildStart() {
-      syncWasmFromNodeModules('node_modules/canvaskit-wasm/bin/canvaskit.wasm', 'public/canvaskit.wasm')
+      syncWasmFromNodeModules(root, 'node_modules/canvaskit-wasm/bin/canvaskit.wasm', 'public/canvaskit.wasm')
       syncWasmFromNodeModules(
+        root,
         'packages/core/vendor/canvaskit-webgpu/canvaskit.wasm',
-        'public/canvaskit-webgpu/canvaskit.wasm',
+        'public/canvaskit-webgpu/canvaskit.wasm'
       )
       syncWasmFromNodeModules(
+        root,
         'packages/core/vendor/canvaskit-webgpu/canvaskit.js',
-        'public/canvaskit-webgpu/canvaskit.js',
+        'public/canvaskit-webgpu/canvaskit.js'
       )
     },
     configureServer(server) {
-      server.middlewares.use(serveCanvasKitWasm(process.cwd()))
+      server.middlewares.use(serveCanvasKitWasm(server.config.root))
     },
     configurePreviewServer(server) {
-      server.middlewares.use(serveCanvasKitWasm(process.cwd()))
-    },
+      server.middlewares.use(serveCanvasKitWasm(server.config.root))
+    }
   }
 }


### PR DESCRIPTION
packages/core/src/text/fonts.ts

The `findLocalFont` function adds the optional parameter `allowVariable`. Using `allowVariable: true` on the system CJK candidate path in `ensureCJKFallback` allows registration of native variable CJK fonts, preventing them from being skipped incorrectly.

Regardless of local success, `CJK_GOOGLE_FONTS` (Noto Sans SC/JP/KR) will be tried again in `Promise.allSettled`, merged with the local list to remove duplicates, and complete the glyphs and fallback chain.

packages/core/src/constants.ts

Microsoft YaHei UI and SimSun have been added as Windows candidates to improve the probability of native matching.