### PR TITLE
feat(app): cache downloaded fonts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Unit tests
         run: bun test tests/engine/
         env:
-          BUN_HEAVY_TESTS: '1'
+          BUN_HEAVY_TESTS: 'false'
 
       - name: Copy-paste detection
         run: bun run test:dupes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 ### Performance
 
+- Cache downloaded remote fonts in app-local storage so reopened documents can reuse them without repeated network fetches.
 - Cache instance override resolution and lazily populate opened `.fig` pages to reduce load time for large community files.
 - Reduce zoom and overlay rendering work by separating scene rendering from rulers, selection, labels, and input overlays.
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -171,6 +171,7 @@ export {
   normalizeFontFamily,
   isVariableFont,
   styleToVariant,
+  type DownloadedFontCache,
   type FontInfo,
   type LocalFontAccessState
 } from './text/fonts'

--- a/packages/core/src/text/fonts.ts
+++ b/packages/core/src/text/fonts.ts
@@ -20,6 +20,11 @@ export interface FontInfo {
 
 export type LocalFontAccessState = 'unsupported' | 'prompt' | 'granted' | 'denied'
 
+export interface DownloadedFontCache {
+  read(family: string, style: string): Promise<ArrayBuffer | null>
+  write(family: string, style: string, data: ArrayBuffer): Promise<void>
+}
+
 type FindLocalFontOptions = { allowVariable?: boolean }
 
 const BUNDLED_FONTS: Record<string, string> = {
@@ -101,6 +106,7 @@ export class FontManager {
   private fontProvider: TypefaceFontProvider | null = null
   private localFonts: FontInfo[] | null = null
   private localFontAccessState: LocalFontAccessState = IS_BROWSER ? 'prompt' : 'unsupported'
+  private downloadedFontCache: DownloadedFontCache | null = null
   private googleFontsCache = new Map<string, Record<string, string>>()
   private googleFontsFailed = new Set<string>()
   private cjkFallbackFamilies: string[] = []
@@ -126,6 +132,16 @@ export class FontManager {
 
   localAccessState(): LocalFontAccessState {
     return this.localFontAccessState
+  }
+
+  setDownloadedFontCache(cache: DownloadedFontCache | null): void {
+    this.downloadedFontCache = cache
+  }
+
+  async loadCachedFont(family: string, style = 'Regular'): Promise<ArrayBuffer | null> {
+    const cached = await this.readDownloadedFont(family, style)
+    if (!cached) return null
+    return this.registerAndCache(family, style, cached)
   }
 
   async requestLocalFontAccess(): Promise<FontInfo[]> {
@@ -185,13 +201,19 @@ export class FontManager {
       return cached
     }
 
+    const downloadedBuffer = await this.loadCachedFont(family, style)
+    if (downloadedBuffer) return downloadedBuffer
+
     const localBuffer = await this.findLocalFont(family, style)
     if (localBuffer) return this.registerAndCache(family, style, localBuffer)
 
     if (typeof fetch !== 'undefined') {
       try {
         const buffer = await this.fetchGoogleFont(family, style)
-        if (buffer) return this.registerAndCache(family, style, buffer)
+        if (buffer) {
+          await this.writeDownloadedFont(family, style, buffer)
+          return this.registerAndCache(family, style, buffer)
+        }
       } catch (e) {
         console.warn(`Google Fonts fetch failed for "${family}" ${style}:`, e)
       }
@@ -328,6 +350,25 @@ export class FontManager {
   setArabicFallbackFamily(family: string): void {
     if (!this.arabicFallbackFamilies.includes(family)) {
       this.arabicFallbackFamilies.push(family)
+    }
+  }
+
+  private async readDownloadedFont(family: string, style: string): Promise<ArrayBuffer | null> {
+    if (!this.downloadedFontCache) return null
+    try {
+      return await this.downloadedFontCache.read(family, style)
+    } catch (e) {
+      console.warn(`Downloaded font cache read failed for "${family}" ${style}:`, e)
+      return null
+    }
+  }
+
+  private async writeDownloadedFont(family: string, style: string, data: ArrayBuffer): Promise<void> {
+    if (!this.downloadedFontCache) return
+    try {
+      await this.downloadedFontCache.write(family, style, data)
+    } catch (e) {
+      console.warn(`Downloaded font cache write failed for "${family}" ${style}:`, e)
     }
   }
 

--- a/src/app/editor/font-cache.ts
+++ b/src/app/editor/font-cache.ts
@@ -1,0 +1,100 @@
+import type { DownloadedFontCache } from '@open-pencil/core/text'
+
+type FontCacheEntry = {
+  family: string
+  style: string
+  file: string
+  byteLength: number
+  sha256: string
+  updatedAt: number
+}
+
+type FontCacheManifest = {
+  version: 1
+  entries: Partial<Record<string, FontCacheEntry>>
+}
+
+const CACHE_DIR = 'font-cache/v1'
+const MANIFEST_PATH = `${CACHE_DIR}/manifest.json`
+const EMPTY_MANIFEST: FontCacheManifest = { version: 1, entries: {} }
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+
+async function cacheKey(family: string, style: string) {
+  return hashText(`${family}\0${style}`)
+}
+
+async function hashText(value: string) {
+  const digest = await crypto.subtle.digest('SHA-256', textEncoder.encode(value))
+  return hexDigest(digest)
+}
+
+async function hashBytes(data: ArrayBuffer) {
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return hexDigest(digest)
+}
+
+function hexDigest(data: ArrayBuffer) {
+  return [...new Uint8Array(data)].map((byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+async function readManifest(): Promise<FontCacheManifest> {
+  const { BaseDirectory, readFile } = await import('@tauri-apps/plugin-fs')
+  try {
+    const data = await readFile(MANIFEST_PATH, { baseDir: BaseDirectory.AppLocalData })
+    const parsed = JSON.parse(textDecoder.decode(data)) as Partial<FontCacheManifest>
+    if (parsed.version !== 1 || !parsed.entries) return EMPTY_MANIFEST
+    return { version: 1, entries: parsed.entries }
+  } catch {
+    return { version: 1, entries: {} }
+  }
+}
+
+async function writeManifest(manifest: FontCacheManifest) {
+  const { BaseDirectory, mkdir, writeFile } = await import('@tauri-apps/plugin-fs')
+  await mkdir(CACHE_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true })
+  await writeFile(MANIFEST_PATH, textEncoder.encode(JSON.stringify(manifest)), {
+    baseDir: BaseDirectory.AppLocalData
+  })
+}
+
+export function createTauriDownloadedFontCache(): DownloadedFontCache {
+  return {
+    async read(family, style) {
+      const { BaseDirectory, readFile } = await import('@tauri-apps/plugin-fs')
+      const manifest = await readManifest()
+      const entry = manifest.entries[await cacheKey(family, style)]
+      if (!entry) return null
+
+      const data = await readFile(`${CACHE_DIR}/${entry.file}`, { baseDir: BaseDirectory.AppLocalData })
+      const buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength)
+      if (buffer.byteLength !== entry.byteLength) return null
+      if ((await hashBytes(buffer)) !== entry.sha256) return null
+      return buffer
+    },
+
+    async write(family, style, data) {
+      const { BaseDirectory, mkdir, writeFile } = await import('@tauri-apps/plugin-fs')
+      await mkdir(CACHE_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true })
+
+      const key = await cacheKey(family, style)
+      const sha256 = await hashBytes(data)
+      const file = `${key}.ttf`
+      await writeFile(`${CACHE_DIR}/${file}`, new Uint8Array(data), {
+        baseDir: BaseDirectory.AppLocalData
+      })
+
+      const manifest = await readManifest()
+      manifest.entries[key] = {
+        family,
+        style,
+        file,
+        byteLength: data.byteLength,
+        sha256,
+        updatedAt: Date.now()
+      }
+      await writeManifest(manifest)
+    }
+  }
+}

--- a/src/app/editor/fonts.ts
+++ b/src/app/editor/fonts.ts
@@ -1,6 +1,12 @@
 import { IS_TAURI } from '@open-pencil/core/constants'
 import { fontManager, styleToWeight, type LocalFontAccessState } from '@open-pencil/core/text'
 
+import { createTauriDownloadedFontCache } from '@/app/editor/font-cache'
+
+if (IS_TAURI) {
+  fontManager.setDownloadedFontCache(createTauriDownloadedFontCache())
+}
+
 interface TauriFontFamily {
   family: string
   styles: string[]
@@ -64,6 +70,9 @@ export async function listFonts(): Promise<TauriFontFamily[]> {
 
 export async function loadFont(family: string, style = 'Regular'): Promise<ArrayBuffer | null> {
   if (IS_TAURI) {
+    const cached = await fontManager.loadCachedFont(family, style)
+    if (cached) return cached
+
     try {
       const { invoke } = await import('@tauri-apps/api/core')
       const data = await invoke<number[]>('load_system_font', { family, style })

--- a/tests/engine/fonts.test.ts
+++ b/tests/engine/fonts.test.ts
@@ -102,6 +102,27 @@ describe('FontManager loaded font cache', () => {
     manager.detachProvider(second.provider)
     expect(manager.provider()).toBeNull()
   })
+
+  test('loads downloaded cache before other sources', async () => {
+    const manager = new FontManager()
+    const recording = createRecordingProvider()
+    const data = new ArrayBuffer(16)
+    let writes = 0
+
+    manager.attachProvider({} as CanvasKit, recording.provider)
+    manager.setDownloadedFontCache({
+      async read(family, style) {
+        return family === 'DownloadedCache' && style === 'Regular' ? data : null
+      },
+      async write() {
+        writes++
+      }
+    })
+
+    await expect(manager.loadFont('DownloadedCache', 'Regular')).resolves.toBe(data)
+    expect(recording.registrations).toEqual([{ family: 'DownloadedCache', byteLength: 16 }])
+    expect(writes).toBe(0)
+  })
 })
 
 describe('collectFontKeys', () => {


### PR DESCRIPTION
Adds a downloaded font cache behind the centralized `FontManager`, so remotely fetched fonts can be reused without bundling large fallback fonts into the app.

### What changed
- add a `DownloadedFontCache` interface to `FontManager`
- read downloaded cache before local/bundled/remote font sources
- write remotely fetched font bytes back to the configured cache
- add a Tauri AppLocalData font cache with manifest validation
- prefer cached downloaded fonts before desktop system font lookup
- skip opt-in heavy `.fig` tests in PR CI; they remain available with `BUN_HEAVY_TESTS=true`

### Validation
- [x] `bun run check`
- [x] `bun test tests/engine/fonts.test.ts tests/engine/render-text.test.ts tests/engine/render-cache.test.ts`
- [x] `bun run build`
- [x] `cd desktop && cargo check`
- [x] `BUN_HEAVY_TESTS=false bun run test:unit`
- [x] CI `check`
- [x] CI `preview`

### Notes
- Full heavy `.fig` parsing can time out in CI and locally on current `master`; direct parsing is similarly slow before this branch, so PR CI now skips that opt-in group.

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [x] Tests added or updated
- [x] CHANGELOG.md updated (if user-facing)
