### PR TITLE
fix(mcp): fix protocol mismatch between stdio-bridge and server

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,16 @@
+# @open-pencil/mcp
+
+MCP (Model Context Protocol) server for OpenPencil browser automation.
+
+## Architecture
+
+```
+┌─────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│ Agent Apps  │     │   Browser RPC    │     │  Browser App     │
+│ (via stdio) │────▶│   Bridge (port   │◀────│  (automation)    │
+└─────────────┘     │   7601)          │     └──────────────────┘
+                    │                  │
+                    │  Multi-client    │
+                    │  connection hub  │
+                    └──────────────────┘
+```

--- a/packages/mcp/src/browser-rpc.ts
+++ b/packages/mcp/src/browser-rpc.ts
@@ -62,9 +62,8 @@ export function createBrowserRpcBridge({ authToken, onConnectionChange }: Browse
     })
   }
 
-  function handleMessage(data: string, ws: WebSocket) {
+  function handleMessage(msg: BrowserMessage, ws: WebSocket) {
     try {
-      const msg = JSON.parse(data) as BrowserMessage
       if (msg.type === 'register' && msg.token) {
         if (authToken && msg.token !== authToken) {
           ws.close()

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -51,18 +51,52 @@ export function startServer(options: ServerOptions = {}) {
   // --- WebSocket: browser connects here ---
 
   const wss = new WebSocketServer({ port: wsPort, host: '127.0.0.1' })
+  let unconnected = (msg) => ({ error: true, message: 'Automation not connected' })
+  let automation = unconnected
+  let queue: Map<string, (response: any) => void> = new Map()
 
   wss.on('connection', (ws) => {
+    let clientId = Math.random().toString().slice(2)
+    let handler = (msg) => {
+      if (msg.type === 'request') {
+        console.log("Handling mcp client request", msg)
+        queue.set(msg.id, (msg) => ws.send(msg))
+        automation(msg)
+      }
+    }
+
     ws.on('message', (raw) => {
-      browserRpc.handleMessage(
-        typeof raw === 'string' ? raw : Buffer.from(raw as Buffer).toString('utf-8'),
-        ws
-      )
+      const msg = JSON.parse(typeof raw === 'string' ? raw : Buffer.from(raw as Buffer).toString('utf-8'))
+
+      if (msg.type === 'register') {
+        console.log('Registering automation')
+        automation = (req) => {
+          console.log("Forwarding to automation", req)
+          ws.send(JSON.stringify(req))
+        }
+        handler = (resp) => {
+          console.log('Message from automation!', resp)
+          if (resp.type == 'response') {
+            queue.get(resp.id)?.(JSON.stringify(resp))
+            queue.delete(resp.id)
+          } else {
+            console.log("Unknown message", resp)
+          }
+        }
+      } else if (msg.type === 'register') {
+        console.log('Registering browser')
+        handler = (msg) => browserRpc.handleMessage(msg, ws)
+      } else {
+        handler(msg)
+      }
     })
 
     ws.on('close', () => {
       browserRpc.handleClose(ws)
+      // TODO automation = unconnected
     })
+
+    ws.send(JSON.stringify({ type: 'register', token: authToken }))
   })
 
   // --- HTTP server ---

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -51,12 +51,11 @@ export function startServer(options: ServerOptions = {}) {
   // --- WebSocket: browser connects here ---
 
   const wss = new WebSocketServer({ port: wsPort, host: '127.0.0.1' })
-  let unconnected = (msg) => ({ error: true, message: 'Automation not connected' })
+  const unconnected = (_msg: unknown) => ({ error: true, message: 'Automation not connected' })
   let automation = unconnected
-  let queue: Map<string, (response: any) => void> = new Map()
+  const queue: Map<string, (response: unknown) => void> = new Map()
 
   wss.on('connection', (ws) => {
-    let clientId = Math.random().toString().slice(2)
     let handler = (msg) => {
       if (msg.type === 'request') {
         console.log("Handling mcp client request", msg)
@@ -76,16 +75,17 @@ export function startServer(options: ServerOptions = {}) {
         }
         handler = (resp) => {
           console.log('Message from automation!', resp)
-          if (resp.type == 'response') {
+          if (resp.type === 'response') {
             queue.get(resp.id)?.(JSON.stringify(resp))
             queue.delete(resp.id)
           } else {
             console.log("Unknown message", resp)
           }
         }
-      } else if (msg.type === 'register') {
-        console.log('Registering browser')
-        handler = (msg) => browserRpc.handleMessage(msg, ws)
+      // TODO is it necessary?
+      // } else if (msg.type === 'registerBrowser') {
+      //   console.log('Registering browser')
+      //   handler = (msg) => browserRpc.handleMessage(msg, ws)
       } else {
         handler(msg)
       }

--- a/src/app/automation/bridge/vite-plugin.ts
+++ b/src/app/automation/bridge/vite-plugin.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process'
 
 import type { Plugin } from 'vite'
 
-// TODO: production — bundle MCP server as Tauri sidecar or spawn via shell plugin
+// TODO: run native MCP server using rmcp
 export function automationPlugin(authToken: string | null, corsOrigin: string): Plugin {
   let child: ReturnType<typeof spawn> | null = null
 
@@ -11,8 +11,9 @@ export function automationPlugin(authToken: string | null, corsOrigin: string): 
     configureServer() {
       if (child) return
 
-      child = spawn('bun', ['run', 'packages/mcp/src/index.ts'], {
+      child = spawn('bun', ['run', '--watch', 'index.ts'], {
         stdio: ['ignore', 'inherit', 'pipe'],
+        cwd: 'packages/mcp/src/',
         env: {
           ...process.env,
           PORT: '7600',


### PR DESCRIPTION
Fixes protocol mismatch between stdio-bridge and server:
- Stdio-bridge was waiting to RECEIVE 'register' from server, 
- while the server expected to RECEIVE 'register' from client
- neither was sending,
- causing stdio-bridge to block forever.

Changes:

- packages/mcp/src/server.ts:
  - Send { type: 'register', token } to clients on WebSocket open
  - Handle 'request' from stdio-bridge, forward to browser automation
  - Route 'response' from automation back to correct client by requestId
  - Track request queue with per-connection handlers for multiple
    clients
  - Clean handler fallback before client registers (returns error)
  
---

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [ ] Tests added or updated
- [ ] CHANGELOG.md updated (if user-facing)
