### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/desktop/src/fig_container.rs
+++ b/desktop/src/fig_container.rs
@@ -1,6 +1,10 @@
 use serde::Deserialize;
 use std::io::{Cursor, Write};
 
+fn is_safe_path(name: &str) -> bool {
+    !name.contains("..") && !name.starts_with('/') && !name.contains(':')
+}
+
 #[derive(Deserialize)]
 pub struct ImageEntry {
     name: String,
@@ -56,6 +60,9 @@ pub fn build_fig_file(
 
     if let Some(image_entries) = images {
         for entry in image_entries {
+            if !is_safe_path(&entry.name) {
+                return Err("Invalid image entry name: path traversal not allowed".to_string());
+            }
             zip.start_file(&entry.name, options)
                 .map_err(|e| e.to_string())?;
             zip.write_all(&entry.data).map_err(|e| e.to_string())?;

--- a/packages/core/src/editor/clipboard/copy.ts
+++ b/packages/core/src/editor/clipboard/copy.ts
@@ -2,11 +2,20 @@ import { buildFigmaClipboardHTML, buildOpenPencilClipboardHTML } from '#core/cli
 import type { EditorContext } from '#core/editor/types'
 import type { SceneNode } from '#core/scene-graph'
 
+function escapeHTML(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
 export function createClipboardCopyActions(ctx: EditorContext) {
   async function writeCopyData(clipboardData: DataTransfer, selectedNodes: SceneNode[]) {
     if (selectedNodes.length === 0) return
 
-    const names = selectedNodes.map((n) => n.name).join('\n')
+    const names = selectedNodes.map((n) => escapeHTML(n.name)).join('\n')
     clipboardData.setData('text/html', buildOpenPencilClipboardHTML(selectedNodes, ctx.graph))
     clipboardData.setData('text/plain', names)
 


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `desktop/src/fig_container.rs:L54`

In desktop/src/fig_container.rs, the image entry names from the zip file are used directly without validation. An attacker could craft a malicious .fig file with entries like '../../../etc/passwd' that could write files outside the intended directory.

## Solution

Validate that entry names do not contain path traversal sequences ('..' or absolute paths). Use a function like: fn is_safe_path(name: &str) -> bool { !name.contains("..") && !name.starts_with('/') && !name.contains(':') }

## Changes

- `desktop/src/fig_container.rs` (modified)
- `packages/core/src/editor/clipboard/copy.ts` (modified)