### PR TITLE
fix(cli): support documented open-pencil command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,29 +2,30 @@
   "name": "@open-pencil/cli",
   "version": "0.12.2",
   "license": "MIT",
-  "type": "module",
-  "imports": {
-    "#cli/*": "./src/*"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-pencil/open-pencil.git",
+    "directory": "packages/cli"
   },
   "bin": {
+    "open-pencil": "./bin/openpencil.js",
     "openpencil": "./bin/openpencil.js"
   },
   "files": [
     "bin",
     "dist"
   ],
-  "scripts": {
-    "build": "bunx tsdown --config tsdown.config.ts",
-    "prepublishOnly": "bun run build"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/open-pencil/open-pencil.git",
-    "directory": "packages/cli"
+  "type": "module",
+  "imports": {
+    "#cli/*": "./src/*.ts"
   },
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "scripts": {
+    "build": "bunx tsdown --config tsdown.config.ts",
+    "prepublishOnly": "bun run build"
   },
   "dependencies": {
     "@open-pencil/core": "workspace:*",


### PR DESCRIPTION
## Summary

Fixes two CLI package metadata issues:

- resolves Bun source execution for CLI-internal `#cli/*` package imports by mapping them to TypeScript source files explicitly
- exposes the documented `open-pencil` binary name in addition to the existing `openpencil` alias

## Why

The CLI docs and help text refer to the command as `open-pencil`, but the published package only declares `openpencil` as its bin. Also, when running the CLI source with Bun, internal imports such as `#cli/format` can fail because the package import map points to `./src/*` without the `.ts` extension.

## Verification

- `bun packages/cli/src/index.ts --help`
- `bun --filter @open-pencil/core build`
- `bun --filter @open-pencil/cli build`
- `node packages/cli/bin/openpencil.js --help`
- `bunx oxfmt --check packages/cli/package.json`
- `git diff --check`