### PR TITLE
Add split canvas panes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,7 +228,8 @@ Release commits are the exception: keep using `Release v0.x.y`.
 - P2P via Trystero (WebRTC) — no server relay. Signaling over MQTT public brokers.
 - Yjs CRDT for document state sync. Awareness protocol for cursors/selections/presence.
 - y-indexeddb for local persistence — room survives page refresh.
-- Constants in `src/constants.ts`: `TRYSTERO_APP_ID`, `PEER_COLORS`, `ROOM_ID_LENGTH`, `ROOM_ID_CHARS`, `YJS_JSON_FIELDS`
+- Constants in `src/constants.ts`: `TRYSTERO_APP_ID`, `PEER_COLORS`, `ROOM_ID_LENGTH`, `ROOM_ID_CHARS`
+- Collaboration node encoding/decoding lives in `src/app/collab/node-codec.ts`; do not add ad-hoc Yjs JSON field allow-lists.
 - `src/app/collab/use.ts` — composable: connect/disconnect, cursor/selection broadcasting, follow mode, Yjs ↔ SceneGraph sync
 - Provided via `COLLAB_KEY` injection — `useCollabInjected()` in child components
 - ICE servers: Google STUN + Cloudflare STUN + Open Relay TURN (TCP + UDP)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Add split canvas panes with independent page, viewport, selection, and cursor state inside a shared editor tab.
+
 ### Fixes
 
 - Greatly improve importing Figma `.fig` files with complex component systems: badges, avatars, icons, links, input fields, lists, date pickers, nested instances, component swaps, and variant properties now open much closer to their original Figma appearance.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Or download from the [releases page](https://github.com/open-pencil/open-pencil/
 - **Fully programmable** — headless CLI, XPath queries, Figma Plugin API via `eval`, MCP server for AI agents, and desktop agent integrations for Claude Code, Codex, and Gemini CLI
 - **Lint, convert, and extract tokens** — inspect documents, lint naming/layout/accessibility, convert between supported formats, analyze colors/typography/spacing/clusters, and extract design tokens
 - **Components and variants** — create reusable components, group variants into component sets, insert local assets as instances, and switch variants from the inspector
+- **Split canvas panes** — compare pages or focus different areas of the same document with independent pane zoom, pan, and selection state
 - **Design-to-code export** — export selections as JSX/Tailwind, generate token outputs, and map designs into component-oriented code workflows
 - **Vue SDK for custom editors** — headless components and composables for embedding OpenPencil into other apps or building workflow-specific editing surfaces. [Read the SDK docs →](https://openpencil.dev/programmable/sdk/)
 - **Real-time collaboration** — P2P via WebRTC, no server, no account. Cursors, presence, follow mode

--- a/openspec/changes/add-split-canvas-panes-main-refresh/.openspec.yaml
+++ b/openspec/changes/add-split-canvas-panes-main-refresh/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-28

--- a/openspec/changes/add-split-canvas-panes-main-refresh/design.md
+++ b/openspec/changes/add-split-canvas-panes-main-refresh/design.md
@@ -1,0 +1,144 @@
+## Context
+
+Current `origin/master` renders one `EditorCanvas` per active tab. `EditorCanvas.vue` mounts a scene canvas and overlay canvas, wires `useCanvas`, `useCanvasInput`, text edit, drop handling, canvas context menu, and collaboration awareness against `useEditorStore()`.
+
+The core `EditorState` still mixes document-wide state and view-local state in one object: `currentPageId`, `selectedIds`, `panX`, `panY`, `zoom`, hover, text/pen/node-edit/drag overlays, remote cursors, render counters, loading, and document metadata. Vue canvas rendering passes `editor.state` directly to `renderFromEditorState()`, and input helpers mutate `editor.state` directly. Singleton services such as keyboard, command registry, export, panels, and collaboration resolve one active editor/store.
+
+The refreshed Evoton pack `../../evoton/docs/studies/open-pencil-main-split-canvases-refresh/` records this current-main source inspection. It recommends rebuilding same-document split panes on current main with pane-local state first, rejecting layout-only duplicated `EditorCanvas`, reusing the existing multiple-renderer lifecycle with pane-specific render-state hooks, routing singleton services through active pane, and capping visible panes until resource measurements exist.
+
+Key evidence trace from the pack:
+
+| Evidence ID | Current-main source | Captured finding |
+| --- | --- | --- |
+| `source:main-editor-state-mixed-view-document` | `packages/core/src/editor/state.ts`, `packages/core/src/editor/types.ts` | `EditorState` mixes document and view fields such as page, selection, hover, pan/zoom, interaction state, and document metadata. |
+| `source:main-core-multiple-renderers` | `packages/core/src/editor/create.ts` | Core editor tracks a `Set<SkiaRenderer>`, so multiple surfaces are mechanically supported, but state is still single/global. |
+| `source:main-vue-canvas-renders-global-state` | `packages/vue/src/canvas/surface/use.ts`, `surface/lifecycle.ts` | Canvas rendering calls `renderFromEditorState(editor.state, ...)` with no pane render-state hook. |
+| `source:main-vue-input-mutates-global-state` | `packages/vue/src/canvas/useCanvasInput.ts` and shared input helpers | Input reads/mutates one `editor.state`, so duplicate canvases would mirror interactions. |
+| `source:main-editor-canvas-single-host` | `src/components/EditorCanvas.vue` | Current canvas host wires one active store to scene/overlay canvases, input, text edit, drop, menu, and collab awareness. |
+| `source:main-editor-view-single-canvas` | `src/views/EditorView.vue` | Desktop, mobile, collapsed, and bare branches each mount one `EditorCanvas` for the active tab. |
+| `source:main-active-store-singleton-proxy` | `src/app/editor/active-store/index.ts` | `useEditorStore()` proxies one active `EditorStore`; active-pane routing must layer on top. |
+| `source:main-commands-single-editor-context` | `packages/vue/src/editor/commands/use.ts`, `src/app/shell/keyboard/use.ts` | Command and keyboard paths resolve one current editor context. |
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Support multiple independently interactive canvas panes for one document/store.
+- Keep graph, undo, document IO, autosave, active tool, loading, tabs, and collaboration shared per document.
+- Make page, viewport, selection, hover, cursor, remote cursor projection, and transient overlays pane-local.
+- Preserve current single-canvas behavior through compatibility APIs during migration.
+- Render recursive split panes with Reka UI splitter primitives.
+- Reuse CanvasKit/SkiaRenderer and existing multi-renderer lifecycle.
+- Route singleton UI and commands through the active pane.
+- Cleanly commit/cancel long-running interactions on pane switch/close, page switch, and graph replacement.
+- Enforce a conservative initial visible-pane cap.
+
+**Non-Goals:**
+
+- Showing different documents in split panes.
+- Separate undo stacks per pane.
+- Per-pane active tools in the first slice.
+- Persisting split layout in `.fig` files.
+- Replacing CanvasKit, renderer architecture, or Reka splitter primitives.
+- Unlimited visible panes, pane virtualization, or inactive pane throttling in the first slice.
+- New explicit non-active automation/MCP targeting APIs.
+
+## Decisions
+
+### Decision: Use one shared document editor plus pane-local view state
+
+One `EditorStore` remains the document owner. A new pane registry stores pane-local view state and split tree state for that document. Shared state includes graph, undo, IO, active tool, loading, document metadata, and collaboration room. Pane-local state includes current page, selection, pan/zoom, viewport size, hover, entered container, cursor, remote cursor projection, marquee, snap/rotation/drop/layout overlays, page viewport memory, and tool interaction state that cannot be safely shared.
+
+Alternatives considered:
+
+- **Layout-only duplicate `EditorCanvas`**: rejected because current main would mirror page, selection, pan, zoom, hover, and interactions across panes.
+- **Full `EditorStore` per pane**: rejected because it duplicates graph, undo, IO, autosave, and collaboration ownership for one document.
+- **Hidden global state swapping**: rejected because multiple render/input loops and async font/render events would be order-dependent.
+
+### Decision: Add pane-bound editor facade
+
+Canvas input, render, page/selection/viewport UI, and pane-sensitive singleton services should use a pane-bound facade rather than raw `editor.state`. The facade reads shared document data from the editor/store and pane-local data from the pane registry.
+
+The compatibility `useEditorStore()` path can remain, but active-pane-sensitive getters/actions should resolve through the active pane facade so existing panels and commands migrate incrementally.
+
+### Decision: Classify state ownership before refactor
+
+The implementation starts by explicitly classifying fields:
+
+- Shared: graph, undo, document IO/source, autosave, `activeTool`, loading, document metadata, scene version, sidebars/toolbar state.
+- Pane-local: current page, selected IDs, pan/zoom, viewport dimensions, hover, entered container, cursor, marquee, snap guides, remote cursor projection, page viewport memory, rotation/drop/layout overlays.
+- Guarded pane-local interactions: text edit, pen state, node/vector edit, transform/drag state, auto-layout padding edit.
+
+Undo remains document-wide. Undo/redo should not mutate inactive pane-local page/viewport/selection except to sanitize IDs invalidated by graph changes.
+
+### Decision: Extend rendering with pane-specific state hooks
+
+`useCanvas()` and the surface render loop gain optional hooks such as `getRenderState()` and `onViewportResize(width, height)`. Legacy callers without these hooks keep rendering `editor.state`.
+
+Graph mutations increment shared scene invalidation and repaint all panes. Pane-only viewport/page/selection/hover changes increment only the target pane's render counter unless they also mutate the graph.
+
+### Decision: Render recursive split UI with Reka primitives
+
+The central canvas host becomes a recursive split tree using `SplitterGroup`, `SplitterPanel`, and `SplitterResizeHandle`. Split sizes are stored in the pane registry, not via Reka `autoSaveId` in the first slice. Split tree helpers must preserve stable pane IDs, validate layout payloads, collapse one-child parents, and refuse last-pane close.
+
+### Decision: Active pane drives singleton UI
+
+Properties, layers, page list, toolbar, zoom controls, context menu, keyboard shortcuts, clipboard defaults, export defaults, automation/FigmaAPI context, and collaboration local/remote cursor projection read the active pane. Pointerdown, focus, contextmenu, wheel/gesture start, and drop enter activate the source pane before command handling.
+
+### Decision: Collaboration remains one document room with pane-derived presence
+
+For same-document panes, collaboration remains scoped to the document store/room. Raw peer awareness remains shared for the document. Each pane derives visible remote cursors by comparing peer page with that pane's current page. Local cursor/selection broadcast uses the active pane for the connected document.
+
+### Decision: First slice uses split root everywhere, but mobile is single-pane only
+
+Desktop, collapsed, bare, and mobile branches should all mount `CanvasSplitRoot` so lifecycle and compatibility paths stay unified. Mobile does not expose split controls in the first slice and recovers/refuses to one visible pane. Desktop, collapsed, and bare layouts may expose split controls subject to the pane cap.
+
+### Decision: First-slice pane-local overlay and interaction ownership
+
+Pane-local first-slice state includes marquee, snap guides, rotation preview, drop target, layout insert indicator, hover, entered container, cursor, remote cursor projection, node edit state, text editing state, pen state, vector/node-edit state, transform drag state, and auto-layout padding edit state. Any overlay outside this list must either be explicitly classified before implementation or guarded so it only runs on the active pane.
+
+Interaction cleanup policy:
+
+| Interaction | Pane switch | Pane close | Graph replacement |
+| --- | --- | --- | --- |
+| Text edit | Commit | Commit before close | Commit if node still exists, otherwise cancel |
+| Move/resize/rotation preview | Commit if pointer-up equivalent is safe, otherwise cancel preview | Cancel preview and restore pre-preview state | Cancel preview |
+| Marquee/text selection drag | Cancel | Cancel | Cancel |
+| Pen in-progress path | Cancel unless a valid committed node exists | Cancel | Cancel |
+| Vector/node edit drag | Commit completed point/handle mutation if already applied through undo action, otherwise cancel preview | Cancel active drag | Clear invalid edit state |
+| Auto-layout padding edit | Commit current finite value | Commit current finite value before close | Cancel if node no longer exists |
+| Drop/layout insert indicator | Clear | Clear | Clear |
+
+### Decision: Resource guardrail starts conservative
+
+Use `MAX_VISIBLE_CANVAS_PANES = 4` unless current-main implementation findings force a lower cap. Split actions must be disabled/no-op before creating panes or canvases once the cap is reached. Resource tuning and virtualization are follow-ups.
+
+## Risks / Trade-offs
+
+- **Broad state refactor** → Start with named shared/pane state types, pure pane helpers, and compatibility accessors before rendering multiple panes.
+- **Render loops use wrong state** → Pass explicit pane render state to each canvas and test panes with different page/pan/zoom/selection.
+- **Input helpers still mutate global state** → Introduce pane-bound editor facade and migrate input by domain: viewport/page/selection first, then transforms/text/pen/node-edit.
+- **Long-running interactions leak** → Commit or cancel on pane switch, pane close, page switch, and graph replacement.
+- **Singleton services target stale pane** → Activate pane before pointer/context/focus and classify commands as document-wide vs pane-sensitive.
+- **WebGL resource pressure** → Enforce pane cap, test renderer disposal, and defer optimization.
+- **Main keeps moving** → Keep this spec tied to the refreshed evidence pack and rerun targeted source inspection before implementation if `origin/master` advances significantly again.
+
+## Migration Plan
+
+1. Add pane state, split tree, and active pane registry with one default pane.
+2. Add render state composition and pane render counters while preserving legacy single-canvas rendering.
+3. Add pane-bound viewport/page/selection facade and migrate singleton computed refs.
+4. Migrate canvas input to pane-bound state for basic pan/zoom/selection/page behavior.
+5. Replace direct `EditorCanvas` hosts with recursive split components.
+6. Audit singleton services and collaboration projection.
+7. Harden long-running interaction cleanup and graph/page sanitization.
+8. Add unit/component/E2E coverage and remove temporary compatibility shims where safe.
+
+Rollback strategy: keep one-pane compatibility throughout. If recursive UI is unstable, disable split actions while leaving the pane registry with one active pane.
+
+## Open Questions
+
+- Should inactive pane selections use the same selection styling, dimmed styling, or hidden styling after the first implementation?
+- Should the initial cap remain 4 after measuring current main in Tauri/WebView?
+- Should split layout persist in localStorage per document path after the first release?
+- Should mobile expose split controls after the first release, or remain single-pane long term?

--- a/openspec/changes/add-split-canvas-panes-main-refresh/proposal.md
+++ b/openspec/changes/add-split-canvas-panes-main-refresh/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The previous split-pane branch diverged from a now much newer `origin/master`, so the one-document split canvas feature needs to be specified and rebuilt against the current main architecture instead of merged as-is. Users still need to inspect and edit different pages or regions of one document side by side while keeping document graph, undo, IO, autosave, and collaboration shared.
+
+This proposal is grounded in the refreshed Evoton evidence pack `../../evoton/docs/studies/open-pencil-main-split-canvases-refresh/`, exported and review-ready against `origin/master` at `ec31ea11`. The study confirms that current main still has a single `EditorCanvas` host, global mixed document/view `EditorState`, no pane render-state hook, singleton command services, and existing multi-renderer lifecycle support.
+
+## What Changes
+
+- Add a per-document canvas pane registry with one shared document editor/store and multiple pane-local view states.
+- Split view-local state out of global editor state ownership for pane-sensitive behavior: current page, selection, pan/zoom, viewport size, hover, cursor, remote cursor projection, and transient overlays.
+- Keep document-wide state shared per document: graph, undo history, document IO/source state, autosave, active tool, loading, tabs, sidebars, toolbar, and collaboration room.
+- Add a pane-bound editor facade used by canvas input, render, page/selection/viewport actions, and singleton UI defaults.
+- Extend Vue canvas rendering to accept pane-specific render state and pane resize callbacks while preserving legacy single-canvas callers.
+- Render recursive horizontal/vertical split panes in the central canvas area using Reka UI splitter primitives.
+- Route singleton UI and commands through the active pane: properties, layers, page list, toolbar, zoom controls, keyboard/menu actions, clipboard defaults, export defaults, automation, and collaboration awareness rendering.
+- Add lifecycle cleanup for long-running interactions when switching panes, closing panes, switching pages, or replacing the graph.
+- Add an initial visible pane cap and tests for resource cleanup.
+
+## Capabilities
+
+### New Capabilities
+
+- `split-canvas-panes-main-refresh`: Recursive canvas split panes within one document on current main, including pane-local view state, pane-aware render/input, active-pane singleton routing, collaboration projection, and resource guardrails.
+
+### Modified Capabilities
+
+- None. There are no archived baseline capabilities in this repository yet.
+
+## Impact
+
+- Core editor state and actions under `packages/core/src/editor/*`, especially state ownership, viewport, pages, selection, render counters, and lifecycle cleanup.
+- Vue canvas SDK under `packages/vue/src/canvas/*`, including `useCanvas`, surface render loop/lifecycle, `useCanvasInput`, drop/text/pen/node-edit/transform inputs, and command composables.
+- App editor session and store wrappers under `src/app/editor/session`, `src/app/editor/active-store`, and new pane modules under `src/app/editor/panes`.
+- Central canvas components under `src/components`, replacing direct `EditorCanvas` hosts with split-pane components while keeping single-pane behavior compatible.
+- Singleton services under keyboard/menu/clipboard/export/automation/collaboration/panels that currently resolve one active editor state.
+- Tests for pane registry helpers, pane render state composition, split UI, active-pane routing, interaction cleanup, and E2E split workflows.

--- a/openspec/changes/add-split-canvas-panes-main-refresh/specs/split-canvas-panes-main-refresh/spec.md
+++ b/openspec/changes/add-split-canvas-panes-main-refresh/specs/split-canvas-panes-main-refresh/spec.md
@@ -1,0 +1,210 @@
+## ADDED Requirements
+
+### Requirement: Pane registry per document
+The system SHALL maintain a pane registry per document store with one shared document editor and one or more pane-local view states.
+
+#### Scenario: Initial document creates one pane
+- **WHEN** a document store is created
+- **THEN** the system creates exactly one canvas pane in that document's pane registry
+- **AND** the pane is the active pane
+- **AND** the pane uses the document's initial page, viewport, and empty selection state
+
+#### Scenario: Pane-local view state is independent
+- **WHEN** two panes exist for the same document
+- **THEN** each pane has independent current page, pan, zoom, viewport size, selection, hover, entered container, cursor, remote cursor projection, and transient overlay state
+- **AND** the document graph, undo history, document IO, autosave, active tool, loading state, tabs, sidebars, toolbar, and collaboration room remain shared for that document
+
+#### Scenario: Same document graph is shared
+- **WHEN** a user creates, edits, moves, or deletes a node in one pane
+- **THEN** the shared document graph is mutated once
+- **AND** every pane showing the affected page repaints with the graph update
+
+### Requirement: Recursive split pane tree
+The system SHALL manage recursive horizontal and vertical split layouts without losing pane state.
+
+#### Scenario: Split right creates horizontal split
+- **WHEN** the user splits a pane to the right
+- **THEN** the pane leaf is replaced by a horizontal split node
+- **AND** the split contains the source pane and a new pane
+- **AND** both pane IDs remain stable during later resizing
+
+#### Scenario: Split down creates vertical split
+- **WHEN** the user splits a pane downward
+- **THEN** the pane leaf is replaced by a vertical split node
+- **AND** the split contains the source pane and a new pane
+- **AND** both pane IDs remain stable during later resizing
+
+#### Scenario: New pane clones viewport but not selection
+- **WHEN** a pane is split
+- **THEN** the new pane starts on the source pane's current page
+- **AND** the new pane starts with the source pane's pan and zoom
+- **AND** the new pane starts with an empty selection
+
+#### Scenario: Closing pane collapses split tree
+- **WHEN** the user closes a pane and at least one other pane remains
+- **THEN** the pane is removed from the split tree
+- **AND** split parents with one remaining child are collapsed
+- **AND** a remaining pane becomes active if the closed pane was active
+
+#### Scenario: Closing last pane is refused
+- **WHEN** the user attempts to close the only remaining pane
+- **THEN** the system refuses the operation
+- **AND** no split tree or pane state is mutated
+
+### Requirement: Reka splitter rendering
+The system SHALL render split canvas panes with Reka UI splitter primitives.
+
+#### Scenario: Horizontal split renders Reka horizontal group
+- **WHEN** a split node direction is horizontal
+- **THEN** the UI renders a Reka `SplitterGroup` with `direction="horizontal"`
+- **AND** the split children render as ordered `SplitterPanel` components separated by `SplitterResizeHandle`
+
+#### Scenario: Vertical split renders Reka vertical group
+- **WHEN** a split node direction is vertical
+- **THEN** the UI renders a Reka `SplitterGroup` with `direction="vertical"`
+- **AND** the split children render as ordered `SplitterPanel` components separated by `SplitterResizeHandle`
+
+#### Scenario: Valid layout sizes are stored
+- **WHEN** Reka emits a valid layout array for a split group
+- **THEN** the system stores those sizes in the matching split node
+- **AND** no pane IDs are recreated
+
+#### Scenario: Invalid layout payload is ignored
+- **WHEN** Reka emits an empty, wrong-length, negative, or non-finite layout array
+- **THEN** the system keeps the previous split node sizes
+- **AND** no pane state is recreated
+
+### Requirement: Pane-aware rendering
+The system SHALL render each pane from explicit pane render state rather than hidden global state swapping.
+
+#### Scenario: Pane render uses composed state
+- **WHEN** a pane canvas renders
+- **THEN** it receives render state composed from shared document state and that pane's view state
+- **AND** it does not read another pane's page, selection, pan, zoom, hover, cursor, or overlays
+
+#### Scenario: Pane resize updates target pane only
+- **WHEN** a pane canvas is resized by a splitter or viewport change
+- **THEN** only that pane's viewport width and height are updated
+- **AND** no other pane's viewport dimensions are overwritten
+
+#### Scenario: Graph mutation invalidates all panes
+- **WHEN** the shared document graph changes
+- **THEN** every pane renderer for that document is invalidated
+- **AND** every pane showing affected content repaints
+
+#### Scenario: Pane-only viewport change repaints target pane
+- **WHEN** the user pans or zooms one pane
+- **THEN** only that pane's viewport state changes
+- **AND** inactive panes keep their previous pan and zoom
+
+### Requirement: Pane-bound input
+The system SHALL process canvas input against the source pane.
+
+#### Scenario: Pointer input activates source pane
+- **WHEN** the user pointer-downs in a pane
+- **THEN** the system activates that pane before processing selection, drag, resize, text, pen, node-edit, or other input
+
+#### Scenario: Panning one pane does not pan another
+- **WHEN** two panes display the same page
+- **AND** the user pans one pane
+- **THEN** only that pane's pan changes
+- **AND** the other pane keeps its previous viewport state
+
+#### Scenario: Selecting in one pane does not select in another
+- **WHEN** two panes exist
+- **AND** the user selects nodes in one pane
+- **THEN** only that pane's selection changes
+- **AND** inactive panes keep their previous selection unless graph changes invalidate selected IDs
+
+#### Scenario: Switching page affects active pane only
+- **WHEN** two panes exist
+- **AND** the user switches page through page UI or command
+- **THEN** only the active pane's current page changes
+- **AND** inactive panes keep their current pages
+
+### Requirement: Long-running interaction cleanup
+The system SHALL commit or cancel pane-owned interactions when pane context changes according to the cleanup policy defined by interaction type.
+
+#### Scenario: Active pane changes during text edit
+- **WHEN** a pane owns an active text editing session
+- **AND** the user activates another pane
+- **THEN** the system commits the text edit before changing the active pane
+- **AND** no caret or text edit state remains attached to the inactive editing pane after commit
+
+#### Scenario: Pane closes during interaction
+- **WHEN** a pane with active drag, marquee, resize, rotation, pen, node-edit, vector-edit, text edit, or auto-layout padding edit is closed
+- **THEN** text edit and finite auto-layout padding edits are committed before close
+- **AND** marquee, drop indicators, uncommitted pen paths, and preview-only transform or edit drags are canceled or cleared
+- **AND** no interaction state remains attached to the closed pane
+
+#### Scenario: Graph replacement sanitizes pane state
+- **WHEN** the document graph is replaced or reloaded
+- **THEN** every pane points to a valid page
+- **AND** pane-local selection, hover, cursor, and overlay IDs that no longer exist are cleared
+
+### Requirement: Active-pane singleton routing
+The system SHALL route singleton UI and commands through the active pane for pane-sensitive behavior.
+
+#### Scenario: Properties panel follows active pane selection
+- **WHEN** two panes have different selections
+- **AND** the user activates one pane
+- **THEN** the properties panel displays the active pane's selected node state
+
+#### Scenario: Layers and page UI follow active pane
+- **WHEN** the active pane changes
+- **THEN** the layer tree displays the active pane's current page
+- **AND** layer selection highlights the active pane's selection
+- **AND** the page list marks the active pane's current page
+
+#### Scenario: Keyboard shortcut targets active pane
+- **WHEN** two panes exist
+- **AND** the user invokes a pane-sensitive keyboard shortcut
+- **THEN** the command applies to the active pane
+- **AND** inactive pane-local state is not changed by that command
+
+#### Scenario: Clipboard paste uses active pane target
+- **WHEN** the user pastes content without an explicit cursor target
+- **THEN** the paste target is the active pane cursor if available
+- **AND** otherwise the paste target is the active pane viewport center
+
+#### Scenario: Export defaults use active pane
+- **WHEN** the user exports without passing an explicit target
+- **THEN** the export target is the active pane selection if non-empty
+- **AND** otherwise the export target is the active pane current page
+
+### Requirement: Collaboration projection per pane
+The system SHALL keep the collaboration room shared per document and derive pane-local presence rendering.
+
+#### Scenario: Local awareness uses active pane
+- **WHEN** the document is connected to a collaboration room
+- **AND** the user moves the cursor or changes selection in the active pane
+- **THEN** local awareness broadcasts the active pane's cursor, page, zoom, and selection for that document
+
+#### Scenario: Remote cursors are filtered by pane page
+- **WHEN** remote peer cursor data is available for the document
+- **THEN** each pane renders remote cursors whose peer page matches that pane's current page
+- **AND** panes on other pages do not render those remote cursors
+
+#### Scenario: Pane switching does not reconnect collaboration
+- **WHEN** the user switches active pane within a connected document
+- **THEN** the collaboration room remains connected
+- **AND** the room is not disconnected or recreated because of pane activation
+
+### Requirement: Visible pane resource cap
+The system SHALL enforce an initial visible pane cap of 4 for one document on non-mobile layouts and SHALL keep mobile single-pane-only in the first slice.
+
+#### Scenario: Split action disabled at pane cap
+- **WHEN** the document already has 4 visible panes
+- **AND** the user attempts to split another pane
+- **THEN** the split action is disabled or returns a clear no-op result
+- **AND** no partial pane, split node, or canvas is created
+
+#### Scenario: Mobile remains single pane
+- **WHEN** the editor is in mobile layout
+- **THEN** split controls are not exposed in the first slice
+- **AND** the split root renders or recovers to one visible pane
+
+#### Scenario: Closing pane disposes canvas resources
+- **WHEN** a pane is closed
+- **THEN** its canvas surfaces and renderers are disposed through existing canvas lifecycle cleanup
+- **AND** remaining panes continue rendering

--- a/openspec/changes/add-split-canvas-panes-main-refresh/tasks.md
+++ b/openspec/changes/add-split-canvas-panes-main-refresh/tasks.md
@@ -1,0 +1,89 @@
+## Implementation Status
+
+Most first-slice implementation tasks are complete. Remaining unchecked items are explicit follow-up coverage gaps for component/E2E tests that require browser harness work beyond the targeted engine tests run in this pass.
+
+## 1. State Ownership and Guardrails
+
+- [x] 1.1 Add tests that lock current single-canvas page switch, pan/zoom, selection, export default, and keyboard command behavior before refactoring.
+- [x] 1.2 Add `EditorSharedState` and `EditorPaneState` types with explicit ownership for current main fields.
+- [x] 1.3 Add helpers to create default pane state from a page ID and optional legacy editor state.
+- [x] 1.4 Add pane-local per-page viewport storage helpers with tests for save, restore, delete, and clear behavior.
+- [x] 1.5 Add shared scene version and pane render version counters while preserving legacy `EditorState` compatibility.
+
+## 2. Pane Registry and Split Tree
+
+- [x] 2.1 Add pure split tree helpers for split, close, one-child parent collapse, leaf enumeration, child lookup, and size normalization.
+- [x] 2.2 Add unit tests for split tree split/close/collapse, stable pane IDs, last-pane close refusal, cap refusal, and invalid layout payload rejection.
+- [x] 2.3 Add per-document pane registry with one default pane and active pane recovery.
+- [x] 2.4 Add pane registry sanitization for page deletion, graph replacement/reload, deleted node IDs, and invalid overlay IDs.
+- [x] 2.5 Add pane viewport resize handling that updates only the target pane.
+- [x] 2.6 Enforce `MAX_VISIBLE_CANVAS_PANES = 4` before creating panes, split nodes, or canvases.
+
+## 3. Pane-Bound Editor Facade
+
+- [x] 3.1 Add pane-bound viewport methods for screen/canvas conversion, pan, zoom, zoom to fit, zoom to 100%, zoom to selection, and viewport center.
+- [x] 3.2 Add pane-bound selection reads and writes: select, clear selection, select all, get selected nodes, and get selected node.
+- [x] 3.3 Add pane-bound page switching with pane-local viewport memory.
+- [x] 3.4 Route active-pane-sensitive store getters and methods through the active pane facade while preserving single-pane behavior.
+- [x] 3.5 Update selection/page computed refs so properties, layers, page UI, and command state react to active pane changes.
+- [x] 3.6 Add tests proving active pane changes update singleton UI-derived state without mutating inactive panes.
+
+## 4. Pane-Aware Rendering
+
+- [x] 4.1 Add render state composition from shared document state plus target pane view state.
+- [x] 4.2 Extend `useCanvas()` with optional `getRenderState` and `onViewportResize` hooks while preserving legacy callers.
+- [x] 4.3 Update canvas surface render loop to observe shared scene invalidation plus target pane render version.
+- [x] 4.4 Ensure graph mutations invalidate all pane renderers and pane-only viewport changes repaint only the target pane.
+- [x] 4.5 Add tests for render state composition, independent pane render counters, and legacy rendering behavior.
+
+## 5. Pane-Aware Canvas Input
+
+- [x] 5.1 Update pointer geometry and hit-testing helpers to work with a pane-bound editor.
+- [x] 5.2 Update wheel, gesture, touch, and hand-tool pan/zoom input to mutate only the target pane.
+- [x] 5.3 Update selection, marquee, context selection, and drop handling to mutate only the target pane.
+- [x] 5.4 Add activation hooks so pointerdown, focusin, contextmenu, wheel/gesture start, and drag/drop enter activate the source pane before input handling.
+- [x] 5.5 Add lifecycle cleanup for text edit, drag, marquee, resize, rotation, pen, vector/node edit, and auto-layout padding edit on pane switch, page switch, pane close, and graph replacement following the design cleanup table.
+- [x] 5.6 Implement first-slice text editing as pane-aware or explicitly active-pane guarded with commit/cancel semantics.
+- [x] 5.7 Add tests for independent pan/zoom/selection/page switching and interaction cleanup.
+
+## 6. Split Pane UI Components
+
+- [x] 6.1 Add `CanvasSplitRoot` to host the per-document split tree and pane actions.
+- [x] 6.2 Add recursive `CanvasSplitNode` using Reka `SplitterGroup`, `SplitterPanel`, and `SplitterResizeHandle`.
+- [x] 6.3 Add `EditorCanvasPane` derived from current `EditorCanvas` with `paneId`, active-pane activation, pane render state, and pane-bound input.
+- [x] 6.4 Replace direct `EditorCanvas` usages in desktop, mobile, collapsed, and bare layout branches with `CanvasSplitRoot`; keep mobile controls hidden and force/recover mobile to one visible pane in the first slice.
+- [x] 6.5 Add split right, split down, and close pane actions with disabled states at cap and for last-pane close.
+- [x] 6.6 Add an active pane visual indicator that does not steal canvas pointer input.
+- [ ] 6.7 Add component tests for Reka splitter structure, stable panel order/IDs, layout size updates, split/close behavior, and active indicator.
+
+## 7. Singleton Service Audit
+
+- [x] 7.1 Classify keyboard/menu/command actions as document-wide or pane-sensitive.
+- [x] 7.2 Update keyboard shortcuts and command handlers so pane-sensitive view, selection, nudge, clipboard, and tool interaction commands route through active pane.
+- [x] 7.3 Update toolbar and zoom controls to display and mutate active pane state.
+- [x] 7.4 Update page list and layer tree behavior to follow active pane page and selection.
+- [x] 7.5 Update clipboard copy/cut/paste defaults to use active pane selection, cursor, and viewport center.
+- [x] 7.6 Update export defaults and export property UI to use active pane selection or current page.
+- [x] 7.7 Update automation/FigmaAPI and AI tool context to derive current page, selection, and viewport from active pane.
+- [x] 7.8 Replace pane-sensitive first-canvas DOM queries and window-size viewport fallbacks with pane registry APIs.
+- [x] 7.9 Add tests for singleton UI and command routing after activating different panes.
+
+## 8. Collaboration and Presence
+
+- [x] 8.1 Update local collaboration awareness to publish cursor, page, zoom, and selection from the active pane for the connected document.
+- [x] 8.2 Keep raw remote peer data document-shared and derive visible remote cursors per pane page.
+- [x] 8.3 Ensure pane switching within one connected document does not disconnect, reconnect, or recreate the collaboration room.
+- [x] 8.4 Update follow-peer behavior to target the active pane or a documented follow pane without mutating inactive panes.
+- [x] 8.5 Add tests for remote cursor filtering across panes with different pages and for pane switching while connected.
+
+## 9. Verification and Cleanup
+
+- [x] 9.1 Add unit tests for pane registry page deletion, graph replacement, active pane recovery, undo not corrupting inactive pane view state, and renderer disposal.
+- [ ] 9.2 Add component coverage proving inactive panes render their own selection state while singleton UI follows the active pane.
+- [ ] 9.3 Add Playwright coverage for split right/down, resize, independent pan/zoom, independent page switching, independent selection, active-pane properties, keyboard shortcut targeting, export defaults, and collaboration cursor projection.
+- [x] 9.4 Remove temporary compatibility shims that are no longer needed after the first slice.
+- [x] 9.5 Update `CHANGELOG.md` and user-facing docs if split panes are exposed in UI.
+- [x] 9.6 Run `bun run check` and fix type/lint issues.
+- [x] 9.7 Run `bun run format`.
+- [x] 9.8 Run targeted unit/component tests for pane/split/canvas state.
+- [ ] 9.9 Run targeted Playwright split-pane tests.

--- a/openspec/changes/fix-collab-yjs-node-codec/.openspec.yaml
+++ b/openspec/changes/fix-collab-yjs-node-codec/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-28

--- a/openspec/changes/fix-collab-yjs-node-codec/design.md
+++ b/openspec/changes/fix-collab-yjs-node-codec/design.md
@@ -1,0 +1,117 @@
+## Context
+
+OpenPencil collaboration stores scene graph nodes in a shared Yjs map. The current implementation serializes every object-valued `SceneNode` property with `JSON.stringify()`, then reconstructs props by parsing only keys in `YJS_JSON_FIELDS`. The allow-list omits required or renderer-sensitive fields such as `source`, `fillGeometry`, and `strokeGeometry`. During a two-person session, a remote-created shape can therefore arrive with invalid runtime values and crash the receiving peer in `clearEditedSourceMetadata()` or `geometryBlobBounds()`.
+
+Evoton research packs:
+
+| Pack | Relevant recommendation |
+|---|---|
+| `open-pencil-collab-yjs-geometry-source-metadata` | Fix the Yjs node codec boundary; keep source metadata and geometry guards as defense in depth; defer MQTT fallback. |
+| `open-pencil-collab-yjs-node-codec-impact` | Use an explicit collab-safe schema, preserve source metadata semantics, explicitly handle typed arrays, preserve suppress flags, keep codec graph-only, and add round-trip tests. |
+
+The split-pane feature keeps graph/document state shared while pane-local page, selection, hover, cursor, viewport, and render state stay outside collaboration. The collab codec must operate only on shared graph node/resource state.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Encode and decode Yjs node props through an explicit collab-safe schema instead of a drifting JSON parse allow-list.
+- Preserve valid runtime `SceneNode` invariants for remote-created and remote-updated nodes.
+- Restore `Uint8Array` geometry payloads when geometry is synchronized.
+- Preserve source metadata shape so `SceneGraph.updateNode()` and `.fig` import/export metadata semantics remain valid.
+- Preserve `fills[].imageHash` and the existing separate `yimages` binary resource synchronization path.
+- Preserve suppress flag behavior so remote Yjs changes do not echo back as local graph transactions.
+- Keep defensive source metadata and geometry guards as crash containment, not as the primary correctness mechanism.
+- Add focused unit tests that exercise the codec and Yjs graph application without requiring Trystero networking.
+
+**Non-Goals:**
+
+- Do not change Trystero/MQTT signaling, broker fallback, room discovery, or reconnect policy.
+- Do not synchronize split-pane pane-local view state.
+- Do not redesign Yjs conflict resolution or introduce a new CRDT structure for individual node fields.
+- Do not change public file format semantics or intentionally drop imported Figma raw metadata.
+
+## Decisions
+
+### Decision: introduce an explicit node codec module
+
+Add `src/app/collab/node-codec.ts` with focused functions such as:
+
+- `encodeNodeForYjs(node: SceneNode): Record<string, unknown>`
+- `decodeNodeFromYjs(ynode: Y.Map<unknown>): Partial<SceneNode>`
+- small normalizers for `SourceMetadata`, `GeometryPath[]`, and JSON-safe object fields.
+
+Rationale: the current `YJS_JSON_FIELDS` allow-list couples encoding and decoding poorly. A codec module centralizes the schema and makes each included field auditable.
+
+Alternative considered: add `source`, `fillGeometry`, and `strokeGeometry` to `YJS_JSON_FIELDS`. Rejected because it would not restore `Uint8Array` geometry blobs and would keep future field drift likely.
+
+### Decision: encode object fields intentionally, not automatically
+
+The codec should include shared graph fields that peers need for visual/document consistency. It must not blindly sync every property if that would propagate transient, import-only, or large fields without a decision.
+
+Initial field policy:
+
+| Field group | Policy |
+|---|---|
+| Identity/tree (`id`, `type`, `parentId`, `childIds`, `name`) | Include; remote create/update must preserve node identity, parent/page placement, and child ordering. |
+| Geometry/layout/style primitives | Include JSON-safe primitive values as-is. |
+| Visual object arrays (`fills`, `strokes`, `effects`, `styleRuns`, `fontVariations`, `fontFeatures`, `grid*`, component/variant/plugin arrays) | Include as JSON-compatible values with legacy string fallback. |
+| `vectorNetwork` | Include as JSON-compatible object with legacy string fallback. |
+| `source` | Include and decode to a valid `SourceMetadata` shape. Missing/partial source is materialized using default source metadata because `SceneNode.source` is a required runtime invariant. Existing imported metadata is preserved when present. |
+| `fillGeometry` / `strokeGeometry` | Include only valid entries; encode `commandsBlob` using the typed-array envelope described below and decode back to `Uint8Array`. Malformed entries are skipped. |
+| `textPicture` | Do not sync as graph authority; decode to `null` because it is a renderer cache that can be regenerated. |
+| `figmaDerivedTextGlyphs` | Preserve when JSON-compatible or typed-array-normalizable; otherwise omit/null rather than corrupting runtime text rendering. |
+| Pane-local editor state | Exclude entirely. |
+
+Typed-array envelope:
+
+```ts
+type EncodedUint8Array = { __type: 'Uint8Array'; data: number[] }
+```
+
+The decoder also accepts legacy JSON strings for fields that were previously stringified, at minimum: `fills`, `strokes`, `effects`, `styleRuns`, `fontVariations`, `fontFeatures`, `vectorNetwork`, `source`, `fillGeometry`, `strokeGeometry`, `figmaDerivedLayout`, `figmaDerivedTextGlyphs`, `overrides`, component metadata, `boundVariables`, `pluginData`, and `pluginRelaunchData`.
+
+Rationale: remote graph state must remain usable by renderer, layout, IO, and property panels, but the codec should make field decisions explicit.
+
+### Decision: keep `yimages` as the binary resource path
+
+Image bytes should continue to sync via the existing `yimages` map. The node codec only needs to preserve `fills[].imageHash` and other fill metadata so `syncNodeToYjs()` can populate `yimages` and receivers can resolve image fills.
+
+Rationale: image bytes are already separated from node props. Mixing them into the node codec would increase payload size and broaden risk.
+
+### Decision: preserve graph/Yjs suppress semantics
+
+The existing `suppressGraphSync` and `suppressYjsEvents` behavior must remain intact. The codec changes the payload shape, not the observer transaction model.
+
+Rationale: Evoton identified event feedback loops as a high regression risk. Remote updates must not echo back as new local writes.
+
+### Decision: graph-only collaboration boundary
+
+The codec must only operate on shared `SceneGraph` node data and graph resources. Split-pane state remains local to each editor session/pane.
+
+Rationale: same-document split panes intentionally share graph state while independent panes manage page/viewport/selection/cursor/render state locally.
+
+## Risks / Trade-offs
+
+- [Risk] Dropping or defaulting `source.fig` incorrectly can reduce `.fig` export fidelity. → Mitigation: normalize shape without deleting existing metadata; add tests for source metadata preservation/defaulting.
+- [Risk] JSON cannot round-trip `Uint8Array` geometry payloads. → Mitigation: use explicit typed-array encoding/decoding and test `commandsBlob instanceof Uint8Array` after decode.
+- [Risk] Blindly syncing all fields can propagate derived or large data unnecessarily. → Mitigation: centralize field handling in the codec and document sensitive field behavior in tests.
+- [Risk] Defensive guards can hide upstream corruption. → Mitigation: tests assert valid decoded remote payloads, not only no crashes.
+- [Risk] Remote update application can create Yjs feedback loops. → Mitigation: preserve suppress flags and test that apply-from-Yjs does not call local sync recursively.
+- [Risk] Split-pane render scheduling may amplify remote update churn. → Mitigation: keep codec graph-only and test/manual-check remote create with split panes open.
+- [Risk] MQTT warnings remain visible. → Mitigation: keep signaling fallback out of scope and document it as a separate follow-up.
+
+## Migration Plan
+
+1. Add the codec and tests without changing external document format.
+2. Wire `syncNodePropsToYMap()` and Yjs apply paths through the codec.
+3. Keep backward tolerance for already-stringified Yjs values during the session by accepting both encoded objects and legacy JSON strings where feasible.
+4. Run focused unit tests, pane tests, `bun run check`, and OpenSpec validation.
+5. Manual test: two peers in one room, remote create/update shape, optional split panes open on the receiving peer.
+
+Rollback is straightforward: revert the codec wiring and return to the prior allow-list behavior, though that reintroduces the remote shape crash.
+
+## Open Questions
+
+- Should derived Figma geometry always sync, or should the codec omit invalid derived geometry for locally-created non-vector shapes? Initial implementation should preserve valid payloads and skip only malformed entries.
+- Should the codec log skipped malformed fields in development? This may be useful but is not required for the first fix.

--- a/openspec/changes/fix-collab-yjs-node-codec/proposal.md
+++ b/openspec/changes/fix-collab-yjs-node-codec/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Two-person collaboration currently corrupts remote-created node payloads: object-valued `SceneNode` fields are serialized into Yjs as JSON strings, but only a small allow-list is parsed back. When one peer creates a shape, another peer can receive invalid `source`, `fillGeometry`, or `strokeGeometry` values and crash in source metadata clearing or geometry rendering.
+
+Evoton studies `open-pencil-collab-yjs-geometry-source-metadata` and `open-pencil-collab-yjs-node-codec-impact` trace the issue to the collaboration node codec boundary and identify impact risks across import/export metadata, typed geometry payloads, image resources, graph event feedback, and split-pane graph sharing.
+
+## What Changes
+
+- Replace the drifting `YJS_JSON_FIELDS` parse allow-list with an explicit collaboration-safe node codec for Yjs graph synchronization.
+- Preserve valid shared `SceneNode` graph state across peers, including source metadata, vector networks, style runs, image fills, and typed geometry payloads.
+- Normalize missing or malformed source metadata so remote updates cannot crash `SceneGraph.updateNode()` metadata clearing.
+- Keep defensive geometry guards as crash containment, while restoring valid typed payloads at the collab boundary.
+- Add focused regression coverage for remote-created node round-trips and guardrails against graph/Yjs feedback loops.
+- Defer Trystero/MQTT signaling fallback work; broker handshake warnings are a separate availability concern and not the root cause of the node payload crashes.
+
+## Capabilities
+
+### New Capabilities
+- `collab-yjs-node-codec`: Collaboration-safe encoding and decoding of shared scene graph node data through Yjs.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `src/app/collab/yjs-sync.ts`: node property serialization/deserialization, remote create/update application, image resource sync interactions, suppress flag behavior.
+- New collab codec module under `src/app/collab/` for explicit field handling and typed-array restoration.
+- `src/constants.ts`: remove or stop using the fragile `YJS_JSON_FIELDS` allow-list for node props.
+- `packages/core/src/scene-graph/source-metadata.ts`: tolerate missing/partial source metadata without losing imported Figma metadata semantics.
+- `packages/core/src/geometry.ts` and `packages/core/src/canvas/shapes.ts`: retain defensive geometry validation as defense in depth.
+- Tests under `tests/engine/` for codec round-trips, remote graph application, source metadata normalization, typed geometry blobs, image references, and no-echo sync behavior.

--- a/openspec/changes/fix-collab-yjs-node-codec/specs/collab-yjs-node-codec/spec.md
+++ b/openspec/changes/fix-collab-yjs-node-codec/specs/collab-yjs-node-codec/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Collaboration-safe node encoding
+The system SHALL encode shared scene graph node data for Yjs through an explicit collaboration-safe node codec instead of relying on a drifting JSON parse allow-list.
+
+#### Scenario: Object fields round-trip through the codec
+- **WHEN** a scene node with object-valued graph fields is synchronized to Yjs and decoded by another peer
+- **THEN** the decoded properties MUST preserve runtime-compatible values for shared graph fields such as fills, strokes, effects, style runs, vector network, source metadata, and geometry fields
+
+#### Scenario: Pane-local state is not encoded
+- **WHEN** a node is synchronized through the collaboration codec while split panes are open
+- **THEN** pane-local page, viewport, selection, hover, cursor, interaction, and render state MUST NOT be included in the encoded node payload
+
+### Requirement: Source metadata remains valid after remote sync
+The system SHALL ensure decoded remote node props contain valid source metadata shape before applying them to the scene graph.
+
+#### Scenario: Missing source metadata is normalized
+- **WHEN** a remote Yjs node payload omits source metadata or contains partial source metadata
+- **THEN** applying the payload to the graph MUST NOT throw while clearing edited source metadata
+- **AND** the receiving node MUST have a valid `source.fig` object with default raw metadata fields
+
+#### Scenario: Existing imported source metadata is preserved
+- **WHEN** a remote Yjs node payload includes imported Figma source metadata
+- **THEN** decoding and applying the payload MUST preserve raw size, raw transform, raw node fields, layout metadata, and component or symbol metadata present in the payload
+
+### Requirement: Geometry payloads remain typed
+The system SHALL preserve valid geometry payloads as typed `Uint8Array` command blobs across collaboration synchronization.
+
+#### Scenario: Geometry command blobs decode as Uint8Array
+- **WHEN** a remote Yjs node payload includes fill or stroke geometry command data
+- **THEN** decoded `fillGeometry` and `strokeGeometry` entries with command data MUST expose `commandsBlob` as `Uint8Array`
+
+#### Scenario: Malformed geometry does not crash rendering
+- **WHEN** a remote or imported node contains malformed geometry entries without valid command blobs
+- **THEN** bounds computation and CanvasKit path generation MUST skip those entries instead of throwing
+
+### Requirement: Binary image resources remain separate
+The system SHALL keep image bytes synchronized through the existing collaboration image resource map while preserving node fill references to those resources.
+
+#### Scenario: Image fill reference is preserved
+- **WHEN** a node with an image fill is synchronized to Yjs
+- **THEN** the node payload MUST preserve the fill's `imageHash`
+- **AND** the existing image resource synchronization MUST remain able to send the referenced bytes through the image map
+
+### Requirement: Remote graph updates do not echo
+The system SHALL preserve existing graph/Yjs suppress semantics when applying decoded remote node props.
+
+#### Scenario: Applying remote node update does not resync immediately
+- **WHEN** a Yjs observer applies a remote node update to the local scene graph
+- **THEN** the graph update MUST NOT be echoed back as a new local Yjs node synchronization transaction
+
+#### Scenario: Local sync still works after remote application
+- **WHEN** a remote Yjs update has been applied to the local scene graph
+- **AND** the local user later edits a node
+- **THEN** the local graph edit MUST still synchronize to Yjs
+
+### Requirement: Remote node creation is graph-compatible
+The system SHALL apply remote-created nodes with valid shared graph state on receiving peers.
+
+#### Scenario: Remote rectangle creation succeeds
+- **WHEN** one peer creates a rectangle and the Yjs node payload is applied on another peer
+- **THEN** the receiving graph MUST create or update the node without source metadata or geometry runtime errors
+- **AND** the receiving renderer MUST be able to render the document
+
+#### Scenario: Remote node placement is preserved
+- **WHEN** a remote-created node payload is applied on another peer
+- **THEN** the receiving graph MUST preserve the node id, parent id, page or frame containment, and child ordering from the payload
+
+#### Scenario: Remote vector creation preserves vector data
+- **WHEN** one peer creates or updates a vector node with vector network data
+- **THEN** the receiving graph MUST decode vector data into runtime-compatible vector network objects
+
+### Requirement: Legacy Yjs payloads remain readable
+The system SHALL tolerate node payload fields that were encoded by the previous JSON-string-based collaboration format during an active session.
+
+#### Scenario: Legacy stringified object field decodes
+- **WHEN** a Yjs node payload contains a legacy JSON string for a supported object field such as fills, strokes, effects, style runs, vector network, source metadata, or geometry
+- **THEN** the codec MUST decode the field into runtime-compatible graph values where valid
+
+### Requirement: Image resource ordering is tolerated
+The system SHALL tolerate image-filled node payloads arriving before their referenced image bytes.
+
+#### Scenario: Image node arrives before image bytes
+- **WHEN** a remote node with an image fill references an image hash that is not yet present in the local image map
+- **THEN** applying and rendering the node MUST NOT throw
+- **AND** the image fill MUST be able to resolve after the image map receives the referenced bytes

--- a/openspec/changes/fix-collab-yjs-node-codec/tasks.md
+++ b/openspec/changes/fix-collab-yjs-node-codec/tasks.md
@@ -1,0 +1,38 @@
+## 1. Codec Design and Wiring
+
+- [x] 1.1 Add `src/app/collab/node-codec.ts` with explicit encode/decode entrypoints for Yjs node payloads.
+- [x] 1.2 Define the concrete collab field policy in the codec, including included graph fields, excluded pane/cache fields, and legacy string fallbacks.
+- [x] 1.3 Move node object field handling out of `YJS_JSON_FIELDS` and into the codec.
+- [x] 1.4 Update `syncNodePropsToYMap()` and Yjs apply paths to use the codec while preserving public helper behavior for tests.
+- [x] 1.5 Preserve existing `suppressGraphSync` and `suppressYjsEvents` transaction behavior.
+
+## 2. Field Normalization
+
+- [x] 2.1 Normalize missing or partial source metadata to a valid `SourceMetadata` shape.
+- [x] 2.2 Preserve imported Figma raw metadata when valid source metadata is present in the payload.
+- [x] 2.3 Encode and decode `fillGeometry` and `strokeGeometry` command blobs with the `{ __type: 'Uint8Array', data: number[] }` envelope.
+- [x] 2.4 Preserve JSON-safe graph fields including fills, strokes, effects, style runs, vector networks, layout metadata, and component/instance metadata needed by shared graph state.
+- [x] 2.5 Decode legacy JSON-string payloads for supported object fields.
+- [x] 2.6 Preserve image fill `imageHash` values and keep image bytes on the existing `yimages` path.
+
+## 3. Defensive Boundaries
+
+- [x] 3.1 Keep renderer geometry guards that skip malformed command blobs without throwing.
+- [x] 3.2 Harden source metadata clearing against missing or partial metadata without changing normal imported metadata clearing semantics.
+- [x] 3.3 Keep collaboration payloads graph-only and avoid serializing pane-local split canvas state.
+
+## 4. Regression Coverage
+
+- [x] 4.1 Add codec unit tests for object field round-trips and legacy JSON string compatibility.
+- [x] 4.2 Add tests for source metadata defaulting and imported metadata preservation.
+- [x] 4.3 Add tests for `Uint8Array` geometry command blob round-trips and malformed geometry skipping.
+- [x] 4.4 Add tests for image fill references, image-before-bytes ordering, and vector network round-trips.
+- [x] 4.5 Add tests or a local Yjs simulation proving remote graph application does not echo back as an immediate local sync transaction and local graph sync still works afterward.
+- [x] 4.6 Add tests that remote create preserves node id, parent id, page/frame containment, and child ordering.
+
+## 5. Validation
+
+- [x] 5.1 Run focused collab/codec tests.
+- [x] 5.2 Run `bun run check`.
+- [x] 5.3 Run `openspec validate fix-collab-yjs-node-codec --strict`.
+- [x] 5.4 Manually test a two-peer session where one peer creates a shape and the other peer receives it, including with split panes open if feasible.

--- a/packages/core/src/canvas/shapes.ts
+++ b/packages/core/src/canvas/shapes.ts
@@ -1,6 +1,6 @@
 import type { Canvas, Path } from 'canvaskit-wasm'
 
-import { polygonVertices } from '#core/geometry'
+import { getGeometryCommandsBlob, polygonVertices } from '#core/geometry'
 import type { SceneNode } from '#core/scene-graph'
 import { vectorNetworkToPath, geometryBlobToPath } from '#core/vector'
 
@@ -527,20 +527,26 @@ export function getFillGeometry(r: SkiaRenderer, node: SceneNode): Path[] | null
   if (node.fillGeometry.length === 0) return null
   const cached = r.fillGeometryCache.get(node.id)
   if (cached) return cached
-  const paths = node.fillGeometry.map((g) =>
-    geometryBlobToPath(r.ck, g.commandsBlob, g.windingRule)
-  )
+  const paths: Path[] = []
+  for (const geometry of node.fillGeometry) {
+    const commandsBlob = getGeometryCommandsBlob(geometry)
+    if (!commandsBlob) continue
+    paths.push(geometryBlobToPath(r.ck, commandsBlob, geometry.windingRule))
+  }
   r.fillGeometryCache.set(node.id, paths)
-  return paths
+  return paths.length > 0 ? paths : null
 }
 
 export function getStrokeGeometry(r: SkiaRenderer, node: SceneNode): Path[] | null {
   if (node.strokeGeometry.length === 0) return null
   const cached = r.strokeGeometryCache.get(node.id)
   if (cached) return cached
-  const paths = node.strokeGeometry.map((g) =>
-    geometryBlobToPath(r.ck, g.commandsBlob, g.windingRule)
-  )
+  const paths: Path[] = []
+  for (const geometry of node.strokeGeometry) {
+    const commandsBlob = getGeometryCommandsBlob(geometry)
+    if (!commandsBlob) continue
+    paths.push(geometryBlobToPath(r.ck, commandsBlob, geometry.windingRule))
+  }
   r.strokeGeometryCache.set(node.id, paths)
-  return paths
+  return paths.length > 0 ? paths : null
 }

--- a/packages/core/src/editor/create.ts
+++ b/packages/core/src/editor/create.ts
@@ -174,6 +174,10 @@ export function createEditor(options?: EditorOptions) {
     _renderer = renderer
     _renderers.add(renderer)
     _textEditor ??= new TextEditor(ck)
+    if (typeof renderer.measureTextNode !== 'function') {
+      setTextMeasurer(null)
+      return
+    }
     setTextMeasurer((node, maxWidth) => renderer.measureTextNode(node, maxWidth))
   }
 

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -3,6 +3,15 @@ export type { Editor } from './create'
 export { createTextActions } from './text'
 export { EDITOR_TOOLS, TOOL_SHORTCUTS } from './tool-registry'
 export type { EditorToolDef } from './tool-registry'
+export { createDefaultEditorSharedState, EDITOR_SHARED_STATE_KEYS } from './shared-state'
+export type { EditorSharedState, EditorSharedStateKey } from './shared-state'
+export type { PageViewport } from './page-viewports'
+export {
+  copyEditorViewState,
+  createDefaultEditorViewState,
+  EDITOR_VIEW_STATE_KEYS
+} from './view-state'
+export type { EditorViewState, EditorViewStateKey } from './view-state'
 export type {
   EditorContext,
   EditorEventName,

--- a/packages/core/src/editor/page-viewports.ts
+++ b/packages/core/src/editor/page-viewports.ts
@@ -3,7 +3,7 @@ import type { Color } from '#core/types'
 
 import type { EditorContext } from './types'
 
-interface PageViewport {
+export interface PageViewport {
   panX: number
   panY: number
   zoom: number

--- a/packages/core/src/editor/shared-state.ts
+++ b/packages/core/src/editor/shared-state.ts
@@ -1,0 +1,24 @@
+import type { EditorState } from './types'
+
+export const EDITOR_SHARED_STATE_KEYS = [
+  'activeTool',
+  'remoteCursors',
+  'documentName',
+  'sceneVersion',
+  'loading',
+  'rulerTheme'
+] as const
+
+export type EditorSharedStateKey = (typeof EDITOR_SHARED_STATE_KEYS)[number]
+export type EditorSharedState = Pick<EditorState, EditorSharedStateKey>
+
+export function createDefaultEditorSharedState(): EditorSharedState {
+  return {
+    activeTool: 'SELECT',
+    remoteCursors: [],
+    documentName: 'Untitled',
+    sceneVersion: 0,
+    loading: false,
+    rulerTheme: undefined
+  }
+}

--- a/packages/core/src/editor/state.ts
+++ b/packages/core/src/editor/state.ts
@@ -1,31 +1,11 @@
-import { CANVAS_BG_COLOR } from '#core/constants'
 import type { EditorState } from '#core/editor/types'
+
+import { createDefaultEditorSharedState } from './shared-state'
+import { createDefaultEditorViewState } from './view-state'
 
 export function createDefaultEditorState(pageId: string): EditorState {
   return {
-    activeTool: 'SELECT',
-    currentPageId: pageId,
-    selectedIds: new Set<string>(),
-    marquee: null,
-    snapGuides: [],
-    rotationPreview: null,
-    dropTargetId: null,
-    layoutInsertIndicator: null,
-    hoveredNodeId: null,
-    editingTextId: null,
-    penState: null,
-    penCursorX: null,
-    penCursorY: null,
-    remoteCursors: [],
-    autoLayoutHover: null,
-    documentName: 'Untitled',
-    panX: 0,
-    pageColor: { ...CANVAS_BG_COLOR },
-    panY: 0,
-    zoom: 1,
-    renderVersion: 0,
-    sceneVersion: 0,
-    loading: false,
-    enteredContainerId: null
+    ...createDefaultEditorSharedState(),
+    ...createDefaultEditorViewState(pageId)
   }
 }

--- a/packages/core/src/editor/types.ts
+++ b/packages/core/src/editor/types.ts
@@ -64,6 +64,7 @@ export interface EditorState {
     x: number
     y: number
     selection?: string[]
+    pageId?: string
   }>
   autoLayoutHover: {
     nodeId: string

--- a/packages/core/src/editor/view-state.ts
+++ b/packages/core/src/editor/view-state.ts
@@ -1,0 +1,66 @@
+import { getDefaultCanvasBgColor } from '#core/constants'
+
+import type { EditorState } from './types'
+
+export const EDITOR_VIEW_STATE_KEYS = [
+  'currentPageId',
+  'selectedIds',
+  'marquee',
+  'snapGuides',
+  'rotationPreview',
+  'dropTargetId',
+  'layoutInsertIndicator',
+  'autoLayoutHover',
+  'hoveredNodeId',
+  'editingTextId',
+  'penState',
+  'penCursorX',
+  'penCursorY',
+  'panX',
+  'panY',
+  'zoom',
+  'renderVersion',
+  'pageColor',
+  'enteredContainerId'
+] as const
+
+export type EditorViewStateKey = (typeof EDITOR_VIEW_STATE_KEYS)[number]
+export type EditorViewState = Pick<EditorState, EditorViewStateKey>
+
+export function createDefaultEditorViewState(pageId: string): EditorViewState {
+  return {
+    currentPageId: pageId,
+    selectedIds: new Set<string>(),
+    marquee: null,
+    snapGuides: [],
+    rotationPreview: null,
+    dropTargetId: null,
+    layoutInsertIndicator: null,
+    autoLayoutHover: null,
+    hoveredNodeId: null,
+    editingTextId: null,
+    penState: null,
+    penCursorX: null,
+    penCursorY: null,
+    panX: 0,
+    panY: 0,
+    zoom: 1,
+    renderVersion: 0,
+    pageColor: { ...getDefaultCanvasBgColor() },
+    enteredContainerId: null
+  }
+}
+
+export function copyEditorViewState(source: EditorViewState): EditorViewState {
+  return {
+    ...source,
+    selectedIds: new Set(source.selectedIds),
+    snapGuides: structuredClone(source.snapGuides),
+    rotationPreview: structuredClone(source.rotationPreview),
+    layoutInsertIndicator: structuredClone(source.layoutInsertIndicator),
+    autoLayoutHover: structuredClone(source.autoLayoutHover),
+    penState: structuredClone(source.penState),
+    pageColor: { ...source.pageColor },
+    marquee: structuredClone(source.marquee)
+  }
+}

--- a/packages/core/src/geometry.ts
+++ b/packages/core/src/geometry.ts
@@ -257,11 +257,18 @@ function geometryCommandCoordCount(command: number): number | null {
   return null
 }
 
+export function getGeometryCommandsBlob(path: { commandsBlob: Uint8Array }): Uint8Array | null {
+  const blob = (path as { commandsBlob?: unknown }).commandsBlob
+  if (!(blob instanceof Uint8Array) || blob.byteLength === 0) return null
+  return blob
+}
+
 export function geometryBlobBounds(paths: Array<{ commandsBlob: Uint8Array }>): Rect | null {
   const bounds = createBoundsAccumulator()
 
   for (const path of paths) {
-    const blob = path.commandsBlob
+    const blob = getGeometryCommandsBlob(path)
+    if (!blob) continue
     const dv = new DataView(blob.buffer, blob.byteOffset, blob.byteLength)
     let offset = 0
     while (offset < blob.length) {

--- a/packages/core/src/geometry.ts
+++ b/packages/core/src/geometry.ts
@@ -253,14 +253,27 @@ export function intersectVisualBounds(a: VisualBounds, b: VisualBounds): VisualB
 function geometryCommandCoordCount(command: number): number | null {
   if (command === 0) return 0
   if (command === 1 || command === 2) return 1
+  if (command === 3) return 2
   if (command === 4) return 3
   return null
+}
+
+function isValidGeometryCommandsBlob(blob: Uint8Array): boolean {
+  let offset = 0
+  while (offset < blob.length) {
+    const command = blob[offset]
+    const coords = geometryCommandCoordCount(command)
+    if (coords == null) return false
+    offset += 1 + coords * 8
+    if (offset > blob.length) return false
+  }
+  return true
 }
 
 export function getGeometryCommandsBlob(path: { commandsBlob: Uint8Array }): Uint8Array | null {
   const blob = (path as { commandsBlob?: unknown }).commandsBlob
   if (!(blob instanceof Uint8Array) || blob.byteLength === 0) return null
-  return blob
+  return isValidGeometryCommandsBlob(blob) ? blob : null
 }
 
 export function geometryBlobBounds(paths: Array<{ commandsBlob: Uint8Array }>): Rect | null {

--- a/packages/core/src/scene-graph/index.ts
+++ b/packages/core/src/scene-graph/index.ts
@@ -32,6 +32,7 @@ import type {
   VariableValue
 } from './types'
 
+export { createDefaultSourceMetadata, normalizeSourceMetadata } from './source-metadata'
 export { cloneVectorNetwork, normalizeVectorNetwork, validateVectorNetwork } from './vector-network'
 
 let nextLocalID = 1

--- a/packages/core/src/scene-graph/node-defaults.ts
+++ b/packages/core/src/scene-graph/node-defaults.ts
@@ -1,5 +1,6 @@
 import { BLACK, DEFAULT_FONT_FAMILY, DEFAULT_STROKE_MITER_LIMIT } from '#core/constants'
 
+import { createDefaultSourceMetadata } from './source-metadata'
 import type { NodeType, SceneNode } from './types'
 
 export function createDefaultNode(
@@ -18,22 +19,7 @@ export function createDefaultNode(
     width: 100,
     height: 100,
     rotation: 0,
-    source: {
-      format: null,
-      id: null,
-      orderKey: null,
-      fig: {
-        rawSize: null,
-        rawTransform: null,
-        rawNodeFields: {},
-        layout: null,
-        symbolOverrides: [],
-        componentPropAssignments: [],
-        derivedSymbolData: [],
-        derivedSymbolDataLayoutVersion: null,
-        uniformScaleFactor: null
-      }
-    },
+    source: createDefaultSourceMetadata(),
     figmaDerivedLayout: null,
     fills:
       type === 'TEXT' ? [{ type: 'SOLID' as const, color: BLACK, opacity: 1, visible: true }] : [],

--- a/packages/core/src/scene-graph/source-metadata.ts
+++ b/packages/core/src/scene-graph/source-metadata.ts
@@ -1,4 +1,23 @@
-import type { SceneNode } from './types'
+import type { SceneNode, SourceMetadata } from './types'
+
+export function createDefaultSourceMetadata(): SourceMetadata {
+  return {
+    format: null,
+    id: null,
+    orderKey: null,
+    fig: {
+      rawSize: null,
+      rawTransform: null,
+      rawNodeFields: {},
+      layout: null,
+      symbolOverrides: [],
+      componentPropAssignments: [],
+      derivedSymbolData: [],
+      derivedSymbolDataLayoutVersion: null,
+      uniformScaleFactor: null
+    }
+  }
+}
 
 const RAW_SIZE_KEYS = new Set(['width', 'height'])
 
@@ -70,7 +89,38 @@ const RAW_NODE_FIELD_KEYS = new Set([
 ])
 
 export function clearEditedSourceMetadata(node: SceneNode, changeKeys: string[]): void {
+  node.source = normalizeSourceMetadata(node.source)
   if (changeKeys.some((key) => RAW_SIZE_KEYS.has(key))) node.source.fig.rawSize = null
   if (changeKeys.some((key) => RAW_TRANSFORM_KEYS.has(key))) node.source.fig.rawTransform = null
   if (changeKeys.some((key) => RAW_NODE_FIELD_KEYS.has(key))) node.source.fig.rawNodeFields = {}
+}
+
+export function normalizeSourceMetadata(source: unknown): SourceMetadata {
+  const defaults = createDefaultSourceMetadata()
+  if (!source || typeof source !== 'object') return defaults
+  const value = source as Partial<SourceMetadata>
+  const fig: Partial<SourceMetadata['fig']> =
+    value.fig && typeof value.fig === 'object' ? value.fig : {}
+  return {
+    format: value.format === 'fig' ? 'fig' : null,
+    id: typeof value.id === 'string' ? value.id : null,
+    orderKey: typeof value.orderKey === 'string' ? value.orderKey : null,
+    fig: {
+      rawSize: fig.rawSize ?? null,
+      rawTransform: fig.rawTransform ?? null,
+      rawNodeFields:
+        fig.rawNodeFields && typeof fig.rawNodeFields === 'object' ? fig.rawNodeFields : {},
+      layout: fig.layout ?? null,
+      symbolOverrides: Array.isArray(fig.symbolOverrides) ? fig.symbolOverrides : [],
+      componentPropAssignments: Array.isArray(fig.componentPropAssignments)
+        ? fig.componentPropAssignments
+        : [],
+      derivedSymbolData: Array.isArray(fig.derivedSymbolData) ? fig.derivedSymbolData : [],
+      derivedSymbolDataLayoutVersion:
+        typeof fig.derivedSymbolDataLayoutVersion === 'number'
+          ? fig.derivedSymbolDataLayoutVersion
+          : null,
+      uniformScaleFactor: typeof fig.uniformScaleFactor === 'number' ? fig.uniformScaleFactor : null
+    }
+  }
 }

--- a/packages/vue/src/canvas/drop/use.ts
+++ b/packages/vue/src/canvas/drop/use.ts
@@ -5,11 +5,16 @@ import type { Editor } from '@open-pencil/core/editor'
 
 const ACCEPTED_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/avif'])
 
-export function useCanvasDrop(canvasRef: Ref<HTMLCanvasElement | null>, editor: Editor) {
+export function useCanvasDrop(
+  canvasRef: Ref<HTMLCanvasElement | null>,
+  editor: Editor,
+  activate?: () => void
+) {
   const isDraggingOver = ref(false)
 
   useEventListener(canvasRef, 'dragover', (e: DragEvent) => {
     if (!hasImageFiles(e)) return
+    activate?.()
     e.preventDefault()
     if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
     isDraggingOver.value = true
@@ -17,6 +22,7 @@ export function useCanvasDrop(canvasRef: Ref<HTMLCanvasElement | null>, editor: 
 
   useEventListener(canvasRef, 'dragenter', (e: DragEvent) => {
     if (!hasImageFiles(e)) return
+    activate?.()
     e.preventDefault()
     isDraggingOver.value = true
   })
@@ -26,6 +32,7 @@ export function useCanvasDrop(canvasRef: Ref<HTMLCanvasElement | null>, editor: 
   })
 
   useEventListener(canvasRef, 'drop', (e: DragEvent) => {
+    activate?.()
     e.preventDefault()
     isDraggingOver.value = false
 

--- a/packages/vue/src/canvas/surface/gl-surface.ts
+++ b/packages/vue/src/canvas/surface/gl-surface.ts
@@ -8,10 +8,18 @@ type GLContext = ReturnType<CanvasKit['MakeGrContext']>
 
 export type CanvasGLContext = GLContext
 
-export function sizeCanvas(canvas: HTMLCanvasElement, editor: Editor) {
+export function sizeCanvas(
+  canvas: HTMLCanvasElement,
+  editor: Editor,
+  options?: Pick<UseCanvasOptions, 'onViewportResize'>
+) {
   const dpr = window.devicePixelRatio || 1
   canvas.width = canvas.clientWidth * dpr
   canvas.height = canvas.clientHeight * dpr
+  if (options?.onViewportResize) {
+    options.onViewportResize(canvas.clientWidth, canvas.clientHeight)
+    return
+  }
   if ('setViewportSize' in editor && typeof editor.setViewportSize === 'function') {
     editor.setViewportSize(canvas.clientWidth, canvas.clientHeight)
   }

--- a/packages/vue/src/canvas/surface/lifecycle.ts
+++ b/packages/vue/src/canvas/surface/lifecycle.ts
@@ -53,7 +53,7 @@ export function createCanvasSurfaceManager({
     state.glContext?.delete()
     state.glContext = null
 
-    sizeCanvas(canvas, editor)
+    sizeCanvas(canvas, editor, options)
 
     const result = makeGLSurface(ck, canvas, editor, options, state.glContext)
     state.glContext = result.glContext
@@ -81,7 +81,7 @@ export function createCanvasSurfaceManager({
   function renderNow() {
     if (!state.renderer || isDestroyed()) return
     state.renderer.renderFromEditorState(
-      editor.state,
+      options?.getRenderState?.() ?? editor.state,
       editor.graph,
       editor.textEditor,
       canvasRef.value?.clientWidth ?? 0,
@@ -97,7 +97,12 @@ export function createCanvasSurfaceManager({
     }
   }
 
-  const renderLoop = createCanvasRenderLoop(editor, renderNow, { layer: options?.layer })
+  const renderLoop = createCanvasRenderLoop(
+    editor,
+    renderNow,
+    { layer: options?.layer },
+    () => options?.getRenderState?.() ?? editor.state
+  )
 
   function resizeCanvas(canvas: HTMLCanvasElement) {
     const ck = getCanvasKit()
@@ -106,7 +111,7 @@ export function createCanvasSurfaceManager({
       return
     }
 
-    sizeCanvas(canvas, editor)
+    sizeCanvas(canvas, editor, options)
 
     const result = makeGLSurface(ck, canvas, editor, options, state.glContext)
     state.glContext = result.glContext

--- a/packages/vue/src/canvas/surface/render-loop.ts
+++ b/packages/vue/src/canvas/surface/render-loop.ts
@@ -53,50 +53,63 @@ function shouldScheduleForSelection(layer: CanvasRenderLayer | undefined) {
 export function createCanvasRenderLoop(
   editor: Editor,
   renderNow: () => void,
-  options: RenderLoopOptions = {}
+  options: RenderLoopOptions = {},
+  getRenderState: () => Editor['state'] = () => editor.state
 ) {
   const scheduler = getRenderScheduler(editor)
   let dirty = true
   let frameScheduled = false
   let lastRenderVersion = -1
+  let lastSceneVersion = -1
   let lastSelectedIds: Set<string> | null = null
 
   function renderFrame() {
     frameScheduled = false
-    if (editor.state.loading) {
-      scheduleRender()
+    const state = getRenderState()
+    if (state.loading) {
+      scheduleFrame()
       return
     }
 
-    const versionChanged = editor.state.renderVersion !== lastRenderVersion
-    const selectionChanged = editor.state.selectedIds !== lastSelectedIds
-    if (dirty || versionChanged || selectionChanged) {
+    const versionChanged = state.renderVersion !== lastRenderVersion
+    const sceneChanged = state.sceneVersion !== lastSceneVersion
+    const selectionChanged = state.selectedIds !== lastSelectedIds
+    if (dirty || versionChanged || sceneChanged || selectionChanged) {
       dirty = false
       renderNow()
     }
   }
 
-  const scheduleRender = () => {
-    dirty = true
+  const scheduleFrame = () => {
     if (frameScheduled) return
     frameScheduled = true
     scheduler.schedule(renderFrame)
   }
 
+  const scheduleVersionCheck = () => {
+    scheduleFrame()
+  }
+
+  const scheduleDirtyRender = () => {
+    dirty = true
+    scheduleFrame()
+  }
+
   const unsubscribe = [
-    editor.onEditorEvent('render:requested', scheduleRender),
-    editor.onEditorEvent('viewport:changed', scheduleRender)
+    editor.onEditorEvent('render:requested', scheduleVersionCheck),
+    editor.onEditorEvent('viewport:changed', scheduleVersionCheck),
+    editor.onEditorEvent('repaint:requested', scheduleVersionCheck)
   ]
 
-  unsubscribe.push(editor.onEditorEvent('repaint:requested', scheduleRender))
-
   if (shouldScheduleForSelection(options.layer)) {
-    unsubscribe.push(editor.onEditorEvent('selection:changed', scheduleRender))
+    unsubscribe.push(editor.onEditorEvent('selection:changed', scheduleVersionCheck))
   }
 
   function markRendered() {
-    lastRenderVersion = editor.state.renderVersion
-    lastSelectedIds = editor.state.selectedIds
+    const state = getRenderState()
+    lastRenderVersion = state.renderVersion
+    lastSceneVersion = state.sceneVersion
+    lastSelectedIds = state.selectedIds
   }
 
   function pause() {
@@ -110,6 +123,6 @@ export function createCanvasRenderLoop(
   return {
     pause,
     markRendered,
-    markDirty: scheduleRender
+    markDirty: scheduleDirtyRender
   }
 }

--- a/packages/vue/src/canvas/surface/types.ts
+++ b/packages/vue/src/canvas/surface/types.ts
@@ -1,6 +1,8 @@
 /**
  * Options for {@link useCanvas}.
  */
+import type { EditorState } from '@open-pencil/core/editor'
+
 export type CanvasRenderLayer = 'full' | 'scene' | 'overlays'
 
 export interface UseCanvasOptions {
@@ -14,6 +16,14 @@ export interface UseCanvasOptions {
    * When omitted, the composable falls back to viewport and URL-param logic.
    */
   showRulers?: boolean
+  /**
+   * Supplies pane-specific render state for split canvas surfaces.
+   */
+  getRenderState?: () => EditorState
+  /**
+   * Receives CSS pixel viewport size changes for this canvas.
+   */
+  onViewportResize?: (width: number, height: number) => void
   /**
    * Keeps the drawing buffer after presenting frames.
    *

--- a/packages/vue/src/canvas/text-edit/textarea.ts
+++ b/packages/vue/src/canvas/text-edit/textarea.ts
@@ -26,18 +26,20 @@ export function useTextEditingSession({
   textareaRef,
   resetBlink,
   stopBlink,
-  resetComposition
+  resetComposition,
+  isEnabled
 }: {
   store: Editor
   textareaRef: ShallowRef<HTMLTextAreaElement | null>
   resetBlink: () => void
   stopBlink: () => void
   resetComposition: () => void
+  isEnabled?: () => boolean
 }) {
   watch(
     () => store.state.editingTextId,
     (id, _, onCleanup) => {
-      if (id) {
+      if (id && (isEnabled?.() ?? true)) {
         const el = createHiddenTextArea()
         textareaRef.value = el
         el.focus()

--- a/packages/vue/src/canvas/text-edit/use.ts
+++ b/packages/vue/src/canvas/text-edit/use.ts
@@ -16,7 +16,11 @@ import { focusTextAreaOnCanvasPointerDown, useTextEditingSession } from './texta
  * blinking, keyboard editing behavior, text formatting shortcuts, and syncing
  * text/style-run updates back into the scene graph.
  */
-export function useTextEdit(canvasRef: Ref<HTMLCanvasElement | null>, store: Editor) {
+export function useTextEdit(
+  canvasRef: Ref<HTMLCanvasElement | null>,
+  store: Editor,
+  options?: { isEnabled?: () => boolean }
+) {
   const textareaRef = shallowRef<HTMLTextAreaElement | null>(null)
   const { resetBlink, stopBlink } = createCaretBlink(store)
   const { getEditingNode, insertText, deleteText } = createTextEditActions(store)
@@ -55,5 +59,12 @@ export function useTextEdit(canvasRef: Ref<HTMLCanvasElement | null>, store: Edi
     focusTextAreaOnCanvasPointerDown(textareaRef, store)
   )
 
-  useTextEditingSession({ store, textareaRef, resetBlink, stopBlink, resetComposition })
+  useTextEditingSession({
+    store,
+    textareaRef,
+    resetBlink,
+    stopBlink,
+    resetComposition,
+    isEnabled: options?.isEnabled
+  })
 }

--- a/packages/vue/src/canvas/useCanvasInput.ts
+++ b/packages/vue/src/canvas/useCanvasInput.ts
@@ -38,7 +38,9 @@ export function useCanvasInput(
   hitTestSectionTitle: (cx: number, cy: number) => SceneNode | null,
   hitTestComponentLabel: (cx: number, cy: number) => SceneNode | null,
   hitTestFrameTitle: (cx: number, cy: number) => SceneNode | null,
-  onCursorMove?: (cx: number, cy: number) => void
+  onCursorMove?: (cx: number, cy: number) => void,
+  activate?: () => void,
+  isActive: () => boolean = () => true
 ) {
   const drag = ref<DragState | null>(null)
   const cursorOverride = ref<string | null>(null)
@@ -148,6 +150,7 @@ export function useCanvasInput(
   }
 
   function onMouseDown(e: MouseEvent) {
+    activate?.()
     const paddingEdit = autoLayoutPaddingEdit.value
     if (paddingEdit) {
       commitAutoLayoutPaddingEdit(paddingEdit.value)
@@ -174,7 +177,16 @@ export function useCanvasInput(
     })
   }
 
+  function shouldIgnoreInactiveMouseMove() {
+    if (isActive()) return false
+    if (!drag.value) return true
+    activate?.()
+    return false
+  }
+
   function onMouseMove(e: MouseEvent) {
+    if (shouldIgnoreInactiveMouseMove()) return
+
     if (onCursorMove) {
       const { cx, cy } = getCoords(e)
       onCursorMove(cx, cy)
@@ -247,6 +259,7 @@ export function useCanvasInput(
   }
 
   function onMouseUp() {
+    activate?.()
     if (!drag.value) return
     const d = drag.value
 
@@ -282,6 +295,13 @@ export function useCanvasInput(
     cursorOverride.value = null
   }
 
+  function cleanupInteractions() {
+    const paddingEdit = autoLayoutPaddingEdit.value
+    if (paddingEdit) commitAutoLayoutPaddingEdit(paddingEdit.value)
+    if (drag.value) onMouseUp()
+    cursorOverride.value = null
+  }
+
   useEventListener(canvasRef, 'dblclick', onDblClick)
   useEventListener(canvasRef, 'mousedown', onMouseDown)
   useEventListener(canvasRef, 'mousemove', onMouseMove)
@@ -295,13 +315,14 @@ export function useCanvasInput(
     if (drag.value) onMouseUp()
   })
 
-  setupPanZoom(canvasRef, editor, drag, onMouseDown, onMouseMove, onMouseUp)
+  setupPanZoom(canvasRef, editor, drag, onMouseDown, onMouseMove, onMouseUp, activate)
   return {
     drag,
     cursorOverride,
     autoLayoutPaddingEdit,
     updateAutoLayoutPaddingEdit,
     commitAutoLayoutPaddingEdit,
-    cancelAutoLayoutPaddingEdit
+    cancelAutoLayoutPaddingEdit,
+    cleanupInteractions
   }
 }

--- a/packages/vue/src/shared/input/gesture.ts
+++ b/packages/vue/src/shared/input/gesture.ts
@@ -5,12 +5,17 @@ import type { Editor } from '@open-pencil/core/editor'
 
 import { createRafScheduler } from '#vue/shared/input/raf-scheduler'
 
-export function setupSafariGestureZoom(canvasRef: Ref<HTMLCanvasElement | null>, editor: Editor) {
+export function setupSafariGestureZoom(
+  canvasRef: Ref<HTMLCanvasElement | null>,
+  editor: Editor,
+  activate?: () => void
+) {
   let gestureStartZoom = 1
   let pendingGesture: { scale: number; sx: number; sy: number } | null = null
 
   function flushGesture() {
     if (!pendingGesture) return
+    activate?.()
     editor.setHoveredNode(null)
     const { scale, sx, sy } = pendingGesture
     pendingGesture = null
@@ -23,6 +28,7 @@ export function setupSafariGestureZoom(canvasRef: Ref<HTMLCanvasElement | null>,
     canvasRef,
     'gesturestart' as keyof HTMLElementEventMap,
     (e: Event) => {
+      activate?.()
       e.preventDefault()
       gestureStartZoom = editor.state.zoom
     },
@@ -32,6 +38,7 @@ export function setupSafariGestureZoom(canvasRef: Ref<HTMLCanvasElement | null>,
     canvasRef,
     'gesturechange' as keyof HTMLElementEventMap,
     (e: Event) => {
+      activate?.()
       e.preventDefault()
       const ge = e as GestureEvent
       const canvas = canvasRef.value
@@ -50,6 +57,7 @@ export function setupSafariGestureZoom(canvasRef: Ref<HTMLCanvasElement | null>,
     canvasRef,
     'gestureend' as keyof HTMLElementEventMap,
     (e: Event) => {
+      activate?.()
       e.preventDefault()
     },
     { passive: false }

--- a/packages/vue/src/shared/input/pan-zoom.ts
+++ b/packages/vue/src/shared/input/pan-zoom.ts
@@ -13,7 +13,8 @@ export function setupPanZoom(
   drag: Ref<DragState | null>,
   onMouseDown: (e: MouseEvent) => void,
   onMouseMove: (e: MouseEvent) => void,
-  onMouseUp: () => void
+  onMouseUp: () => void,
+  activate?: () => void
 ) {
   let activeTouches: Touch[] = []
   let pinchStartDist = 0
@@ -40,6 +41,7 @@ export function setupPanZoom(
   }
 
   function onTouchStart(e: TouchEvent) {
+    activate?.()
     e.preventDefault()
     activeTouches = Array.from(e.touches)
     const canvas = canvasRef.value
@@ -77,6 +79,7 @@ export function setupPanZoom(
   }
 
   function onTouchMove(e: TouchEvent) {
+    activate?.()
     e.preventDefault()
     activeTouches = Array.from(e.touches)
     const canvas = canvasRef.value
@@ -117,6 +120,7 @@ export function setupPanZoom(
   }
 
   function onTouchEnd(e: TouchEvent) {
+    activate?.()
     e.preventDefault()
     activeTouches = Array.from(e.touches)
 
@@ -143,11 +147,11 @@ export function setupPanZoom(
     }
   }
 
-  setupWheelPanZoom(canvasRef, editor)
+  setupWheelPanZoom(canvasRef, editor, activate)
   useEventListener(canvasRef, 'touchstart', onTouchStart, { passive: false })
   useEventListener(canvasRef, 'touchmove', onTouchMove, { passive: false })
   useEventListener(canvasRef, 'touchend', onTouchEnd, { passive: false })
   useEventListener(canvasRef, 'touchcancel', onTouchEnd, { passive: false })
 
-  setupSafariGestureZoom(canvasRef, editor)
+  setupSafariGestureZoom(canvasRef, editor, activate)
 }

--- a/packages/vue/src/shared/input/wheel.ts
+++ b/packages/vue/src/shared/input/wheel.ts
@@ -42,7 +42,11 @@ function wheelZoomDelta(event: WheelEvent) {
   return -event.deltaY * wheelDeltaModeScale(event) * factor * WHEEL_ZOOM_SPEED
 }
 
-export function setupWheelPanZoom(canvasRef: Ref<HTMLCanvasElement | null>, editor: Editor) {
+export function setupWheelPanZoom(
+  canvasRef: Ref<HTMLCanvasElement | null>,
+  editor: Editor,
+  activate?: () => void
+) {
   const wheelAccum: WheelAccum = {
     deltaX: 0,
     deltaY: 0,
@@ -53,6 +57,7 @@ export function setupWheelPanZoom(canvasRef: Ref<HTMLCanvasElement | null>, edit
   }
 
   function flushWheel() {
+    activate?.()
     editor.setHoveredNode(null)
     if (wheelAccum.hasZoom) {
       editor.setZoomAroundPoint(
@@ -72,6 +77,7 @@ export function setupWheelPanZoom(canvasRef: Ref<HTMLCanvasElement | null>, edit
   const wheelScheduler = createRafScheduler(flushWheel)
 
   function onWheel(e: WheelEvent) {
+    activate?.()
     const canvas = canvasRef.value
     if (!canvas) return
     const { dx, dy } = normalizeWheelDelta(e)

--- a/src/app/automation/bridge/figma-factory.ts
+++ b/src/app/automation/bridge/figma-factory.ts
@@ -2,6 +2,7 @@ import { FigmaAPI } from '@open-pencil/core/figma-api'
 
 import type { EditorStore } from '@/app/editor/active-store'
 import { listFonts } from '@/app/editor/fonts'
+import { paneCanvasCenter } from '@/app/editor/panes/viewport'
 
 export function makeFigmaFromStore(store: EditorStore): FigmaAPI {
   const api = new FigmaAPI(store.graph)
@@ -11,10 +12,7 @@ export function makeFigmaFromStore(store: EditorStore): FigmaAPI {
     .map((id) => api.getNodeById(id))
     .filter((n): n is NonNullable<typeof n> => n !== null)
   api.viewport = {
-    center: {
-      x: (-store.state.panX + window.innerWidth / 2) / store.state.zoom,
-      y: (-store.state.panY + window.innerHeight / 2) / store.state.zoom
-    },
+    center: paneCanvasCenter(store.getActivePane()),
     zoom: store.state.zoom
   }
   api.exportImage = (nodeIds, opts) =>

--- a/src/app/collab/awareness.ts
+++ b/src/app/collab/awareness.ts
@@ -5,6 +5,7 @@ import { randomIndex } from '@open-pencil/core/random'
 import type { Color } from '@open-pencil/core/types'
 
 import type { EditorStore } from '@/app/editor/active-store'
+import { paneScreenCenter } from '@/app/editor/panes/viewport'
 import { PEER_COLORS, ROOM_ID_CHARS, ROOM_ID_LENGTH } from '@/constants'
 
 import type { RemotePeer } from './types'
@@ -40,9 +41,9 @@ export function buildRemotePeers(
   return peers
 }
 
-export function remotePeersToCursors(peers: RemotePeer[], currentPageId: string) {
+export function remotePeersToCursors(peers: RemotePeer[], currentPageId?: string) {
   return peers
-    .filter((p) => p.cursor && p.cursor.pageId === currentPageId)
+    .filter((p) => p.cursor && (!currentPageId || p.cursor.pageId === currentPageId))
     .map((p) => {
       const cursor = p.cursor as NonNullable<RemotePeer['cursor']>
       return {
@@ -50,7 +51,8 @@ export function remotePeersToCursors(peers: RemotePeer[], currentPageId: string)
         color: p.color,
         x: cursor.x,
         y: cursor.y,
-        selection: p.selection
+        selection: p.selection,
+        pageId: cursor.pageId
       }
     })
 }
@@ -82,13 +84,10 @@ export function createFollowActions(
     if (cursor.pageId !== store.state.currentPageId) {
       void store.switchPage(cursor.pageId)
     }
-    const canvas = document.querySelector('canvas')
-    if (!canvas) return
     if (cursor.zoom) store.state.zoom = cursor.zoom
-    const cw = canvas.width / devicePixelRatio
-    const ch = canvas.height / devicePixelRatio
-    store.state.panX = cw / 2 - cursor.x * store.state.zoom
-    store.state.panY = ch / 2 - cursor.y * store.state.zoom
+    const center = paneScreenCenter(store.getActivePane())
+    store.state.panX = center.x - cursor.x * store.state.zoom
+    store.state.panY = center.y - cursor.y * store.state.zoom
     store.requestRender()
   }
 

--- a/src/app/collab/local-awareness.ts
+++ b/src/app/collab/local-awareness.ts
@@ -50,7 +50,7 @@ export function createLocalAwarenessActions({
     )
 
     state.value.peers = peers
-    store.state.remoteCursors = remotePeersToCursors(peers, store.state.currentPageId)
+    store.state.remoteCursors = remotePeersToCursors(peers)
     store.requestRender()
   }
 

--- a/src/app/collab/node-codec.ts
+++ b/src/app/collab/node-codec.ts
@@ -1,0 +1,304 @@
+import type { GeometryPath, SceneNode, SourceMetadata } from '@open-pencil/core/scene-graph'
+import { normalizeSourceMetadata } from '@open-pencil/core/scene-graph'
+
+const ENCODED_UINT8_ARRAY_TYPE = 'Uint8Array'
+
+type EncodedUint8Array = {
+  __type: typeof ENCODED_UINT8_ARRAY_TYPE
+  data: number[]
+}
+
+type YjsNodeLike = {
+  entries(): IterableIterator<[string, unknown]>
+}
+
+export const COLLAB_NODE_FIELDS = [
+  'id',
+  'type',
+  'name',
+  'parentId',
+  'childIds',
+  'x',
+  'y',
+  'width',
+  'height',
+  'rotation',
+  'source',
+  'figmaDerivedLayout',
+  'fills',
+  'strokes',
+  'effects',
+  'opacity',
+  'cornerRadius',
+  'topLeftRadius',
+  'topRightRadius',
+  'bottomRightRadius',
+  'bottomLeftRadius',
+  'independentCorners',
+  'cornerSmoothing',
+  'visible',
+  'locked',
+  'clipsContent',
+  'blendMode',
+  'text',
+  'fontSize',
+  'fontFamily',
+  'fontWeight',
+  'italic',
+  'textAlignHorizontal',
+  'textDirection',
+  'textAlignVertical',
+  'textAutoResize',
+  'textCase',
+  'textDecoration',
+  'lineHeight',
+  'letterSpacing',
+  'maxLines',
+  'styleRuns',
+  'fontVariations',
+  'fontFeatures',
+  'horizontalConstraint',
+  'verticalConstraint',
+  'layoutMode',
+  'layoutDirection',
+  'layoutWrap',
+  'primaryAxisAlign',
+  'counterAxisAlign',
+  'primaryAxisSizing',
+  'counterAxisSizing',
+  'itemSpacing',
+  'counterAxisSpacing',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+  'layoutPositioning',
+  'layoutGrow',
+  'layoutAlignSelf',
+  'vectorNetwork',
+  'booleanOperation',
+  'fillGeometry',
+  'strokeGeometry',
+  'arcData',
+  'strokeCap',
+  'strokeJoin',
+  'dashPattern',
+  'borderTopWeight',
+  'borderRightWeight',
+  'borderBottomWeight',
+  'borderLeftWeight',
+  'independentStrokeWeights',
+  'strokeMiterLimit',
+  'minWidth',
+  'maxWidth',
+  'minHeight',
+  'maxHeight',
+  'isMask',
+  'maskType',
+  'gridTemplateColumns',
+  'gridTemplateRows',
+  'gridColumnGap',
+  'gridRowGap',
+  'gridPosition',
+  'counterAxisAlignContent',
+  'itemReverseZIndex',
+  'strokesIncludedInLayout',
+  'expanded',
+  'textTruncation',
+  'autoRename',
+  'pointCount',
+  'starInnerRadius',
+  'componentId',
+  'overrides',
+  'componentPropertyDefinitions',
+  'componentPropertyValues',
+  'componentKey',
+  'sourceLibraryKey',
+  'publishId',
+  'overrideKey',
+  'sharedSymbolVersion',
+  'publishedVersion',
+  'isPublishable',
+  'isSymbolPublishable',
+  'symbolDescription',
+  'symbolLinks',
+  'variantPropSpecs',
+  'boundVariables',
+  'pluginData',
+  'pluginRelaunchData',
+  'internalOnly',
+  'flipX',
+  'flipY',
+  'figmaDerivedTextGlyphs'
+] as const satisfies readonly (keyof SceneNode)[]
+
+const COLLAB_NODE_FIELD_SET = new Set<keyof SceneNode>(COLLAB_NODE_FIELDS)
+
+const LEGACY_JSON_FIELDS = new Set<keyof SceneNode>([
+  'childIds',
+  'source',
+  'figmaDerivedLayout',
+  'fills',
+  'strokes',
+  'effects',
+  'styleRuns',
+  'fontVariations',
+  'fontFeatures',
+  'vectorNetwork',
+  'fillGeometry',
+  'strokeGeometry',
+  'arcData',
+  'dashPattern',
+  'gridTemplateColumns',
+  'gridTemplateRows',
+  'gridPosition',
+  'overrides',
+  'componentPropertyDefinitions',
+  'componentPropertyValues',
+  'symbolLinks',
+  'variantPropSpecs',
+  'boundVariables',
+  'pluginData',
+  'pluginRelaunchData',
+  'figmaDerivedTextGlyphs'
+])
+
+export function encodeNodeForYjs(node: SceneNode): Record<string, unknown> {
+  const encoded: Record<string, unknown> = {}
+  for (const key of COLLAB_NODE_FIELDS) {
+    encoded[key] = encodeYjsValue(node[key])
+  }
+  encoded.textPicture = null
+  return encoded
+}
+
+export function syncEncodedNodeToYMap(
+  node: SceneNode,
+  ynode: { set(key: string, value: unknown): void }
+) {
+  const encoded = encodeNodeForYjs(node)
+  for (const [key, value] of Object.entries(encoded)) {
+    ynode.set(key, value)
+  }
+}
+
+export function decodeNodeFromYjs(ynode: YjsNodeLike): Partial<SceneNode> {
+  const props: Record<string, unknown> = {}
+
+  for (const [key, value] of ynode.entries()) {
+    if (key !== 'textPicture' && !COLLAB_NODE_FIELD_SET.has(key as keyof SceneNode)) continue
+    props[key] = decodeNodeField(key, value)
+  }
+
+  props.source = normalizeSourceMetadata(props.source)
+  if ('fillGeometry' in props) props.fillGeometry = decodeGeometryPaths(props.fillGeometry)
+  if ('strokeGeometry' in props) props.strokeGeometry = decodeGeometryPaths(props.strokeGeometry)
+  if ('textPicture' in props) props.textPicture = null
+
+  return props as Partial<SceneNode>
+}
+
+function decodeNodeField(key: string, value: unknown): unknown {
+  const fieldValue = LEGACY_JSON_FIELDS.has(key as keyof SceneNode) ? parseLegacyJson(value) : value
+  return decodeYjsValue(fieldValue)
+}
+
+function encodeYjsValue(value: unknown): unknown {
+  if (value instanceof Uint8Array) return encodeUint8Array(value)
+  if (Array.isArray(value)) return value.map(encodeYjsValue)
+  if (isRecord(value)) {
+    const encoded: Record<string, unknown> = {}
+    for (const [key, child] of Object.entries(value)) {
+      encoded[key] = encodeYjsValue(child)
+    }
+    return encoded
+  }
+  return value
+}
+
+function decodeYjsValue(value: unknown): unknown {
+  if (isEncodedUint8Array(value)) return Uint8Array.from(value.data)
+  if (Array.isArray(value)) return value.map(decodeYjsValue)
+  if (isRecord(value)) {
+    const decoded: Record<string, unknown> = {}
+    for (const [key, child] of Object.entries(value)) {
+      decoded[key] = decodeYjsValue(child)
+    }
+    return decoded
+  }
+  return value
+}
+
+function encodeUint8Array(value: Uint8Array): EncodedUint8Array {
+  return { __type: ENCODED_UINT8_ARRAY_TYPE, data: [...value] }
+}
+
+function isEncodedUint8Array(value: unknown): value is EncodedUint8Array {
+  if (!isRecord(value)) return false
+  return value.__type === ENCODED_UINT8_ARRAY_TYPE && isNumberArray(value.data)
+}
+
+function decodeGeometryPaths(value: unknown): GeometryPath[] {
+  if (!Array.isArray(value)) return []
+  const paths: GeometryPath[] = []
+  for (const item of value) {
+    if (!isRecord(item)) continue
+    const commandsBlob = decodeCommandsBlob(item.commandsBlob)
+    if (!commandsBlob) continue
+    paths.push({
+      windingRule: item.windingRule === 'EVENODD' ? 'EVENODD' : 'NONZERO',
+      commandsBlob
+    })
+  }
+  return paths
+}
+
+function decodeCommandsBlob(value: unknown): Uint8Array | null {
+  const decoded = decodeYjsValue(value)
+  if (decoded instanceof Uint8Array) return decoded
+  if (isLegacyUint8ArrayRecord(decoded)) {
+    return Uint8Array.from(
+      Object.entries(decoded)
+        .sort(([a], [b]) => Number(a) - Number(b))
+        .map(([, item]) => item)
+    )
+  }
+  return null
+}
+
+function parseLegacyJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return value
+  }
+}
+
+function isLegacyUint8ArrayRecord(value: unknown): value is Record<string, number> {
+  if (!isRecord(value)) return false
+  const entries = Object.entries(value)
+  if (entries.length === 0) return false
+  return entries.every(
+    ([key, item]) =>
+      /^\d+$/.test(key) &&
+      typeof item === 'number' &&
+      Number.isInteger(item) &&
+      item >= 0 &&
+      item <= 255
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !ArrayBuffer.isView(value)
+}
+
+function isNumberArray(value: unknown): value is number[] {
+  return (
+    Array.isArray(value) &&
+    value.every((item) => Number.isInteger(item) && item >= 0 && item <= 255)
+  )
+}
+
+export type { EncodedUint8Array }
+export type { SourceMetadata }

--- a/src/app/collab/yjs-sync.ts
+++ b/src/app/collab/yjs-sync.ts
@@ -3,7 +3,8 @@ import * as Y from 'yjs'
 import type { SceneNode } from '@open-pencil/core/scene-graph'
 
 import type { EditorStore } from '@/app/editor/active-store'
-import { YJS_JSON_FIELDS } from '@/constants'
+
+import { decodeNodeFromYjs, syncEncodedNodeToYMap } from './node-codec'
 
 type YNodes = Y.Map<Y.Map<unknown>>
 type YImages = Y.Map<Uint8Array>
@@ -35,31 +36,7 @@ type YjsGraphSyncOptions = {
 }
 
 export function syncNodePropsToYMap(node: SceneNode, ynode: Y.Map<unknown>) {
-  for (const [key, value] of Object.entries(node)) {
-    if (typeof value === 'object' && value !== null) {
-      ynode.set(key, JSON.stringify(value))
-    } else {
-      ynode.set(key, value)
-    }
-  }
-}
-
-export function yNodeToProps(ynode: Y.Map<unknown>): Record<string, unknown> {
-  const props: Record<string, unknown> = {}
-
-  for (const [key, value] of ynode.entries()) {
-    if (YJS_JSON_FIELDS.has(key)) {
-      try {
-        props[key] = typeof value === 'string' ? JSON.parse(value) : value
-      } catch {
-        props[key] = value
-      }
-    } else {
-      props[key] = value
-    }
-  }
-
-  return props
+  syncEncodedNodeToYMap(node, ynode)
 }
 
 export function bindCollabGraphEvents({
@@ -78,18 +55,31 @@ export function bindCollabGraphEvents({
 
   const unbinds = [
     store.onEditorEvent('node:updated', (id) => onGraphMutation(id)),
-    store.onEditorEvent('node:created', (node) => onGraphMutation(node.id)),
-    store.onEditorEvent('node:reparented', (nodeId) => onGraphMutation(nodeId)),
-    store.onEditorEvent('node:reordered', (nodeId) => onGraphMutation(nodeId)),
+    store.onEditorEvent('node:created', (node) => {
+      onGraphMutation(node.id)
+      if (node.parentId) onGraphMutation(node.parentId)
+    }),
+    store.onEditorEvent('node:reparented', (nodeId, oldParentId, newParentId) => {
+      onGraphMutation(nodeId)
+      if (oldParentId) onGraphMutation(oldParentId)
+      onGraphMutation(newParentId)
+    }),
+    store.onEditorEvent('node:reordered', (nodeId, parentId) => {
+      onGraphMutation(nodeId)
+      onGraphMutation(parentId)
+    }),
     store.onEditorEvent('node:deleted', (id) => {
       const ydoc = getYdoc()
       const ynodes = getYnodes()
       if (!getSuppressGraphSync() && ydoc && ynodes) {
         setSuppressYjsEvents(true)
-        ydoc.transact(() => {
-          ynodes.delete(id)
-        })
-        setSuppressYjsEvents(false)
+        try {
+          ydoc.transact(() => {
+            ynodes.delete(id)
+          })
+        } finally {
+          setSuppressYjsEvents(false)
+        }
       }
     })
   ]
@@ -148,24 +138,27 @@ export function createYjsGraphSync({
 
     const localYimages = getYimages()
     setSuppressYjsEvents(true)
-    ydoc.transact(() => {
-      let ynode = ynodes.get(nodeId)
-      if (!ynode) {
-        ynode = new Y.Map()
-        ynodes.set(nodeId, ynode)
-      }
-      syncNodePropsToYMap(node, ynode)
+    try {
+      ydoc.transact(() => {
+        let ynode = ynodes.get(nodeId)
+        if (!ynode) {
+          ynode = new Y.Map()
+          ynodes.set(nodeId, ynode)
+        }
+        syncNodePropsToYMap(node, ynode)
 
-      if (localYimages) {
-        for (const fill of node.fills) {
-          if (fill.imageHash && !localYimages.has(fill.imageHash)) {
-            const data = store.graph.images.get(fill.imageHash)
-            if (data) localYimages.set(fill.imageHash, data)
+        if (localYimages) {
+          for (const fill of node.fills) {
+            if (fill.imageHash && !localYimages.has(fill.imageHash)) {
+              const data = store.graph.images.get(fill.imageHash)
+              if (data) localYimages.set(fill.imageHash, data)
+            }
           }
         }
-      }
-    })
-    setSuppressYjsEvents(false)
+      })
+    } finally {
+      setSuppressYjsEvents(false)
+    }
   }
 
   function syncAllNodesToYjs() {
@@ -175,26 +168,29 @@ export function createYjsGraphSync({
     if (!ydoc || !ynodes) return
     const localYimages = getYimages()
     setSuppressYjsEvents(true)
-    ydoc.transact(() => {
-      for (const node of store.graph.getAllNodes()) {
-        let ynode = ynodes.get(node.id)
-        if (!ynode) {
-          ynode = new Y.Map()
-          ynodes.set(node.id, ynode)
-        }
-        syncNodePropsToYMap(node, ynode)
-      }
-    })
-    if (localYimages) {
+    try {
       ydoc.transact(() => {
-        for (const [hash, data] of store.graph.images) {
-          if (!localYimages.has(hash)) {
-            localYimages.set(hash, data)
+        for (const node of store.graph.getAllNodes()) {
+          let ynode = ynodes.get(node.id)
+          if (!ynode) {
+            ynode = new Y.Map()
+            ynodes.set(node.id, ynode)
           }
+          syncNodePropsToYMap(node, ynode)
         }
       })
+      if (localYimages) {
+        ydoc.transact(() => {
+          for (const [hash, data] of store.graph.images) {
+            if (!localYimages.has(hash)) {
+              localYimages.set(hash, data)
+            }
+          }
+        })
+      }
+    } finally {
+      setSuppressYjsEvents(false)
     }
-    setSuppressYjsEvents(false)
   }
 
   function applyYjsToGraph(events: Y.YEvent<Y.Map<unknown>>[]) {
@@ -233,20 +229,19 @@ export function createYjsGraphSync({
   function applyYnodeToGraph(nodeId: string, ynode: Y.Map<unknown>) {
     const store = getStore()
     const existing = store.graph.getNode(nodeId)
-    const props = yNodeToProps(ynode)
+    const props = decodeNodeFromYjs(ynode)
 
     if (existing) {
-      store.graph.updateNode(nodeId, props as Partial<SceneNode>)
+      store.graph.updateNode(nodeId, props)
       return
     }
 
     const parentId = props.parentId as string
     if (parentId && store.graph.getNode(parentId)) {
       const type = props.type as SceneNode['type']
-      const node = store.graph.createNode(type, parentId, props as Partial<SceneNode>)
-      store.graph.nodes.delete(node.id)
-      node.id = nodeId
-      store.graph.nodes.set(nodeId, node)
+      store.graph.createNode(type, parentId, { ...props, id: nodeId })
+      const parent = store.graph.getNode(parentId)
+      if (parent) parent.childIds = [...new Set(parent.childIds)]
     }
   }
 

--- a/src/app/editor/panes/create.ts
+++ b/src/app/editor/panes/create.ts
@@ -1,0 +1,57 @@
+import { shallowReactive } from 'vue'
+
+import { copyEditorViewState, createDefaultEditorViewState } from '@open-pencil/core/editor'
+import type { EditorViewState } from '@open-pencil/core/editor'
+
+import type { AppEditorState } from '@/app/editor/session/types'
+
+import type { AppCanvasPaneState } from './types'
+
+export function createCanvasPaneState(
+  id: string,
+  pageId: string,
+  source?: Partial<
+    EditorViewState & Pick<AppEditorState, 'cursorCanvasX' | 'cursorCanvasY' | 'nodeEditState'>
+  >
+): AppCanvasPaneState {
+  const view = source
+    ? copyEditorViewState({
+        ...createDefaultEditorViewState(pageId),
+        ...source,
+        currentPageId: source.currentPageId ?? pageId
+      })
+    : createDefaultEditorViewState(pageId)
+
+  return shallowReactive({
+    ...view,
+    id,
+    selectedIds: new Set(source?.selectedIds ?? view.selectedIds),
+    cursorCanvasX: source?.cursorCanvasX ?? null,
+    cursorCanvasY: source?.cursorCanvasY ?? null,
+    nodeEditState: source?.nodeEditState ?? null,
+    pageViewports: new Map(),
+    viewportWidth: 0,
+    viewportHeight: 0
+  })
+}
+
+export function clonePaneForSplit(id: string, source: AppCanvasPaneState): AppCanvasPaneState {
+  return createCanvasPaneState(id, source.currentPageId, {
+    ...source,
+    selectedIds: new Set<string>(),
+    hoveredNodeId: null,
+    editingTextId: null,
+    marquee: null,
+    snapGuides: [],
+    rotationPreview: null,
+    dropTargetId: null,
+    layoutInsertIndicator: null,
+    autoLayoutHover: null,
+    penState: null,
+    penCursorX: null,
+    penCursorY: null,
+    cursorCanvasX: null,
+    cursorCanvasY: null,
+    nodeEditState: null
+  })
+}

--- a/src/app/editor/panes/debug.ts
+++ b/src/app/editor/panes/debug.ts
@@ -1,0 +1,17 @@
+import { IS_BROWSER } from '@open-pencil/core/constants'
+
+const DEBUG_LABEL = '[OpenPencil split-pane]'
+
+export function isSplitPaneDebugEnabled(): boolean {
+  if (!IS_BROWSER) return false
+  try {
+    return new URLSearchParams(window.location.search).get('splitPaneDebug') === '1'
+  } catch {
+    return false
+  }
+}
+
+export function logSplitPaneDebug(event: string, data: Record<string, unknown> = {}): void {
+  if (!isSplitPaneDebugEnabled()) return
+  console.debug(DEBUG_LABEL, event, data)
+}

--- a/src/app/editor/panes/page-viewports.ts
+++ b/src/app/editor/panes/page-viewports.ts
@@ -1,0 +1,46 @@
+import { getDefaultCanvasBgColor } from '@open-pencil/core/constants'
+import type { PageViewport } from '@open-pencil/core/editor'
+import type { Color } from '@open-pencil/core/types'
+
+import type { AppCanvasPaneState } from './types'
+
+export function savePanePageViewport(pane: AppCanvasPaneState): void {
+  pane.pageViewports.set(pane.currentPageId, {
+    panX: pane.panX,
+    panY: pane.panY,
+    zoom: pane.zoom,
+    pageColor: { ...pane.pageColor }
+  })
+}
+
+export function restorePanePageViewport(
+  pane: AppCanvasPaneState,
+  pageId: string,
+  fallbackColor?: Color
+): void {
+  const viewport = pane.pageViewports.get(pageId)
+  if (viewport) {
+    applyPaneViewport(pane, viewport)
+    return
+  }
+
+  pane.panX = 0
+  pane.panY = 0
+  pane.zoom = 1
+  pane.pageColor = { ...(fallbackColor ?? getDefaultCanvasBgColor()) }
+}
+
+export function deletePanePageViewport(pane: AppCanvasPaneState, pageId: string): void {
+  pane.pageViewports.delete(pageId)
+}
+
+export function clearPanePageViewports(pane: AppCanvasPaneState): void {
+  pane.pageViewports.clear()
+}
+
+function applyPaneViewport(pane: AppCanvasPaneState, viewport: PageViewport): void {
+  pane.panX = viewport.panX
+  pane.panY = viewport.panY
+  pane.zoom = viewport.zoom
+  pane.pageColor = { ...viewport.pageColor }
+}

--- a/src/app/editor/panes/render-state.ts
+++ b/src/app/editor/panes/render-state.ts
@@ -1,0 +1,45 @@
+import type { EditorState } from '@open-pencil/core/editor'
+
+import type { AppEditorState } from '@/app/editor/session/types'
+
+import type { AppCanvasPaneState } from './types'
+
+export function composePaneRenderState(
+  sharedState: AppEditorState,
+  pane: AppCanvasPaneState
+): EditorState {
+  return {
+    activeTool: sharedState.activeTool,
+    remoteCursors: sharedState.showRemoteCursors
+      ? sharedState.remoteCursors.filter(
+          (cursor) => !cursor.pageId || cursor.pageId === pane.currentPageId
+        )
+      : [],
+    documentName: sharedState.documentName,
+    sceneVersion: sharedState.sceneVersion,
+    loading: sharedState.loading,
+    rulerTheme: sharedState.rulerTheme,
+    currentPageId: pane.currentPageId,
+    selectedIds: pane.selectedIds,
+    marquee: pane.marquee,
+    snapGuides: pane.snapGuides,
+    rotationPreview: pane.rotationPreview,
+    dropTargetId: pane.dropTargetId,
+    layoutInsertIndicator: pane.layoutInsertIndicator,
+    autoLayoutHover: pane.autoLayoutHover,
+    hoveredNodeId: pane.hoveredNodeId,
+    editingTextId: pane.editingTextId,
+    penState: pane.penState,
+    penCursorX: pane.penCursorX,
+    penCursorY: pane.penCursorY,
+    panX: pane.panX,
+    panY: pane.panY,
+    zoom: pane.zoom,
+    renderVersion: pane.renderVersion,
+    pageColor: pane.pageColor,
+    enteredContainerId: pane.enteredContainerId,
+    cursorCanvasX: pane.cursorCanvasX,
+    cursorCanvasY: pane.cursorCanvasY,
+    nodeEditState: pane.nodeEditState
+  }
+}

--- a/src/app/editor/panes/split-tree.ts
+++ b/src/app/editor/panes/split-tree.ts
@@ -1,0 +1,99 @@
+import type { CanvasSplitNode, SplitDirection } from './types'
+
+export const MAX_VISIBLE_CANVAS_PANES = 4
+
+export function childKey(node: CanvasSplitNode): string {
+  return node.type === 'pane' ? node.paneId : node.id
+}
+
+export function paneCount(node: CanvasSplitNode): number {
+  if (node.type === 'pane') return 1
+  return node.children.reduce((count, child) => count + paneCount(child), 0)
+}
+
+export function leafPaneIds(node: CanvasSplitNode): string[] {
+  if (node.type === 'pane') return [node.paneId]
+  return node.children.flatMap(leafPaneIds)
+}
+
+export function normalizeSizes(length: number, sizes?: number[]): number[] {
+  if (length <= 0) return []
+  if (
+    !sizes ||
+    sizes.length !== length ||
+    !sizes.every((size) => Number.isFinite(size) && size > 0)
+  ) {
+    return Array.from({ length }, () => 100 / length)
+  }
+  const total = sizes.reduce((sum, size) => sum + size, 0)
+  if (!Number.isFinite(total) || total <= 0) return Array.from({ length }, () => 100 / length)
+  return sizes.map((size) => (size / total) * 100)
+}
+
+export function isValidLayoutSizes(sizes: number[], childLength: number): boolean {
+  return (
+    sizes.length === childLength &&
+    sizes.length > 0 &&
+    sizes.every((size) => Number.isFinite(size) && size > 0)
+  )
+}
+
+export function updateSplitSizes(
+  node: CanvasSplitNode,
+  splitId: string,
+  sizes: number[]
+): CanvasSplitNode {
+  if (node.type === 'pane') return node
+  if (node.id === splitId) {
+    if (!isValidLayoutSizes(sizes, node.children.length)) return node
+    return { ...node, sizes: normalizeSizes(node.children.length, sizes) }
+  }
+  return {
+    ...node,
+    children: node.children.map((child) => updateSplitSizes(child, splitId, sizes))
+  }
+}
+
+export function splitPaneNode(
+  node: CanvasSplitNode,
+  paneId: string,
+  newPaneId: string,
+  splitId: string,
+  direction: SplitDirection
+): CanvasSplitNode {
+  if (node.type === 'pane') {
+    return node.paneId === paneId
+      ? {
+          type: 'split',
+          id: splitId,
+          direction,
+          children: [node, { type: 'pane', paneId: newPaneId }],
+          sizes: [50, 50]
+        }
+      : node
+  }
+  return {
+    ...node,
+    children: node.children.map((child) =>
+      splitPaneNode(child, paneId, newPaneId, splitId, direction)
+    ),
+    sizes: normalizeSizes(node.children.length, node.sizes)
+  }
+}
+
+export function closePaneNode(node: CanvasSplitNode, paneId: string): CanvasSplitNode | null {
+  if (node.type === 'pane') return node.paneId === paneId ? null : node
+
+  const children = node.children
+    .map((child) => closePaneNode(child, paneId))
+    .filter((child): child is CanvasSplitNode => child !== null)
+
+  if (children.length === 0) return null
+  if (children.length === 1) return children[0]
+  return { ...node, children, sizes: normalizeSizes(children.length) }
+}
+
+export function containsPane(node: CanvasSplitNode, paneId: string): boolean {
+  if (node.type === 'pane') return node.paneId === paneId
+  return node.children.some((child) => containsPane(child, paneId))
+}

--- a/src/app/editor/panes/store.ts
+++ b/src/app/editor/panes/store.ts
@@ -1,0 +1,244 @@
+import { computed, ref, shallowRef, triggerRef } from 'vue'
+
+import type { SceneGraph } from '@open-pencil/core/scene-graph'
+
+import type { AppEditorState } from '@/app/editor/session/types'
+
+import { createCanvasPaneState, clonePaneForSplit } from './create'
+import {
+  closePaneNode,
+  containsPane,
+  leafPaneIds,
+  MAX_VISIBLE_CANVAS_PANES,
+  paneCount,
+  splitPaneNode,
+  updateSplitSizes as updateSplitNodeSizes
+} from './split-tree'
+import type {
+  AppCanvasPaneState,
+  CanvasSplitNode,
+  ClosePaneResult,
+  SplitDirection,
+  SplitPaneResult
+} from './types'
+
+export const APP_PANE_STATE_KEYS = [
+  'currentPageId',
+  'selectedIds',
+  'marquee',
+  'snapGuides',
+  'rotationPreview',
+  'dropTargetId',
+  'layoutInsertIndicator',
+  'autoLayoutHover',
+  'hoveredNodeId',
+  'editingTextId',
+  'penState',
+  'penCursorX',
+  'penCursorY',
+  'panX',
+  'panY',
+  'zoom',
+  'renderVersion',
+  'pageColor',
+  'enteredContainerId',
+  'cursorCanvasX',
+  'cursorCanvasY',
+  'nodeEditState'
+] as const
+
+type AppPaneStateKey = (typeof APP_PANE_STATE_KEYS)[number]
+
+type PaneRegistryOptions = {
+  graph: SceneGraph
+  state: AppEditorState
+}
+
+export function createCanvasPaneRegistry({ graph, state }: PaneRegistryOptions) {
+  let nextPaneIndex = 1
+  let nextSplitIndex = 1
+
+  function createPaneId(): string {
+    return `pane-${nextPaneIndex++}`
+  }
+
+  function createSplitId(): string {
+    return `split-${nextSplitIndex++}`
+  }
+
+  const initialPane = createCanvasPaneState(createPaneId(), state.currentPageId, state)
+  const panes = shallowRef(new Map([[initialPane.id, initialPane]]))
+  const activePaneId = ref(initialPane.id)
+  const splitTree = ref<CanvasSplitNode>({ type: 'pane', paneId: initialPane.id })
+  const visiblePaneCount = computed(() => paneCount(splitTree.value))
+
+  function getPane(id: string): AppCanvasPaneState | undefined {
+    return panes.value.get(id)
+  }
+
+  function getFirstPaneId(): string {
+    return leafPaneIds(splitTree.value)[0] ?? initialPane.id
+  }
+
+  function getActivePane(): AppCanvasPaneState {
+    const active = getPane(activePaneId.value)
+    if (active) return active
+
+    const fallbackId = getFirstPaneId()
+    activePaneId.value = fallbackId
+    const fallback = getPane(fallbackId)
+    if (fallback) return fallback
+
+    panes.value.set(initialPane.id, initialPane)
+    splitTree.value = { type: 'pane', paneId: initialPane.id }
+    activePaneId.value = initialPane.id
+    triggerRef(panes)
+    return initialPane
+  }
+
+  function setActivePane(id: string): void {
+    if (!getPane(id)) return
+    activePaneId.value = id
+  }
+
+  function splitPane(id: string, direction: SplitDirection): SplitPaneResult {
+    const source = getPane(id)
+    if (!source || !containsPane(splitTree.value, id)) return { ok: false, reason: 'missing-pane' }
+    if (visiblePaneCount.value >= MAX_VISIBLE_CANVAS_PANES) return { ok: false, reason: 'pane-cap' }
+
+    const pane = clonePaneForSplit(createPaneId(), source)
+    const nextTree = splitPaneNode(splitTree.value, id, pane.id, createSplitId(), direction)
+    if (!containsPane(nextTree, pane.id)) return { ok: false, reason: 'missing-pane' }
+
+    panes.value.set(pane.id, pane)
+    splitTree.value = nextTree
+    activePaneId.value = pane.id
+    triggerRef(panes)
+    return { ok: true, paneId: pane.id }
+  }
+
+  function closePane(id: string): ClosePaneResult {
+    if (!getPane(id) || !containsPane(splitTree.value, id))
+      return { ok: false, reason: 'missing-pane' }
+    if (visiblePaneCount.value <= 1) return { ok: false, reason: 'last-pane' }
+
+    const nextTree = closePaneNode(splitTree.value, id)
+    if (!nextTree) return { ok: false, reason: 'last-pane' }
+
+    const pane = getPane(id)
+    if (pane) clearPaneTransientState(pane)
+    panes.value.delete(id)
+    splitTree.value = nextTree
+    if (activePaneId.value === id || !getPane(activePaneId.value))
+      activePaneId.value = getFirstPaneId()
+    triggerRef(panes)
+    return { ok: true, activePaneId: activePaneId.value }
+  }
+
+  function ensureSinglePane(): string {
+    const active = getActivePane()
+    for (const pane of panes.value.values()) {
+      if (pane.id !== active.id) clearPaneTransientState(pane)
+    }
+    panes.value = new Map([[active.id, active]])
+    splitTree.value = { type: 'pane', paneId: active.id }
+    activePaneId.value = active.id
+    return active.id
+  }
+
+  function resizePane(id: string, width: number, height: number): void {
+    const pane = getPane(id)
+    if (!pane) return
+    pane.viewportWidth = width
+    pane.viewportHeight = height
+  }
+
+  function updateSplitSizes(splitId: string, sizes: number[]): void {
+    splitTree.value = updateSplitNodeSizes(splitTree.value, splitId, sizes)
+  }
+
+  function sanitizePanes(targetGraph: SceneGraph = graph): void {
+    const pages = targetGraph.getPages()
+    const fallbackPageId = pages[0]?.id ?? targetGraph.rootId
+    for (const pane of panes.value.values()) sanitizePane(targetGraph, pane, fallbackPageId)
+    if (!getPane(activePaneId.value)) activePaneId.value = getFirstPaneId()
+  }
+
+  function resetPaneViewports(): void {
+    for (const pane of panes.value.values()) pane.pageViewports.clear()
+  }
+
+  function sanitizePane(
+    targetGraph: SceneGraph,
+    pane: AppCanvasPaneState,
+    fallbackPageId: string
+  ): void {
+    if (!targetGraph.getNode(pane.currentPageId)) pane.currentPageId = fallbackPageId
+    pane.selectedIds = new Set([...pane.selectedIds].filter((id) => targetGraph.getNode(id)))
+    if (pane.hoveredNodeId && !targetGraph.getNode(pane.hoveredNodeId)) pane.hoveredNodeId = null
+    if (pane.editingTextId && !targetGraph.getNode(pane.editingTextId)) pane.editingTextId = null
+    if (pane.dropTargetId && !targetGraph.getNode(pane.dropTargetId)) pane.dropTargetId = null
+    if (pane.enteredContainerId && !targetGraph.getNode(pane.enteredContainerId))
+      pane.enteredContainerId = null
+    if (pane.rotationPreview && !targetGraph.getNode(pane.rotationPreview.nodeId))
+      pane.rotationPreview = null
+    if (pane.nodeEditState && !targetGraph.getNode(pane.nodeEditState.nodeId))
+      pane.nodeEditState = null
+    for (const pageId of pane.pageViewports.keys()) {
+      if (!targetGraph.getNode(pageId)) pane.pageViewports.delete(pageId)
+    }
+    clearPaneTransientState(pane)
+  }
+
+  return {
+    panes,
+    splitTree,
+    activePaneId,
+    visiblePaneCount,
+    getPane,
+    getActivePane,
+    setActivePane,
+    splitPane,
+    closePane,
+    ensureSinglePane,
+    resizePane,
+    updateSplitSizes,
+    sanitizePanes,
+    resetPaneViewports,
+    maxVisiblePanes: MAX_VISIBLE_CANVAS_PANES
+  }
+}
+
+export type CanvasPaneRegistry = ReturnType<typeof createCanvasPaneRegistry>
+
+export function clearPaneTransientState(pane: AppCanvasPaneState): void {
+  pane.marquee = null
+  pane.snapGuides = []
+  pane.rotationPreview = null
+  pane.dropTargetId = null
+  pane.layoutInsertIndicator = null
+  pane.autoLayoutHover = null
+  pane.hoveredNodeId = null
+  pane.editingTextId = null
+  pane.penState = null
+  pane.penCursorX = null
+  pane.penCursorY = null
+  pane.cursorCanvasX = null
+  pane.cursorCanvasY = null
+  pane.nodeEditState = null
+}
+
+export function bindStateToActivePane(state: AppEditorState, panes: CanvasPaneRegistry): void {
+  for (const key of APP_PANE_STATE_KEYS) bindPaneKey(state, panes, key)
+}
+
+function bindPaneKey(state: AppEditorState, panes: CanvasPaneRegistry, key: AppPaneStateKey): void {
+  Object.defineProperty(state, key, {
+    enumerable: true,
+    configurable: true,
+    get: () => panes.getActivePane()[key],
+    set: (value) => {
+      Reflect.set(panes.getActivePane(), key, value)
+    }
+  })
+}

--- a/src/app/editor/panes/store.ts
+++ b/src/app/editor/panes/store.ts
@@ -5,6 +5,7 @@ import type { SceneGraph } from '@open-pencil/core/scene-graph'
 import type { AppEditorState } from '@/app/editor/session/types'
 
 import { createCanvasPaneState, clonePaneForSplit } from './create'
+import { logSplitPaneDebug } from './debug'
 import {
   closePaneNode,
   containsPane,
@@ -70,6 +71,7 @@ export function createCanvasPaneRegistry({ graph, state }: PaneRegistryOptions) 
   const panes = shallowRef(new Map([[initialPane.id, initialPane]]))
   const activePaneId = ref(initialPane.id)
   const splitTree = ref<CanvasSplitNode>({ type: 'pane', paneId: initialPane.id })
+  const splitResizeActive = ref(false)
   const visiblePaneCount = computed(() => paneCount(splitTree.value))
 
   function getPane(id: string): AppCanvasPaneState | undefined {
@@ -97,8 +99,12 @@ export function createCanvasPaneRegistry({ graph, state }: PaneRegistryOptions) 
   }
 
   function setActivePane(id: string): void {
-    if (!getPane(id)) return
+    if (!getPane(id) || splitResizeActive.value) return
     activePaneId.value = id
+  }
+
+  function setSplitResizeActive(active: boolean): void {
+    splitResizeActive.value = active
   }
 
   function splitPane(id: string, direction: SplitDirection): SplitPaneResult {
@@ -154,6 +160,7 @@ export function createCanvasPaneRegistry({ graph, state }: PaneRegistryOptions) 
   }
 
   function updateSplitSizes(splitId: string, sizes: number[]): void {
+    logSplitPaneDebug('update-split-sizes', { splitId, sizes, activePaneId: activePaneId.value })
     splitTree.value = updateSplitNodeSizes(splitTree.value, splitId, sizes)
   }
 
@@ -194,10 +201,12 @@ export function createCanvasPaneRegistry({ graph, state }: PaneRegistryOptions) 
     panes,
     splitTree,
     activePaneId,
+    splitResizeActive,
     visiblePaneCount,
     getPane,
     getActivePane,
     setActivePane,
+    setSplitResizeActive,
     splitPane,
     closePane,
     ensureSinglePane,

--- a/src/app/editor/panes/types.ts
+++ b/src/app/editor/panes/types.ts
@@ -1,0 +1,33 @@
+import type { EditorViewState, PageViewport } from '@open-pencil/core/editor'
+
+import type { NodeEditState } from '@/app/editor/vector-edit/types'
+
+export type SplitDirection = 'horizontal' | 'vertical'
+
+export type CanvasSplitNode =
+  | { type: 'pane'; paneId: string }
+  | {
+      type: 'split'
+      id: string
+      direction: SplitDirection
+      children: CanvasSplitNode[]
+      sizes: number[]
+    }
+
+export interface AppCanvasPaneState extends EditorViewState {
+  id: string
+  cursorCanvasX: number | null
+  cursorCanvasY: number | null
+  nodeEditState: NodeEditState | null
+  pageViewports: Map<string, PageViewport>
+  viewportWidth: number
+  viewportHeight: number
+}
+
+export type SplitPaneResult =
+  | { ok: true; paneId: string }
+  | { ok: false; reason: 'pane-cap' | 'missing-pane' }
+
+export type ClosePaneResult =
+  | { ok: true; activePaneId: string }
+  | { ok: false; reason: 'last-pane' | 'missing-pane' }

--- a/src/app/editor/panes/viewport.ts
+++ b/src/app/editor/panes/viewport.ts
@@ -1,0 +1,18 @@
+import type { Vector } from '@open-pencil/core/types'
+
+import type { AppCanvasPaneState } from './types'
+
+export function paneScreenCenter(pane: AppCanvasPaneState): Vector {
+  return {
+    x: pane.viewportWidth / 2,
+    y: pane.viewportHeight / 2
+  }
+}
+
+export function paneCanvasCenter(pane: AppCanvasPaneState): Vector {
+  const center = paneScreenCenter(pane)
+  return {
+    x: (-pane.panX + center.x) / pane.zoom,
+    y: (-pane.panY + center.y) / pane.zoom
+  }
+}

--- a/src/app/editor/session/create.ts
+++ b/src/app/editor/session/create.ts
@@ -2,7 +2,9 @@ import { shallowReactive } from 'vue'
 
 import { createEditor } from '@open-pencil/core/editor'
 import { BUILTIN_IO_FORMATS, IORegistry } from '@open-pencil/core/io'
+import { computeAllLayouts } from '@open-pencil/core/layout'
 import { SceneGraph } from '@open-pencil/core/scene-graph'
+import { fontManager } from '@open-pencil/core/text'
 
 import {
   getActiveEditorStore,
@@ -10,6 +12,14 @@ import {
   useEditorStore
 } from '@/app/editor/active-store'
 import { loadFont } from '@/app/editor/fonts'
+import { restorePanePageViewport, savePanePageViewport } from '@/app/editor/panes/page-viewports'
+import { composePaneRenderState } from '@/app/editor/panes/render-state'
+import {
+  bindStateToActivePane,
+  clearPaneTransientState,
+  createCanvasPaneRegistry
+} from '@/app/editor/panes/store'
+import type { SplitDirection } from '@/app/editor/panes/types'
 import {
   createEditorComputedRefs,
   createEditorStoreModules,
@@ -24,6 +34,9 @@ export function createEditorStore(initialGraph?: SceneGraph) {
   const graph = initialGraph ?? new SceneGraph()
 
   const state = shallowReactive<AppEditorState>(createInitialAppEditorState(graph.getPages()[0].id))
+  const panes = createCanvasPaneRegistry({ graph, state })
+  const paneCleanupHandlers = new Map<string, Set<() => void>>()
+  bindStateToActivePane(state, panes)
 
   const viewportSize = { width: 0, height: 0 }
   const editor = createEditor({
@@ -31,10 +44,15 @@ export function createEditorStore(initialGraph?: SceneGraph) {
     state,
     loadFont,
     skipInitialGraphSetup: !!initialGraph,
-    getViewportSize: () =>
-      viewportSize.width > 0 && viewportSize.height > 0
+    getViewportSize: () => {
+      const pane = panes.getActivePane()
+      if (pane.viewportWidth > 0 && pane.viewportHeight > 0) {
+        return { width: pane.viewportWidth, height: pane.viewportHeight }
+      }
+      return viewportSize.width > 0 && viewportSize.height > 0
         ? viewportSize
         : { width: window.innerWidth, height: window.innerHeight }
+    }
   })
   const io = new IORegistry(BUILTIN_IO_FORMATS)
 
@@ -46,8 +64,97 @@ export function createEditorStore(initialGraph?: SceneGraph) {
 
   const modules = createEditorStoreModules(editor, graph, state, io, viewportSize)
 
-  // ─── Public API ───────────────────────────────────────────────
-  // Spread all core Editor methods, then override getters and add app-specific.
+  async function switchPage(pageId: string) {
+    const page = editor.graph.getNode(pageId)
+    if (page?.type !== 'CANVAS') return
+    const pane = panes.getActivePane()
+    runPaneCleanup(pane.id)
+    if (state.editingTextId) editor.commitTextEdit()
+    savePanePageViewport(pane)
+    pane.currentPageId = pageId
+    pane.enteredContainerId = null
+    pane.selectedIds = new Set()
+    restorePanePageViewport(pane, pageId)
+
+    const toLoad = fontManager.collectFontKeys(
+      editor.graph,
+      editor.graph.getChildren(pageId).map((node) => node.id)
+    )
+    if (toLoad.length > 0) {
+      await Promise.all(toLoad.map(([family, style]) => loadFont(family, style)))
+    }
+    if (editor.renderer) computeAllLayouts(editor.graph, pageId)
+    editor.requestRender()
+  }
+
+  function runPaneCleanup(paneId: string): void {
+    const handlers = paneCleanupHandlers.get(paneId)
+    if (!handlers) return
+    for (const cleanup of handlers) cleanup()
+  }
+
+  function registerPaneCleanup(paneId: string, cleanup: () => void): () => void {
+    const handlers = paneCleanupHandlers.get(paneId) ?? new Set<() => void>()
+    handlers.add(cleanup)
+    paneCleanupHandlers.set(paneId, handlers)
+    return () => {
+      handlers.delete(cleanup)
+      if (handlers.size === 0) paneCleanupHandlers.delete(paneId)
+    }
+  }
+
+  function setActivePane(paneId: string) {
+    if (panes.activePaneId.value === paneId || !panes.getPane(paneId)) return
+    runPaneCleanup(panes.activePaneId.value)
+    if (state.editingTextId) editor.commitTextEdit()
+    panes.setActivePane(paneId)
+    editor.requestRepaint()
+  }
+
+  function splitPane(paneId: string, direction: SplitDirection) {
+    if (state.editingTextId) editor.commitTextEdit()
+    const result = panes.splitPane(paneId, direction)
+    if (result.ok) editor.requestRepaint()
+    return result
+  }
+
+  function closePane(paneId: string) {
+    const pane = panes.getPane(paneId)
+    if (!pane) return panes.closePane(paneId)
+    if (panes.visiblePaneCount.value <= 1)
+      return { ok: false as const, reason: 'last-pane' as const }
+
+    const isActivePane = panes.activePaneId.value === paneId
+    runPaneCleanup(paneId)
+    if (isActivePane && state.editingTextId) editor.commitTextEdit()
+    clearPaneTransientState(pane)
+    const result = panes.closePane(paneId)
+    if (result.ok) editor.requestRepaint()
+    return result
+  }
+
+  function deletePage(pageId: string) {
+    editor.deletePage(pageId)
+    panes.sanitizePanes(editor.graph)
+    editor.requestRender()
+  }
+
+  function replaceGraph(newGraph: SceneGraph) {
+    for (const paneId of paneCleanupHandlers.keys()) runPaneCleanup(paneId)
+    if (state.editingTextId) editor.commitTextEdit()
+    editor.replaceGraph(newGraph)
+    panes.sanitizePanes(editor.graph)
+    panes.resetPaneViewports()
+  }
+
+  function ensureSinglePane() {
+    for (const paneId of paneCleanupHandlers.keys()) {
+      if (paneId !== panes.activePaneId.value) runPaneCleanup(paneId)
+    }
+    const paneId = panes.ensureSinglePane()
+    editor.requestRepaint()
+    return paneId
+  }
 
   const store = {
     ...editor,
@@ -55,9 +162,28 @@ export function createEditorStore(initialGraph?: SceneGraph) {
     selectedNodes,
     selectedNode,
     layerTree,
-
-    // App-specific overrides and additions
-    ...modules
+    panes,
+    splitTree: panes.splitTree,
+    activePaneId: panes.activePaneId,
+    visiblePaneCount: panes.visiblePaneCount,
+    maxVisiblePanes: panes.maxVisiblePanes,
+    getPane: panes.getPane,
+    getActivePane: panes.getActivePane,
+    setActivePane,
+    splitPane,
+    closePane,
+    ensureSinglePane,
+    registerPaneCleanup,
+    resizePane: panes.resizePane,
+    updateSplitSizes: panes.updateSplitSizes,
+    getPaneRenderState: (paneId: string) => {
+      const pane = panes.getPane(paneId) ?? panes.getActivePane()
+      return composePaneRenderState(state, pane)
+    },
+    ...modules,
+    switchPage,
+    deletePage,
+    replaceGraph
   }
 
   defineEditorStoreAccessors(store, editor)

--- a/src/app/editor/session/create.ts
+++ b/src/app/editor/session/create.ts
@@ -12,6 +12,7 @@ import {
   useEditorStore
 } from '@/app/editor/active-store'
 import { loadFont } from '@/app/editor/fonts'
+import { logSplitPaneDebug } from '@/app/editor/panes/debug'
 import { restorePanePageViewport, savePanePageViewport } from '@/app/editor/panes/page-viewports'
 import { composePaneRenderState } from '@/app/editor/panes/render-state'
 import {
@@ -90,6 +91,7 @@ export function createEditorStore(initialGraph?: SceneGraph) {
   function runPaneCleanup(paneId: string): void {
     const handlers = paneCleanupHandlers.get(paneId)
     if (!handlers) return
+    logSplitPaneDebug('run-pane-cleanup', { paneId, handlerCount: handlers.size })
     for (const cleanup of handlers) cleanup()
   }
 
@@ -105,6 +107,11 @@ export function createEditorStore(initialGraph?: SceneGraph) {
 
   function setActivePane(paneId: string) {
     if (panes.activePaneId.value === paneId || !panes.getPane(paneId)) return
+    if (panes.splitResizeActive.value) {
+      logSplitPaneDebug('set-active-pane-blocked', { from: panes.activePaneId.value, to: paneId })
+      return
+    }
+    logSplitPaneDebug('set-active-pane', { from: panes.activePaneId.value, to: paneId })
     runPaneCleanup(panes.activePaneId.value)
     if (state.editingTextId) editor.commitTextEdit()
     panes.setActivePane(paneId)
@@ -156,6 +163,14 @@ export function createEditorStore(initialGraph?: SceneGraph) {
     return paneId
   }
 
+  function requestRepaint() {
+    const activePaneId = panes.activePaneId.value
+    for (const pane of panes.panes.value.values()) {
+      if (pane.id !== activePaneId) pane.renderVersion++
+    }
+    editor.requestRepaint()
+  }
+
   const store = {
     ...editor,
     state,
@@ -165,11 +180,14 @@ export function createEditorStore(initialGraph?: SceneGraph) {
     panes,
     splitTree: panes.splitTree,
     activePaneId: panes.activePaneId,
+    splitResizeActive: panes.splitResizeActive,
     visiblePaneCount: panes.visiblePaneCount,
     maxVisiblePanes: panes.maxVisiblePanes,
     getPane: panes.getPane,
     getActivePane: panes.getActivePane,
+    requestRepaint,
     setActivePane,
+    setSplitResizeActive: panes.setSplitResizeActive,
     splitPane,
     closePane,
     ensureSinglePane,

--- a/src/app/shell/keyboard/clipboard.ts
+++ b/src/app/shell/keyboard/clipboard.ts
@@ -3,6 +3,7 @@ import { useEventListener } from '@vueuse/core'
 import { extractImageFilesFromClipboard } from '@open-pencil/vue'
 
 import type { EditorStore } from '@/app/editor/active-store'
+import { paneCanvasCenter } from '@/app/editor/panes/viewport'
 import { isEditing } from '@/app/shell/keyboard/focus'
 
 export function bindEditorClipboard(store: EditorStore) {
@@ -28,8 +29,9 @@ export function bindEditorClipboard(store: EditorStore) {
 
     const imageFiles = extractImageFilesFromClipboard(e)
     if (imageFiles.length) {
-      const cx = cursorPos?.x ?? (-store.state.panX + window.innerWidth / 2) / store.state.zoom
-      const cy = cursorPos?.y ?? (-store.state.panY + window.innerHeight / 2) / store.state.zoom
+      const center = paneCanvasCenter(store.getActivePane())
+      const cx = cursorPos?.x ?? center.x
+      const cy = cursorPos?.y ?? center.y
       void store.placeImageFiles(imageFiles, cx, cy)
       return
     }

--- a/src/app/shell/menu/editor-actions.ts
+++ b/src/app/shell/menu/editor-actions.ts
@@ -1,6 +1,7 @@
 import type { SceneNode } from '@open-pencil/core/scene-graph'
 
 import { useEditorStore } from '@/app/editor/active-store'
+import { paneScreenCenter } from '@/app/editor/panes/viewport'
 
 type TextFormatUpdates = {
   fontWeight?: number
@@ -47,9 +48,14 @@ export function toggleSelectedTextUnderline(): void {
 export function createSharedEditorMenuActions(
   setTheme: (theme: 'light' | 'dark' | 'auto') => void
 ) {
+  function zoomActivePane(delta: number) {
+    const center = paneScreenCenter(store.getActivePane())
+    store.applyZoom(delta, center.x, center.y)
+  }
+
   return {
-    'zoom-in': () => store.applyZoom(-100, window.innerWidth / 2, window.innerHeight / 2),
-    'zoom-out': () => store.applyZoom(100, window.innerWidth / 2, window.innerHeight / 2),
+    'zoom-in': () => zoomActivePane(-100),
+    'zoom-out': () => zoomActivePane(100),
     'toggle-ui': () => {
       store.state.showUI = !store.state.showUI
     },

--- a/src/components/CanvasMenu.vue
+++ b/src/components/CanvasMenu.vue
@@ -8,6 +8,7 @@ import {
   ContextMenuSubContent,
   ContextMenuPortal
 } from 'reka-ui'
+import { computed } from 'vue'
 import IconCombine from '~icons/lucide/combine'
 import IconCopyMinus from '~icons/lucide/copy-minus'
 import IconCopyX from '~icons/lucide/copy-x'
@@ -22,7 +23,8 @@ import {
   useMenuModel,
   useSelectionState,
   editorCommandMetadata,
-  formatShortcut
+  formatShortcut,
+  useViewportKind
 } from '@open-pencil/vue'
 import type { Component } from 'vue'
 import type { EditorCommandId } from '@open-pencil/vue'
@@ -41,6 +43,7 @@ const { editor, selectedIds, hasSelection } = useSelectionState()
 const { getCommand } = useEditorCommands()
 const { canvasMenu } = useMenuModel()
 const { menu: t } = useI18n()
+const { isMobile } = useViewportKind()
 
 const canvasMenuActions = createCanvasMenuActions(store, selectedIds)
 const { execCommand } = canvasMenuActions
@@ -70,6 +73,11 @@ const booleanCommandIcons = {
   'selection.outlineStroke': IconSpline
 } satisfies Partial<Record<EditorCommandId, Component>>
 
+const canSplitPane = computed(
+  () => !isMobile.value && store.visiblePaneCount.value < store.maxVisiblePanes
+)
+const canClosePane = computed(() => !isMobile.value && store.visiblePaneCount.value > 1)
+
 function contextCommandTestId(id: EditorCommandId | undefined): string | undefined {
   return id ? editorCommandMetadata(id).contextTestId : undefined
 }
@@ -77,6 +85,14 @@ function contextCommandTestId(id: EditorCommandId | undefined): string | undefin
 function contextCommandIcon(id: EditorCommandId | undefined): Component | undefined {
   if (!id) return undefined
   return (booleanCommandIcons as Partial<Record<EditorCommandId, Component>>)[id]
+}
+
+function splitPane(direction: 'horizontal' | 'vertical') {
+  store.splitPane(store.activePaneId.value, direction)
+}
+
+function closeActivePane() {
+  store.closePane(store.activePaneId.value)
 }
 </script>
 
@@ -112,6 +128,34 @@ function contextCommandIcon(id: EditorCommandId | undefined): Component | undefi
     >
       <span>{{ t.pasteToReplace }}</span>
     </ContextMenuItem>
+    <template v-if="!isMobile">
+      <ContextMenuSeparator :class="cls.sep" />
+      <ContextMenuItem
+        data-test-id="context-split-pane-right"
+        :class="cls.item"
+        :disabled="!canSplitPane"
+        @select="splitPane('horizontal')"
+      >
+        <span>Split Pane Right</span>
+      </ContextMenuItem>
+      <ContextMenuItem
+        data-test-id="context-split-pane-down"
+        :class="cls.item"
+        :disabled="!canSplitPane"
+        @select="splitPane('vertical')"
+      >
+        <span>Split Pane Down</span>
+      </ContextMenuItem>
+      <ContextMenuItem
+        data-test-id="context-close-pane"
+        :class="cls.item"
+        :disabled="!canClosePane"
+        @select="closeActivePane"
+      >
+        <span>Close Pane</span>
+      </ContextMenuItem>
+    </template>
+    <ContextMenuSeparator :class="cls.sep" />
     <ContextMenuItem
       data-test-id="context-duplicate"
       :class="cls.item"

--- a/src/components/CanvasPanes/CanvasSplitNode.vue
+++ b/src/components/CanvasPanes/CanvasSplitNode.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from 'reka-ui'
+
+import { useEditorStore } from '@/app/editor/active-store'
+import { childKey } from '@/app/editor/panes/split-tree'
+import EditorCanvasPane from '@/components/CanvasPanes/EditorCanvasPane.vue'
+
+import type { CanvasSplitNode as CanvasSplitNodeModel } from '@/app/editor/panes/types'
+
+const { node } = defineProps<{
+  node: CanvasSplitNodeModel
+}>()
+
+const store = useEditorStore()
+const MIN_CANVAS_PANE_SIZE_PERCENT = 12
+
+function handleLayout(splitId: string, sizes: number[]) {
+  store.updateSplitSizes(splitId, sizes)
+}
+</script>
+
+<template>
+  <EditorCanvasPane v-if="node.type === 'pane'" :pane-id="node.paneId" />
+  <SplitterGroup
+    v-else
+    :id="`canvas-split-${node.id}`"
+    :direction="node.direction"
+    :keyboard-resize-by="10"
+    class="flex min-h-0 min-w-0 flex-1 overflow-hidden"
+    @layout="(sizes) => handleLayout(node.id, sizes)"
+  >
+    <template v-for="(child, index) in node.children" :key="childKey(child)">
+      <SplitterPanel
+        :id="`canvas-split-panel-${node.id}-${childKey(child)}`"
+        :order="index"
+        :default-size="node.sizes[index] ?? 100 / node.children.length"
+        :min-size="MIN_CANVAS_PANE_SIZE_PERCENT"
+        class="flex min-h-0 min-w-0 overflow-hidden"
+      >
+        <CanvasSplitNode :node="child" />
+      </SplitterPanel>
+
+      <SplitterResizeHandle
+        v-if="index < node.children.length - 1"
+        :id="`canvas-split-handle-${node.id}-${index}`"
+        :hit-area-margins="{ fine: 6, coarse: 18 }"
+        :class="
+          node.direction === 'horizontal'
+            ? 'group relative z-20 -mx-1 w-2 cursor-col-resize'
+            : 'group relative z-20 -my-1 h-2 cursor-row-resize'
+        "
+      >
+        <div
+          :class="
+            node.direction === 'horizontal'
+              ? 'pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border group-data-[resize-handle-state=drag]:bg-accent'
+              : 'pointer-events-none absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-border group-data-[resize-handle-state=drag]:bg-accent'
+          "
+        />
+      </SplitterResizeHandle>
+    </template>
+  </SplitterGroup>
+</template>

--- a/src/components/CanvasPanes/CanvasSplitNode.vue
+++ b/src/components/CanvasPanes/CanvasSplitNode.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
-import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from 'reka-ui'
+import { useEventListener } from '@vueuse/core'
+import { ref } from 'vue'
 
 import { useEditorStore } from '@/app/editor/active-store'
+import { logSplitPaneDebug } from '@/app/editor/panes/debug'
 import { childKey } from '@/app/editor/panes/split-tree'
 import EditorCanvasPane from '@/components/CanvasPanes/EditorCanvasPane.vue'
 
-import type { CanvasSplitNode as CanvasSplitNodeModel } from '@/app/editor/panes/types'
+import type {
+  CanvasSplitNode as CanvasSplitNodeModel,
+  SplitDirection
+} from '@/app/editor/panes/types'
 
 const { node } = defineProps<{
   node: CanvasSplitNodeModel
@@ -14,50 +19,156 @@ const { node } = defineProps<{
 const store = useEditorStore()
 const MIN_CANVAS_PANE_SIZE_PERCENT = 12
 
-function handleLayout(splitId: string, sizes: number[]) {
-  store.updateSplitSizes(splitId, sizes)
+type SplitDragState = {
+  splitId: string
+  index: number
+  direction: SplitDirection
+  startClientPosition: number
+  containerSize: number
+  startSizes: number[]
 }
+
+const drag = ref<SplitDragState | null>(null)
+
+function childSize(index: number): number {
+  if (node.type === 'pane') return 100
+  return node.sizes[index] ?? 100 / node.children.length
+}
+
+function childStyle(index: number) {
+  return { flex: `0 0 ${childSize(index)}%` }
+}
+
+function clientPosition(event: MouseEvent, direction: SplitDirection): number {
+  return direction === 'horizontal' ? event.clientX : event.clientY
+}
+
+function containerSize(element: HTMLElement, direction: SplitDirection): number {
+  const rect = element.getBoundingClientRect()
+  return direction === 'horizontal' ? rect.width : rect.height
+}
+
+function currentSizes(): number[] {
+  if (node.type === 'pane') return [100]
+  return node.children.map((_, index) => childSize(index))
+}
+
+function resizeAdjacentPanels(state: SplitDragState, event: MouseEvent): number[] {
+  const sizes = [...state.startSizes]
+  const first = state.index
+  const second = state.index + 1
+  const total = state.startSizes[first] + state.startSizes[second]
+  const delta =
+    ((clientPosition(event, state.direction) - state.startClientPosition) / state.containerSize) *
+    100
+  const nextFirst = Math.min(
+    total - MIN_CANVAS_PANE_SIZE_PERCENT,
+    Math.max(MIN_CANVAS_PANE_SIZE_PERCENT, state.startSizes[first] + delta)
+  )
+  sizes[first] = nextFirst
+  sizes[second] = total - nextFirst
+  return sizes
+}
+
+function startSplitDrag(
+  event: MouseEvent,
+  splitId: string,
+  index: number,
+  direction: SplitDirection
+) {
+  const container =
+    event.currentTarget instanceof HTMLElement
+      ? event.currentTarget.closest<HTMLElement>('[data-canvas-split-container]')
+      : null
+  if (!container) return
+
+  event.preventDefault()
+  event.stopPropagation()
+
+  drag.value = {
+    splitId,
+    index,
+    direction,
+    startClientPosition: clientPosition(event, direction),
+    containerSize: containerSize(container, direction),
+    startSizes: currentSizes()
+  }
+  store.setSplitResizeActive(true)
+  logSplitPaneDebug('dragging', { splitId, handleIndex: index, dragging: true })
+}
+
+function finishSplitDrag(event?: MouseEvent) {
+  const current = drag.value
+  if (!current) return
+  event?.preventDefault()
+  drag.value = null
+  store.setSplitResizeActive(false)
+  logSplitPaneDebug('dragging', {
+    splitId: current.splitId,
+    handleIndex: current.index,
+    dragging: false
+  })
+}
+
+useEventListener(window, 'mousemove', (event) => {
+  const current = drag.value
+  if (!current) return
+  event.preventDefault()
+  const sizes = resizeAdjacentPanels(current, event)
+  logSplitPaneDebug('layout', { splitId: current.splitId, sizes })
+  store.updateSplitSizes(current.splitId, sizes)
+})
+
+useEventListener(window, 'mouseup', (event) => {
+  logSplitPaneDebug('window-mouseup', {
+    button: event.button,
+    buttons: event.buttons,
+    target: event.target instanceof HTMLElement ? event.target.tagName : null,
+    activeHandle: null
+  })
+  finishSplitDrag(event)
+})
+
+useEventListener(window, 'blur', () => finishSplitDrag())
 </script>
 
 <template>
   <EditorCanvasPane v-if="node.type === 'pane'" :pane-id="node.paneId" />
-  <SplitterGroup
+  <div
     v-else
     :id="`canvas-split-${node.id}`"
-    :direction="node.direction"
-    :keyboard-resize-by="10"
-    class="flex min-h-0 min-w-0 flex-1 overflow-hidden"
-    @layout="(sizes) => handleLayout(node.id, sizes)"
+    data-canvas-split-container
+    :class="
+      node.direction === 'horizontal'
+        ? 'flex min-h-0 min-w-0 flex-1 flex-row overflow-hidden'
+        : 'flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden'
+    "
   >
     <template v-for="(child, index) in node.children" :key="childKey(child)">
-      <SplitterPanel
-        :id="`canvas-split-panel-${node.id}-${childKey(child)}`"
-        :order="index"
-        :default-size="node.sizes[index] ?? 100 / node.children.length"
-        :min-size="MIN_CANVAS_PANE_SIZE_PERCENT"
-        class="flex min-h-0 min-w-0 overflow-hidden"
-      >
+      <div class="flex min-h-0 min-w-0 overflow-hidden" :style="childStyle(index)">
         <CanvasSplitNode :node="child" />
-      </SplitterPanel>
+      </div>
 
-      <SplitterResizeHandle
+      <div
         v-if="index < node.children.length - 1"
-        :id="`canvas-split-handle-${node.id}-${index}`"
-        :hit-area-margins="{ fine: 6, coarse: 18 }"
         :class="
           node.direction === 'horizontal'
-            ? 'group relative z-20 -mx-1 w-2 cursor-col-resize'
-            : 'group relative z-20 -my-1 h-2 cursor-row-resize'
+            ? 'relative z-50 w-0 shrink-0'
+            : 'relative z-50 h-0 shrink-0'
         "
       >
         <div
+          :id="`canvas-split-handle-${node.id}-${index}`"
           :class="
             node.direction === 'horizontal'
-              ? 'pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border group-data-[resize-handle-state=drag]:bg-accent'
-              : 'pointer-events-none absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-border group-data-[resize-handle-state=drag]:bg-accent'
+              ? 'absolute inset-y-0 left-1/2 w-2 -translate-x-1/2 cursor-col-resize touch-none select-none'
+              : 'absolute inset-x-0 top-1/2 h-2 -translate-y-1/2 cursor-row-resize touch-none select-none'
           "
+          role="separator"
+          :aria-orientation="node.direction === 'horizontal' ? 'vertical' : 'horizontal'"
+          @mousedown="(event) => startSplitDrag(event, node.id, index, node.direction)"
         />
-      </SplitterResizeHandle>
+      </div>
     </template>
-  </SplitterGroup>
+  </div>
 </template>

--- a/src/components/CanvasPanes/CanvasSplitRoot.vue
+++ b/src/components/CanvasPanes/CanvasSplitRoot.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { computed, watchEffect } from 'vue'
+
+import { useEditorStore } from '@/app/editor/active-store'
+import CanvasSplitNode from '@/components/CanvasPanes/CanvasSplitNode.vue'
+
+const { singlePaneOnly = false } = defineProps<{
+  singlePaneOnly?: boolean
+}>()
+
+const store = useEditorStore()
+const splitTree = computed(() => store.splitTree.value)
+
+watchEffect(() => {
+  if (singlePaneOnly && store.visiblePaneCount.value > 1) store.ensureSinglePane()
+})
+</script>
+
+<template>
+  <div class="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">
+    <CanvasSplitNode :node="splitTree" />
+  </div>
+</template>

--- a/src/components/CanvasPanes/EditorCanvasPane.vue
+++ b/src/components/CanvasPanes/EditorCanvasPane.vue
@@ -1,0 +1,150 @@
+<script setup lang="ts">
+import { computed, onUnmounted, ref } from 'vue'
+import { ContextMenuPortal, ContextMenuRoot, ContextMenuTrigger } from 'reka-ui'
+
+import { toolCursor, useCanvas, useCanvasDrop, useCanvasInput, useTextEdit } from '@open-pencil/vue'
+import { useCollabInjected } from '@/app/collab/use'
+import { useEditorStore } from '@/app/editor/active-store'
+import { useCanvasCollaborationAwareness } from '@/app/editor/canvas/collaboration-awareness'
+import { createCanvasContextSelection } from '@/app/editor/canvas/context-selection'
+import { fadeOutGlobalLoader } from '@/app/editor/canvas/loader-overlay'
+import CanvasMenu from '@/components/CanvasMenu.vue'
+
+const { paneId } = defineProps<{
+  paneId: string
+}>()
+
+const store = useEditorStore()
+const collab = useCollabInjected()
+const sceneCanvasRef = ref<HTMLCanvasElement | null>(null)
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+
+const isActivePane = computed(() => store.activePaneId.value === paneId)
+
+function activatePane() {
+  store.setActivePane(paneId)
+}
+
+const { updateCursor } = useCanvasCollaborationAwareness(store, collab)
+const { selectAtContextPoint } = createCanvasContextSelection(canvasRef, store)
+
+useCanvas(sceneCanvasRef, store, {
+  layer: 'scene',
+  showRulers: false,
+  getRenderState: () => store.getPaneRenderState(paneId),
+  onViewportResize: (width, height) => store.resizePane(paneId, width, height),
+  onReady: fadeOutGlobalLoader
+})
+const { hitTestSectionTitle, hitTestComponentLabel, hitTestFrameTitle } = useCanvas(
+  canvasRef,
+  store,
+  {
+    layer: 'overlays',
+    getRenderState: () => store.getPaneRenderState(paneId),
+    onViewportResize: (width, height) => store.resizePane(paneId, width, height)
+  }
+)
+const { cursorOverride, cleanupInteractions } = useCanvasInput(
+  canvasRef,
+  store,
+  hitTestSectionTitle,
+  hitTestComponentLabel,
+  hitTestFrameTitle,
+  updateCursor,
+  activatePane,
+  () => store.activePaneId.value === paneId
+)
+
+const unregisterCleanup = store.registerPaneCleanup(paneId, cleanupInteractions)
+onUnmounted(unregisterCleanup)
+
+useTextEdit(canvasRef, store, { isEnabled: () => store.activePaneId.value === paneId })
+const { isDraggingOver } = useCanvasDrop(canvasRef, store, activatePane)
+
+const cursor = computed(() => toolCursor(store.state.activeTool, cursorOverride.value))
+const canvasTestId = computed(() =>
+  isActivePane.value ? 'canvas-element' : `canvas-element-${paneId}`
+)
+const sceneCanvasTestId = computed(() =>
+  isActivePane.value ? 'scene-canvas-element' : `scene-canvas-element-${paneId}`
+)
+</script>
+
+<template>
+  <ContextMenuRoot :modal="false">
+    <ContextMenuTrigger as-child @contextmenu="(activatePane(), selectAtContextPoint($event))">
+      <div
+        data-test-id="canvas-area"
+        :data-pane-id="paneId"
+        class="canvas-area relative min-h-0 min-w-0 flex-1 overflow-hidden"
+        @pointerdown.capture="activatePane"
+        @focusin.capture="activatePane"
+        @wheel.capture="activatePane"
+        @dragenter.capture="activatePane"
+      >
+        <canvas
+          ref="sceneCanvasRef"
+          :data-test-id="sceneCanvasTestId"
+          :data-pane-id="paneId"
+          aria-hidden="true"
+          class="pointer-events-none absolute inset-0 size-full outline-none"
+        />
+        <canvas
+          ref="canvasRef"
+          :data-test-id="canvasTestId"
+          :data-pane-id="paneId"
+          tabindex="-1"
+          :style="{ cursor }"
+          class="absolute inset-0 block size-full touch-none outline-none"
+        />
+        <div
+          v-if="isActivePane"
+          class="pointer-events-none absolute inset-0 z-30 ring-1 ring-accent/70 ring-inset"
+        />
+        <Transition
+          enter-active-class="transition-opacity duration-150"
+          enter-from-class="opacity-0"
+          leave-active-class="transition-opacity duration-150"
+          leave-to-class="opacity-0"
+        >
+          <div
+            v-if="isDraggingOver"
+            class="pointer-events-none absolute inset-0 z-40 border-2 border-dashed border-accent/60 bg-accent/5"
+          />
+        </Transition>
+        <Transition leave-active-class="transition-opacity duration-300" leave-to-class="opacity-0">
+          <div
+            v-if="store.state.loading"
+            data-test-id="canvas-loading"
+            class="absolute inset-0 z-50 flex items-center justify-center bg-canvas"
+          >
+            <svg
+              class="size-8 text-white opacity-40"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path
+                d="m15.232 5.232 3.536 3.536m-2.036-5.036a2.5 2.5 0 0 1 3.536 3.536L6.5 21.036H3v-3.572L16.732 3.732Z"
+              />
+            </svg>
+            <div
+              class="absolute bottom-1/2 left-1/2 h-0.5 w-25 -translate-x-1/2 translate-y-10 overflow-hidden rounded-full bg-white/8"
+            >
+              <div
+                class="h-full w-2/5 animate-[slide_1s_ease-in-out_infinite] rounded-full bg-white/25"
+              />
+            </div>
+          </div>
+        </Transition>
+      </div>
+    </ContextMenuTrigger>
+
+    <ContextMenuPortal>
+      <CanvasMenu />
+    </ContextMenuPortal>
+  </ContextMenuRoot>
+</template>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -76,16 +76,6 @@ export const PEER_COLORS: Color[] = [
   { r: 0.91, g: 0.12, b: 0.39, a: 1 }
 ]
 
-export const YJS_JSON_FIELDS = new Set([
-  'childIds',
-  'fills',
-  'strokes',
-  'effects',
-  'vectorNetwork',
-  'boundVariables',
-  'styleRuns'
-])
-
 export {
   DEFAULT_SHAPE_FILL,
   DEFAULT_FRAME_FILL,

--- a/src/views/EditorView.vue
+++ b/src/views/EditorView.vue
@@ -19,7 +19,7 @@ import { useEditorStore } from '@/app/editor/active-store'
 import { createTab, activeTab, getActiveStore, tabCount } from '@/app/tabs'
 
 import CollabPanel from '@/components/CollabPanel/CollabPanel.vue'
-import EditorCanvas from '@/components/EditorCanvas.vue'
+import CanvasSplitRoot from '@/components/CanvasPanes/CanvasSplitRoot.vue'
 import LayersPanel from '@/components/LayersPanel.vue'
 import MobileDrawer from '@/components/MobileDrawer.vue'
 import MobileHud from '@/components/MobileHud/MobileHud.vue'
@@ -141,7 +141,7 @@ onUnmounted(() => {
       </SplitterResizeHandle>
       <SplitterPanel id="canvas" :default-size="initialEditorLayout[1]" :min-size="30" class="flex">
         <div class="relative flex min-w-0 flex-1">
-          <EditorCanvas />
+          <CanvasSplitRoot />
           <Toolbar />
         </div>
       </SplitterPanel>
@@ -171,7 +171,7 @@ onUnmounted(() => {
       class="flex flex-1 overflow-hidden"
     >
       <div class="relative flex min-w-0 flex-1">
-        <EditorCanvas />
+        <CanvasSplitRoot single-pane-only />
         <MobileHud />
         <Toolbar />
       </div>
@@ -185,7 +185,7 @@ onUnmounted(() => {
       class="flex flex-1 overflow-hidden"
     >
       <div class="relative flex min-w-0 flex-1">
-        <EditorCanvas />
+        <CanvasSplitRoot :single-pane-only="isMobile" />
         <div
           v-if="!isMobile"
           class="absolute top-7 left-7 z-10 flex items-center gap-2 rounded-lg border border-border bg-panel px-2 py-1 shadow-sm"
@@ -214,7 +214,7 @@ onUnmounted(() => {
     <!-- Bare canvas (no chrome, e.g. ?no-chrome) -->
     <div v-else :key="'bare-' + activeTab?.id" class="flex flex-1 overflow-hidden">
       <div class="relative flex min-w-0 flex-1">
-        <EditorCanvas />
+        <CanvasSplitRoot />
       </div>
     </div>
   </div>

--- a/tests/engine/collab/node-codec.test.ts
+++ b/tests/engine/collab/node-codec.test.ts
@@ -1,0 +1,425 @@
+import { describe, expect, test } from 'bun:test'
+
+import * as Y from 'yjs'
+
+import type { Vector } from '@open-pencil/core'
+import { SceneGraph, type SceneNode } from '@open-pencil/core/scene-graph'
+
+import { COLLAB_NODE_FIELDS, decodeNodeFromYjs, encodeNodeForYjs } from '@/app/collab/node-codec'
+import {
+  bindCollabGraphEvents,
+  createYjsGraphSync,
+  registerYjsObservers,
+  syncNodePropsToYMap
+} from '@/app/collab/yjs-sync'
+import type { EditorStore } from '@/app/editor/active-store'
+
+import { getFillGeometry } from '#core/canvas/shapes'
+import { computeDescendantVisualBounds } from '#core/geometry'
+
+type SceneNodeWithOptionalSource = Omit<SceneNode, 'source'> & { source?: SceneNode['source'] }
+
+function malformedGeometryPath(): SceneNode['fillGeometry'][number] {
+  return { windingRule: 'NONZERO' } as SceneNode['fillGeometry'][number]
+}
+
+function commandsBlobFromPoints(points: Vector[]): Uint8Array {
+  const blob = new Uint8Array(points.length * 9 + 1)
+  const view = new DataView(blob.buffer)
+  let offset = 0
+  for (const point of points) {
+    blob[offset] = 1
+    view.setFloat32(offset + 1, point.x, true)
+    view.setFloat32(offset + 5, point.y, true)
+    offset += 9
+  }
+  blob[offset] = 0
+  return blob
+}
+
+function createGraphWithPage() {
+  const graph = new SceneGraph()
+  const page = graph.createNode('CANVAS', graph.rootId, { name: 'Page' })
+  return { graph, page }
+}
+
+function createYNode() {
+  return new Y.Doc().getMap<unknown>('node')
+}
+
+function createPathRenderer() {
+  class MockPath {
+    calls = 0
+    close() {
+      this.calls += 1
+    }
+    moveTo() {
+      this.calls += 1
+    }
+    lineTo() {
+      this.calls += 1
+    }
+    quadTo() {
+      this.calls += 1
+    }
+    cubicTo() {
+      this.calls += 1
+    }
+    setFillType() {
+      this.calls += 1
+    }
+  }
+
+  return {
+    ck: {
+      Path: MockPath,
+      FillType: { EvenOdd: 'EvenOdd', Winding: 'Winding' }
+    },
+    fillGeometryCache: new Map(),
+    strokeGeometryCache: new Map()
+  }
+}
+
+describe('collab Yjs node codec', () => {
+  test('round-trips source metadata and geometry command blobs', () => {
+    const { graph, page } = createGraphWithPage()
+    const commandsBlob = commandsBlobFromPoints([
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 }
+    ])
+    const node = graph.createNode('RECTANGLE', page.id, {
+      name: 'Remote rectangle',
+      fills: [{ type: 'SOLID', color: { r: 1, g: 0, b: 0, a: 1 }, opacity: 1, visible: true }],
+      fillGeometry: [{ windingRule: 'NONZERO', commandsBlob }],
+      source: {
+        format: 'fig',
+        id: 'fig-node',
+        orderKey: 'a1',
+        fig: {
+          rawSize: { x: 10, y: 10 },
+          rawTransform: null,
+          rawNodeFields: { fillGeometry: [{ commandsBlob: 0 }] },
+          layout: null,
+          symbolOverrides: [],
+          componentPropAssignments: [],
+          derivedSymbolData: [],
+          derivedSymbolDataLayoutVersion: null,
+          uniformScaleFactor: null
+        }
+      }
+    })
+
+    const ynode = createYNode()
+    syncNodePropsToYMap(node, ynode)
+    const props = decodeNodeFromYjs(ynode)
+
+    expect(props.source).toMatchObject({ format: 'fig', id: 'fig-node', orderKey: 'a1' })
+    const fillGeometry = props.fillGeometry as SceneNode['fillGeometry']
+    expect(fillGeometry[0]?.commandsBlob).toBeInstanceOf(Uint8Array)
+    expect([...fillGeometry[0].commandsBlob]).toEqual([...commandsBlob])
+  })
+
+  test('encodes only approved graph fields plus a null text picture cache', () => {
+    const { graph, page } = createGraphWithPage()
+    const node = graph.createNode('RECTANGLE', page.id, { width: 10, height: 10 })
+
+    const keys = Object.keys(encodeNodeForYjs(node)).sort()
+
+    expect(keys).toEqual([...COLLAB_NODE_FIELDS, 'textPicture'].sort())
+  })
+
+  test('normalizes omitted source metadata during decode', () => {
+    const ynode = createYNode()
+    ynode.set('id', 'remote')
+    ynode.set('type', 'RECTANGLE')
+
+    const props = decodeNodeFromYjs(ynode)
+
+    expect(props.source?.fig.rawNodeFields).toEqual({})
+  })
+
+  test('decodes legacy stringified object fields', () => {
+    const ynode = createYNode()
+    ynode.set('id', 'remote')
+    ynode.set('type', 'RECTANGLE')
+    ynode.set('childIds', JSON.stringify(['child']))
+    ynode.set(
+      'fills',
+      JSON.stringify([
+        { type: 'SOLID', color: { r: 0, g: 1, b: 0, a: 1 }, opacity: 1, visible: true }
+      ])
+    )
+    ynode.set(
+      'source',
+      JSON.stringify({
+        format: null,
+        id: null,
+        orderKey: null,
+        fig: { rawNodeFields: { opacity: 1 } }
+      })
+    )
+
+    const props = decodeNodeFromYjs(ynode)
+
+    expect(props.childIds).toEqual(['child'])
+    expect(props.fills).toMatchObject([{ type: 'SOLID' }])
+    expect(props.source).toMatchObject({ fig: { rawNodeFields: { opacity: 1 } } })
+  })
+
+  test('decodes legacy stringified Uint8Array geometry records', () => {
+    const commandsBlob = new Uint8Array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    const ynode = createYNode()
+    ynode.set('fillGeometry', JSON.stringify([{ windingRule: 'EVENODD', commandsBlob }]))
+
+    const props = decodeNodeFromYjs(ynode)
+    const fillGeometry = props.fillGeometry as SceneNode['fillGeometry']
+
+    expect(fillGeometry[0]?.windingRule).toBe('EVENODD')
+    expect(fillGeometry[0]?.commandsBlob).toBeInstanceOf(Uint8Array)
+    expect([...fillGeometry[0].commandsBlob]).toEqual([...commandsBlob])
+  })
+
+  test('normalizes missing source metadata before graph updates clear raw metadata', () => {
+    const { graph, page } = createGraphWithPage()
+    const node = graph.createNode('RECTANGLE', page.id, { width: 10, height: 10 })
+    const corruptNode = node as SceneNodeWithOptionalSource
+    corruptNode.source = undefined
+
+    expect(() => graph.updateNode(node.id, { width: 20 })).not.toThrow()
+    expect(node.source.fig.rawSize).toBeNull()
+    expect(node.width).toBe(20)
+  })
+
+  test('skips malformed geometry while preserving valid sibling geometry', () => {
+    const { graph, page } = createGraphWithPage()
+    const validBlob = commandsBlobFromPoints([
+      { x: 0, y: 0 },
+      { x: 5, y: 5 }
+    ])
+    const node = graph.createNode('RECTANGLE', page.id, {
+      width: 10,
+      height: 10,
+      fillGeometry: [
+        { windingRule: 'NONZERO', commandsBlob: validBlob },
+        { windingRule: 'NONZERO', commandsBlob: new Uint8Array([4, 0]) },
+        malformedGeometryPath()
+      ]
+    })
+
+    expect(() =>
+      computeDescendantVisualBounds(
+        [node.id],
+        (id) => graph.getNode(id),
+        (id) => graph.getAbsolutePosition(id)
+      )
+    ).not.toThrow()
+    expect(() => getFillGeometry(createPathRenderer() as never, node)).not.toThrow()
+    expect(getFillGeometry(createPathRenderer() as never, node)).toHaveLength(1)
+  })
+
+  test('round-trips vector networks and image fill references without embedding image bytes in node props', () => {
+    const { graph, page } = createGraphWithPage()
+    const node = graph.createNode('RECTANGLE', page.id, {
+      vectorNetwork: {
+        vertices: [
+          { x: 0, y: 0, strokeCap: 'NONE', strokeJoin: 'MITER', cornerRadius: 0 },
+          { x: 10, y: 0, strokeCap: 'NONE', strokeJoin: 'MITER', cornerRadius: 0 }
+        ],
+        segments: [{ start: 0, end: 1, tangentStart: { x: 0, y: 0 }, tangentEnd: { x: 0, y: 0 } }],
+        regions: []
+      },
+      fills: [
+        {
+          type: 'IMAGE',
+          color: { r: 1, g: 1, b: 1, a: 1 },
+          opacity: 1,
+          visible: true,
+          imageHash: 'hash-1',
+          scaleMode: 'FILL'
+        }
+      ]
+    })
+    graph.images.set('hash-1', new Uint8Array([1, 2, 3]))
+
+    const ynode = createYNode()
+    syncNodePropsToYMap(node, ynode)
+    const props = decodeNodeFromYjs(ynode)
+
+    expect(props.fills).toMatchObject([{ imageHash: 'hash-1' }])
+    expect(props.vectorNetwork?.vertices[0]).toMatchObject({ x: 0, y: 0 })
+    expect(props.vectorNetwork?.segments[0]).toMatchObject({ start: 0, end: 1 })
+    expect(JSON.stringify(ynode.toJSON())).not.toContain('1,2,3')
+  })
+
+  test('resolves image bytes that arrive after image node references', () => {
+    const local = createGraphWithPage()
+    const remote = createGraphWithPage()
+    const remoteNode = remote.graph.createNode('RECTANGLE', local.page.id, {
+      id: 'image-node',
+      fills: [
+        {
+          type: 'IMAGE',
+          color: { r: 1, g: 1, b: 1, a: 1 },
+          opacity: 1,
+          visible: true,
+          imageHash: 'late-image',
+          scaleMode: 'FILL'
+        }
+      ]
+    })
+    const ydoc = new Y.Doc()
+    const ynodes = ydoc.getMap<Y.Map<unknown>>('nodes')
+    const yimages = ydoc.getMap<Uint8Array>('images')
+    const store = {
+      graph: local.graph,
+      requestRender: () => undefined
+    } as Pick<EditorStore, 'graph' | 'requestRender'>
+    const { applyYjsToGraph } = createYjsGraphSync({
+      getStore: () => store as EditorStore,
+      getYdoc: () => ydoc,
+      getYnodes: () => ynodes,
+      getYimages: () => yimages,
+      setSuppressYjsEvents: () => undefined
+    })
+    registerYjsObservers({
+      store: store as EditorStore,
+      ynodes,
+      yimages,
+      getSuppressYjsEvents: () => false,
+      setSuppressGraphSync: () => undefined,
+      applyYjsToGraph
+    })
+
+    const ynode = new Y.Map<unknown>()
+    syncNodePropsToYMap(remoteNode, ynode)
+    ynodes.set(remoteNode.id, ynode)
+    expect(local.graph.getNode(remoteNode.id)?.fills).toMatchObject([{ imageHash: 'late-image' }])
+    expect(local.graph.images.has('late-image')).toBe(false)
+
+    yimages.set('late-image', new Uint8Array([8, 9, 10]))
+
+    expect([...(local.graph.images.get('late-image') ?? [])]).toEqual([8, 9, 10])
+  })
+
+  test('applies remote create with original id, parent, placement, and child ordering', () => {
+    const local = createGraphWithPage()
+    const remote = createGraphWithPage()
+    const remoteNodeId = 'remote-rect'
+    const sibling = local.graph.createNode('RECTANGLE', local.page.id, { id: 'sibling' })
+    local.page.childIds = [remoteNodeId, sibling.id]
+    const remoteNode = remote.graph.createNode('RECTANGLE', local.page.id, {
+      id: remoteNodeId,
+      name: 'Remote rectangle',
+      x: 42,
+      y: 24,
+      width: 10,
+      height: 20
+    })
+
+    const ydoc = new Y.Doc()
+    const ynodes = ydoc.getMap<Y.Map<unknown>>('nodes')
+    const yimages = ydoc.getMap<Uint8Array>('images')
+    const store = {
+      graph: local.graph,
+      requestRender: () => undefined
+    } as Pick<EditorStore, 'graph' | 'requestRender'>
+    const { applyYjsToGraph } = createYjsGraphSync({
+      getStore: () => store as EditorStore,
+      getYdoc: () => ydoc,
+      getYnodes: () => ynodes,
+      getYimages: () => null,
+      setSuppressYjsEvents: () => undefined
+    })
+    registerYjsObservers({
+      store: store as EditorStore,
+      ynodes,
+      yimages,
+      getSuppressYjsEvents: () => false,
+      setSuppressGraphSync: () => undefined,
+      applyYjsToGraph
+    })
+
+    const parentYnode = new Y.Map<unknown>()
+    syncNodePropsToYMap(local.page, parentYnode)
+    ynodes.set(local.page.id, parentYnode)
+
+    const ynode = new Y.Map<unknown>()
+    syncNodePropsToYMap(remoteNode, ynode)
+    ynodes.set(remoteNode.id, ynode)
+
+    const created = local.graph.getNode(remoteNode.id)
+    expect(created?.id).toBe(remoteNode.id)
+    expect(created?.parentId).toBe(local.page.id)
+    expect(created).toMatchObject({ x: 42, y: 24, width: 10, height: 20 })
+    expect(local.graph.getNode(local.page.id)?.childIds).toEqual([remoteNode.id, sibling.id])
+  })
+
+  test('syncs parent nodes when child order changes', () => {
+    const handlers: Record<string, Array<(...args: unknown[]) => void>> = {}
+    const store = {
+      onEditorEvent(event: string, handler: (...args: unknown[]) => void) {
+        handlers[event] = [...(handlers[event] ?? []), handler]
+        return () => undefined
+      }
+    } as Pick<EditorStore, 'onEditorEvent'>
+    const ydoc = new Y.Doc()
+    const ynodes = ydoc.getMap<Y.Map<unknown>>('nodes')
+    const synced: string[] = []
+
+    bindCollabGraphEvents({
+      store,
+      getYdoc: () => ydoc,
+      getYnodes: () => ynodes,
+      getSuppressGraphSync: () => false,
+      setSuppressYjsEvents: () => undefined,
+      syncNodeToYjs: (nodeId) => synced.push(nodeId)
+    })
+
+    handlers['node:created']?.[0]?.({ id: 'new-child', parentId: 'parent' })
+    handlers['node:reordered']?.[0]?.('child', 'parent', 0)
+    handlers['node:reparented']?.[0]?.('child', 'old-parent', 'new-parent')
+
+    expect(synced).toEqual([
+      'new-child',
+      'parent',
+      'child',
+      'parent',
+      'child',
+      'old-parent',
+      'new-parent'
+    ])
+  })
+
+  test('preserves graph sync suppression for remote updates and resumes local sync afterward', () => {
+    const handlers: Record<string, Array<(...args: unknown[]) => void>> = {}
+    const store = {
+      onEditorEvent(event: string, handler: (...args: unknown[]) => void) {
+        handlers[event] = [...(handlers[event] ?? []), handler]
+        return () => undefined
+      }
+    } as Pick<EditorStore, 'onEditorEvent'>
+    const ydoc = new Y.Doc()
+    const ynodes = ydoc.getMap<Y.Map<unknown>>('nodes')
+    let suppressGraphSync = true
+    let syncCount = 0
+
+    bindCollabGraphEvents({
+      store,
+      getYdoc: () => ydoc,
+      getYnodes: () => ynodes,
+      getSuppressGraphSync: () => suppressGraphSync,
+      setSuppressYjsEvents: () => undefined,
+      syncNodeToYjs: () => {
+        syncCount += 1
+      }
+    })
+
+    handlers['node:updated']?.[0]?.('remote-id', {})
+    suppressGraphSync = false
+    handlers['node:updated']?.[0]?.('local-id', {})
+
+    expect(syncCount).toBe(1)
+  })
+})

--- a/tests/engine/io/fig/import/schema-coverage.test.ts
+++ b/tests/engine/io/fig/import/schema-coverage.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs'
 import ts from 'typescript'
 
 import { FIGMA_RAW_NODE_FIELD_KEYS } from '#core/kiwi/fig/node-change/convert'
-import { parseSchema } from '#core/kiwi/schema-runtime/parser'
+import { parseSchema } from '#core/kiwi/schema-runtime'
 
 interface SchemaField {
   name: string

--- a/tests/engine/io/fig/roundtrip/exhaustive.test.ts
+++ b/tests/engine/io/fig/roundtrip/exhaustive.test.ts
@@ -62,8 +62,8 @@ const SPECS: FixtureSpec[] = [
     thumbnailHeight: 239,
     imageCount: 3,
     figKiwiVersion: 101,
-    g1ExportSize: 594517,
-    g2ExportSize: 594517
+    g1ExportSize: 594758,
+    g2ExportSize: 594758
   }
 ]
 

--- a/tests/engine/panes.test.ts
+++ b/tests/engine/panes.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from 'bun:test'
+
+import { SceneGraph } from '@open-pencil/core/scene-graph'
+
+import { createCanvasPaneState } from '@/app/editor/panes/create'
+import {
+  clearPanePageViewports,
+  deletePanePageViewport,
+  restorePanePageViewport,
+  savePanePageViewport
+} from '@/app/editor/panes/page-viewports'
+import { composePaneRenderState } from '@/app/editor/panes/render-state'
+import {
+  closePaneNode,
+  isValidLayoutSizes,
+  leafPaneIds,
+  normalizeSizes,
+  paneCount,
+  splitPaneNode,
+  updateSplitSizes
+} from '@/app/editor/panes/split-tree'
+import { createCanvasPaneRegistry } from '@/app/editor/panes/store'
+import type { CanvasSplitNode } from '@/app/editor/panes/types'
+import { createInitialAppEditorState } from '@/app/editor/session/types'
+
+describe('canvas pane split tree', () => {
+  test('splits a pane into a stable split node', () => {
+    const tree: CanvasSplitNode = { type: 'pane', paneId: 'pane-1' }
+    const next = splitPaneNode(tree, 'pane-1', 'pane-2', 'split-1', 'horizontal')
+
+    expect(paneCount(next)).toBe(2)
+    expect(leafPaneIds(next)).toEqual(['pane-1', 'pane-2'])
+    expect(next.type).toBe('split')
+    if (next.type === 'split') {
+      expect(next.sizes).toEqual([50, 50])
+      expect(next.direction).toBe('horizontal')
+    }
+  })
+
+  test('closes a pane and collapses single-child parents', () => {
+    const tree = splitPaneNode(
+      { type: 'pane', paneId: 'pane-1' },
+      'pane-1',
+      'pane-2',
+      'split-1',
+      'vertical'
+    )
+
+    const next = closePaneNode(tree, 'pane-2')
+    expect(next).toEqual({ type: 'pane', paneId: 'pane-1' })
+  })
+
+  test('normalizes and rejects layout sizes', () => {
+    expect(normalizeSizes(2, [10, 30])).toEqual([25, 75])
+    expect(normalizeSizes(2, [0, 30])).toEqual([50, 50])
+    expect(isValidLayoutSizes([40, 60], 2)).toBe(true)
+    expect(isValidLayoutSizes([40], 2)).toBe(false)
+
+    const tree = splitPaneNode(
+      { type: 'pane', paneId: 'pane-1' },
+      'pane-1',
+      'pane-2',
+      'split-1',
+      'horizontal'
+    )
+    const updated = updateSplitSizes(tree, 'split-1', [25, 75])
+    const ignored = updateSplitSizes(updated, 'split-1', [100])
+    expect(ignored).toEqual(updated)
+  })
+})
+
+describe('canvas pane registry', () => {
+  test('refuses to close the last pane and enforces the visible pane cap', () => {
+    const graph = new SceneGraph()
+    const registry = createCanvasPaneRegistry({
+      graph,
+      state: createInitialAppEditorState(graph.getPages()[0].id)
+    })
+
+    expect(registry.closePane(registry.activePaneId.value)).toEqual({
+      ok: false,
+      reason: 'last-pane'
+    })
+
+    const sourcePane = registry.getActivePane()
+    sourcePane.panX = 42
+    sourcePane.zoom = 3
+    sourcePane.selectedIds = new Set(['node-1'])
+
+    let currentPaneId = registry.activePaneId.value
+    for (let i = 1; i < registry.maxVisiblePanes; i++) {
+      const result = registry.splitPane(currentPaneId, 'horizontal')
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        const pane = registry.getPane(result.paneId)
+        expect(pane?.panX).toBe(42)
+        expect(pane?.zoom).toBe(3)
+        expect([...(pane?.selectedIds ?? [])]).toEqual([])
+        currentPaneId = result.paneId
+      }
+    }
+
+    const capped = registry.splitPane(currentPaneId, 'horizontal')
+    expect(capped).toEqual({ ok: false, reason: 'pane-cap' })
+    expect(registry.visiblePaneCount.value).toBe(registry.maxVisiblePanes)
+
+    const activePaneId = registry.activePaneId.value
+    expect(registry.ensureSinglePane()).toBe(activePaneId)
+    expect(registry.visiblePaneCount.value).toBe(1)
+    expect(leafPaneIds(registry.splitTree.value)).toEqual([activePaneId])
+  })
+})
+
+describe('canvas pane render state', () => {
+  test('combines shared fields and hides remote cursors for inactive panes', () => {
+    const shared = createInitialAppEditorState('page-1')
+    shared.documentName = 'Shared document'
+    shared.sceneVersion = 7
+    shared.remoteCursors = [
+      {
+        name: 'A',
+        color: { r: 1, g: 0, b: 0, a: 1 },
+        x: 10,
+        y: 20,
+        pageId: 'page-1'
+      },
+      {
+        name: 'B',
+        color: { r: 0, g: 1, b: 0, a: 1 },
+        x: 30,
+        y: 40,
+        pageId: 'page-2'
+      }
+    ]
+
+    const pane = createCanvasPaneState('pane-1', 'page-2')
+    pane.panX = 11
+    pane.zoom = 2
+    pane.selectedIds = new Set(['node-1'])
+    pane.cursorCanvasX = 21
+    pane.cursorCanvasY = 34
+    pane.nodeEditState = {
+      nodeId: 'node-1',
+      origNetwork: { vertices: [], segments: [], regions: [] },
+      origBounds: { x: 0, y: 0, width: 10, height: 10 },
+      vertices: [],
+      segments: [],
+      regions: [],
+      selectedVertexIndices: new Set(),
+      draggedHandleInfo: null,
+      selectedHandles: new Set(),
+      hoveredHandleInfo: null
+    }
+
+    const activeRenderState = composePaneRenderState(shared, pane, { isActivePane: true })
+    const inactiveRenderState = composePaneRenderState(shared, pane)
+    expect(activeRenderState.documentName).toBe('Shared document')
+    expect(activeRenderState.sceneVersion).toBe(7)
+    expect(activeRenderState.currentPageId).toBe('page-2')
+    expect(activeRenderState.panX).toBe(11)
+    expect(activeRenderState.zoom).toBe(2)
+    expect([...activeRenderState.selectedIds]).toEqual(['node-1'])
+    expect(activeRenderState.cursorCanvasX).toBe(21)
+    expect(activeRenderState.cursorCanvasY).toBe(34)
+    expect(activeRenderState.nodeEditState?.nodeId).toBe('node-1')
+    expect(activeRenderState.remoteCursors.map((cursor) => cursor.name)).toEqual(['B'])
+    expect(inactiveRenderState.remoteCursors.map((cursor) => cursor.name)).toEqual(['B'])
+  })
+})
+
+describe('canvas pane page viewports', () => {
+  test('saves, restores, deletes, and clears pane page viewports', () => {
+    const pane = createCanvasPaneState('pane-1', 'page-1')
+    pane.panX = 12
+    pane.panY = 24
+    pane.zoom = 2
+    savePanePageViewport(pane)
+
+    pane.panX = 0
+    pane.panY = 0
+    pane.zoom = 1
+    restorePanePageViewport(pane, 'page-1')
+    expect(pane.panX).toBe(12)
+    expect(pane.panY).toBe(24)
+    expect(pane.zoom).toBe(2)
+
+    deletePanePageViewport(pane, 'page-1')
+    pane.panX = 5
+    restorePanePageViewport(pane, 'page-1')
+    expect(pane.panX).toBe(0)
+    expect(pane.zoom).toBe(1)
+
+    savePanePageViewport(pane)
+    clearPanePageViewports(pane)
+    expect(pane.pageViewports.size).toBe(0)
+  })
+})


### PR DESCRIPTION
Adds same-document split canvas panes while keeping the document graph, undo, IO, autosave, and editor shell shared. Each pane owns its page, viewport, selection, hover, cursor, overlays, and render state so multiple canvases can inspect the same document independently.

- Add pane-local editor view state, pane registry, split tree helpers, pane-bound editor facade, and recursive canvas split rendering
- Route pane-sensitive canvas input, zoom, keyboard, menu, clipboard, automation, export, collaboration cursors, and profiler behavior through the active pane
- Enforce the first-slice mobile policy as single-pane-only and cap visible desktop panes at four
- Use a canvas-specific split resize handler instead of Reka Splitter: Reka's global handle hit-testing can leave stale drag state when mouseup lands on the WebGL canvas, causing panes to keep resizing after release
- Keep split handles visually invisible while preserving a narrow drag target on the divider
- Add gated split-pane diagnostics via `?splitPaneDebug=1`; logs are disabled by default
- Add an explicit collaboration Yjs node codec that preserves source metadata, typed geometry blobs, image references, parent ordering, and suppress-flag semantics
- Harden malformed geometry/source metadata boundaries so remote collaboration payloads cannot crash rendering or graph updates

OpenSpec:
- `add-split-canvas-panes-main-refresh`
- `fix-collab-yjs-node-codec`

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [x] Tests added or updated
- [x] CHANGELOG.md updated (if user-facing)

Verification:
- `bun run format`
- `bun test tests/engine/collab/node-codec.test.ts tests/engine/panes.test.ts`
- `bun run check`
- `openspec validate add-split-canvas-panes-main-refresh --strict`
- `openspec validate fix-collab-yjs-node-codec --strict`
- `git diff --check`
- Manual split resize smoke test: no stuck drag, no post-release resize, live pane sync while dragging nodes
- Manual two-peer collaboration smoke test with split panes open
