### PR TITLE
fix(core): correct boolean op mapping, rotated transform, and fillGeometry fallback

### DIFF
--- a/packages/core/src/canvas/boolean.ts
+++ b/packages/core/src/canvas/boolean.ts
@@ -251,6 +251,13 @@ export function makeBooleanOperationPath(
   node: SceneNode,
   graph: SceneGraph
 ): Path | null {
+  const fg = r.getFillGeometry(node)
+  if (fg) {
+    const result = new r.ck.Path()
+    for (const p of fg) result.addPath(p)
+    return result
+  }
+
   const childPaths: Path[] = []
   for (const childId of node.childIds) {
     const child = graph.getNode(childId)
@@ -263,7 +270,11 @@ export function makeBooleanOperationPath(
 
   const first = childPaths[0]
   for (const path of childPaths.slice(1)) {
-    first.op(path, operationForNode(r, node))
+    if (!first.op(path, operationForNode(r, node))) {
+      path.delete()
+      for (const p of childPaths) p.delete()
+      return null
+    }
     path.delete()
   }
   return first

--- a/packages/core/src/canvas/shapes.ts
+++ b/packages/core/src/canvas/shapes.ts
@@ -1,10 +1,19 @@
 import type { Canvas, Path } from 'canvaskit-wasm'
 
 import { polygonVertices } from '#core/geometry'
-import type { SceneNode } from '#core/scene-graph'
+import type { SceneNode, VectorNetwork } from '#core/scene-graph'
 import { vectorNetworkToPath, geometryBlobToPath } from '#core/vector'
 
 import type { SkiaRenderer } from './renderer'
+
+function isSimpleRectNetwork(vn: VectorNetwork): boolean {
+  if (vn.vertices.length !== 4 || vn.segments.length !== 4) return false
+  for (const seg of vn.segments) {
+    if (seg.tangentStart.x !== 0 || seg.tangentStart.y !== 0) return false
+    if (seg.tangentEnd.x !== 0 || seg.tangentEnd.y !== 0) return false
+  }
+  return true
+}
 
 export function nodeHasRadius(node: SceneNode): boolean {
   return (
@@ -371,9 +380,20 @@ export function makeNodeShapePath(
       path.addOval(rect)
       break
     case 'VECTOR': {
-      const vps = r.getVectorPaths(node)
-      if (vps) {
-        for (const vp of vps) path.addPath(vp)
+      const vn = node.vectorNetwork
+      if (hasRadius && vn && isSimpleRectNetwork(vn)) {
+        if (nodeHasSmoothCorners(node)) {
+          const smoothPath = makeSmoothRRectPath(r, node)
+          path.addPath(smoothPath)
+          smoothPath.delete()
+        } else {
+          path.addRRect(r.makeRRect(node))
+        }
+      } else {
+        const vps = r.getVectorPaths(node)
+        if (vps) {
+          for (const vp of vps) path.addPath(vp)
+        }
       }
       break
     }

--- a/packages/core/src/kiwi/fig/codec/index.ts
+++ b/packages/core/src/kiwi/fig/codec/index.ts
@@ -329,7 +329,7 @@ export interface NodeChange {
   frameMaskDisabled?: boolean
   resizeToFit?: boolean
   // Vector
-  booleanOperation?: 'UNION' | 'SUBTRACT' | 'INTERSECT' | 'EXCLUDE'
+  booleanOperation?: 'UNION' | 'SUBTRACT' | 'INTERSECT' | 'EXCLUDE' | 'XOR'
   vectorData?: unknown
   fillGeometry?: Array<{ windingRule?: string; commandsBlob?: number }>
   strokeGeometry?: Array<{ windingRule?: string; commandsBlob?: number }>

--- a/packages/core/src/kiwi/fig/node-change/convert.ts
+++ b/packages/core/src/kiwi/fig/node-change/convert.ts
@@ -112,8 +112,10 @@ function mapBooleanOperation(nc: NodeChange): SceneNode['booleanOperation'] {
   switch (nc.booleanOperation) {
     case 'SUBTRACT':
     case 'INTERSECT':
-    case 'EXCLUDE':
       return nc.booleanOperation
+    case 'XOR':
+    case 'EXCLUDE':
+      return 'EXCLUDE'
     default:
       return 'UNION'
   }
@@ -229,17 +231,13 @@ function convertTransformProps(
     const sx = flipX ? -1 : 1
     rotation = Math.atan2(t.m10 * sx, t.m00 * sx) * (180 / Math.PI)
 
-    const corners = [
-      { x: 0, y: 0 },
-      { x: width, y: 0 },
-      { x: 0, y: height },
-      { x: width, y: height }
-    ].map((point) => ({
-      x: t.m00 * point.x + t.m01 * point.y + t.m02,
-      y: t.m10 * point.x + t.m11 * point.y + t.m12
-    }))
-    x = Math.min(...corners.map((point) => point.x))
-    y = Math.min(...corners.map((point) => point.y))
+    if (rotation !== 0) {
+      const rad = (rotation * Math.PI) / 180
+      const cosR = Math.cos(rad)
+      const sinR = Math.sin(rad)
+      x = t.m02 - (width / 2) * (1 - cosR) - sinR * (height / 2)
+      y = t.m12 - (height / 2) * (1 - cosR) + sinR * (width / 2)
+    }
   }
 
   return { x, y, width, height, rotation, flipX, flipY: false }


### PR DESCRIPTION
## Summary

- Fixes .fig import boolean operation `XOR` → `EXCLUDE` mapping (kiwi enum value 3 was treated as UNION)
- Computes correct `(x,y)` for rotated nodes so `translate+rotate` matches the Figma transform matrix
- Prefers Figma's pre-computed `fillGeometry` over recomputing from children via `Path.op()`, which fails on self-intersecting paths (e.g. star polygons in rating stars)
- Checks `Path.op()` return value and cleans up on failure
- Detects VECTOR nodes with `cornerRadius` + simple 4-vertex straight-segment network and renders as rounded rects

## Test Plan

- [x] Import demo.fig with mixed boolean operations (UNION, SUBTRACT, EXCLUDE/XOR)
- [x] Verify WeChat/Alipay payment icons render with correct cutout shapes (not solid rectangles)
- [x] Verify rotated elements (e.g. divider lines) position correctly and are visible
- [x] Verify star-shaped SUBTRACT boolean ops (rating stars) render with proper cutouts
- [x] Run `bun run lint` — 0 warnings, 0 errors
- [ ] Run `bun test` Playwright E2E visual regression (requires test environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)