### PR TITLE
feat(demo): save demo into local storage in development

### DIFF
--- a/packages/core/src/kiwi/index.ts
+++ b/packages/core/src/kiwi/index.ts
@@ -49,3 +49,7 @@ export {
   parseVarint,
   FIG_WIRE_MAGIC
 } from './fig/codec/protocol'
+
+export { deserializeSceneGraph, serializeSceneGraph } from './fig/parse/transfer'
+
+export type { SerializedSceneGraph } from './fig/parse/transfer'

--- a/src/views/EditorView.vue
+++ b/src/views/EditorView.vue
@@ -28,21 +28,60 @@ import SafariBanner from '@/components/SafariBanner.vue'
 import TabBar from '@/components/TabBar.vue'
 import Tip from '@/components/ui/Tip.vue'
 import Toolbar from '@/components/Toolbar/Toolbar.vue'
-
+import { readCacheText, writeCacheText } from '@/app/cache'
+import type { SerializedSceneGraph } from '@open-pencil/core/kiwi'
+import { deserializeSceneGraph, serializeSceneGraph } from '@open-pencil/core/kiwi'
 const route = useRoute()
 const params = useUrlSearchParams('history')
 const showChrome = !('no-chrome' in params)
 
+const localStorageKey = `demo-test-store-data`
 const createdInitialTab = tabCount() === 0
 const firstTab = createdInitialTab ? createTab() : (activeTab.value ?? createTab())
 const store = useEditorStore()
 const { dialogs } = useI18n()
 const { isMobile } = useViewportKind()
 
-if (createdInitialTab && route.meta.demo && !('test' in params)) {
+if (route.meta.demo && !('test' in params)) {
   createDemoShapes(firstTab.store)
 }
+if (route.meta.demo && 'test' in params && process.env.NODE_ENV === 'development') {
+  readCacheText(localStorageKey).then((text) => {
+    const json = JSON.parse(text ?? '{}') as SerializedSceneGraph
+    if (json) {
+      const g = deserializeSceneGraph(json)
+      firstTab.store.replaceGraph(g)
+      const pages = g.getPages(true)
+      if (pages?.length) {
+        firstTab.store.switchPage(pages[0]?.id)
+      }
 
+      store.requestRepaint()
+    }
+  })
+}
+
+useEventListener(window, 'keydown', (e: KeyboardEvent) => {
+  if (route.meta.demo && 'test' in params && process.env.NODE_ENV === 'development') {
+    const isSave = e.shiftKey && e.ctrlKey && e.code === 'KeyS'
+    const isPrint = e.shiftKey && e.ctrlKey && e.code === 'KeyP'
+    if (isSave) {
+      const json = serializeSceneGraph(store.graph)
+      writeCacheText(localStorageKey, JSON.stringify(json)).catch((e) =>
+        console.error('[Cache]', e)
+      )
+      return false
+    } else if (isPrint) {
+      const nodes = store.getSelectedNodes()
+      if (nodes?.length) {
+        console.debug('selected nodes json:', ...nodes)
+      } else {
+        console.debug('graph json:', serializeSceneGraph(store.graph))
+      }
+      return false
+    }
+  }
+})
 useHead({ title: route.meta.demo ? 'Demo' : undefined })
 useKeyboard()
 useMenu()


### PR DESCRIPTION
Feat #

- Restore SceneGraph from local cache on demo page startup
- Add Ctrl+Shift+S to persist current graph into cache
- Add Ctrl+Shift+P to print selected nodes or the whole graph
- Enabled only for demo routes with `test` param in development mode

---

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [x] Tests added or updated
- [ ] CHANGELOG.md updated (if user-facing)
