### PR TITLE
fix(vue): fix node renaming when the input position changes

### DIFF
--- a/packages/vue/src/editor/inline-rename/use.ts
+++ b/packages/vue/src/editor/inline-rename/use.ts
@@ -5,6 +5,7 @@ import { blurTarget } from '#vue/shared/dom-events'
 
 export interface InlineRenameState<T extends string> {
   editingId: Ref<T | null>
+  editingValue: Ref<string | null>
   start: (id: T, currentName: string) => void
   focusInput: (input: HTMLInputElement | null) => Promise<void>
   commit: (id: T, eventOrInput: Event | HTMLInputElement) => void
@@ -16,11 +17,14 @@ export function useInlineRename<T extends string>(
   onCommit: (id: T, newName: string) => void
 ): InlineRenameState<T> {
   const editingId: Ref<T | null> = ref(null)
+  const editingValue: Ref<string | null> = ref(null)
   const inputRef: Ref<HTMLInputElement | null> = ref(null)
   let originalName = ''
+
   let cleanupOutsideClick: (() => void) | undefined
 
   function start(id: T, currentName: string) {
+    editingValue.value = currentName
     editingId.value = id
     originalName = currentName
   }
@@ -50,6 +54,7 @@ export function useInlineRename<T extends string>(
     if (value && value !== originalName) {
       onCommit(id, value)
     }
+    editingValue.value = null
     editingId.value = null
     inputRef.value = null
     cleanupOutsideClick?.()
@@ -57,8 +62,10 @@ export function useInlineRename<T extends string>(
   }
 
   function cancel() {
+    editingValue.value = null
     editingId.value = null
     inputRef.value = null
+
     cleanupOutsideClick?.()
     cleanupOutsideClick = undefined
   }
@@ -74,5 +81,13 @@ export function useInlineRename<T extends string>(
     }
   }
 
-  return { editingId, start, focusInput, commit, cancel, onKeydown }
+  return {
+    editingValue,
+    editingId,
+    start,
+    focusInput,
+    commit,
+    cancel,
+    onKeydown
+  }
 }

--- a/src/components/LayerTree.vue
+++ b/src/components/LayerTree.vue
@@ -88,11 +88,10 @@ function onTreeSelect(e: CustomEvent, select: (additive: boolean) => void) {
                     <input
                       ref="renameInput"
                       data-layer-edit
+                      v-model="rename.editingValue.value"
                       data-test-id="layers-item-input"
                       class="min-w-0 flex-1 rounded border border-accent bg-input px-1 py-0 text-xs text-surface outline-none"
-                      :value="node.name"
                       @blur="rename.commit(node.id, $event)"
-                      @keydown.stop="rename.onKeydown"
                     />
                   </div>
 


### PR DESCRIPTION
Fixes #

> fix input value reset when cursor position changes

---

**Checklist:**
- [x] `bun run check` passes (lint + typecheck)
- [x] Tests added or updated
- [ ] CHANGELOG.md updated (if user-facing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved inline rename workflow: the rename input now reflects live editing state, and commit/cancel reliably clear the editor state and handlers for more consistent behavior.
  * Minor input behavior adjusted to rely on blur for commits, simplifying key interactions during rename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->