### PR TITLE
fix(ai): apply stock photos only to image-capable nodes

### DIFF
--- a/packages/core/src/tools/modify/paint.ts
+++ b/packages/core/src/tools/modify/paint.ts
@@ -3,6 +3,16 @@ import { BLACK } from '#core/constants'
 import { defineTool } from '#core/tools/schema'
 import type { Matrix } from '#core/types'
 
+function canUseImageFill(type: string): boolean {
+  return (
+    type === 'RECTANGLE' ||
+    type === 'ELLIPSE' ||
+    type === 'FRAME' ||
+    type === 'COMPONENT' ||
+    type === 'INSTANCE'
+  )
+}
+
 export const setFill = defineTool({
   name: 'set_fill',
   mutates: true,
@@ -111,6 +121,9 @@ export const setImageFill = defineTool({
   execute: (figma, { id, image_data, scale_mode }) => {
     const node = figma.getNodeById(id)
     if (!node) return { error: `Node "${id}" not found` }
+    if (!canUseImageFill(node.type)) {
+      return { error: `Node "${id}" is ${node.type}; use a shape for image fills` }
+    }
     const bytes = Uint8Array.fromBase64(image_data)
     const image = figma.createImage(bytes)
     const mode = (scale_mode ?? 'FILL') as 'FILL' | 'FIT' | 'CROP' | 'TILE'

--- a/packages/core/src/tools/stock-photo/apply.ts
+++ b/packages/core/src/tools/stock-photo/apply.ts
@@ -13,6 +13,18 @@ interface NodeWithChildren {
   children: unknown[]
 }
 
+interface CoverLikeNode {
+  id: string
+  name: string
+  x: number
+  y: number
+  width: number
+  height: number
+  parent?: unknown
+}
+
+const CONTAINER_FILL_NAMES = /\b(background|bg|cover|hero|banner|header|photo\s*holder)\b/iu
+
 export interface PhotoResult {
   id: string
   photo?: {
@@ -25,6 +37,48 @@ export interface PhotoResult {
   error?: string
 }
 
+function bytesFromDataUrl(url: string): Uint8Array | null {
+  const match = url.match(/^data:([^,]*),(.+)$/u)
+  if (!match) return null
+  const isBase64 = match[1]?.includes(';base64')
+  const payload = match[2] ?? ''
+  if (!isBase64) return new TextEncoder().encode(decodeURIComponent(payload))
+  const binary = atob(payload)
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0))
+}
+
+function isImageFillTarget(type: string): boolean {
+  return (
+    type === 'RECTANGLE' ||
+    type === 'ELLIPSE' ||
+    type === 'FRAME' ||
+    type === 'COMPONENT' ||
+    type === 'INSTANCE'
+  )
+}
+
+function fitCoverLikeNodeToParent(figma: FigmaAPI, node: CoverLikeNode) {
+  if (!CONTAINER_FILL_NAMES.test(node.name)) return
+  const parent = node.parent
+  if (
+    !parent ||
+    typeof parent !== 'object' ||
+    !('width' in parent) ||
+    !('height' in parent) ||
+    typeof parent.width !== 'number' ||
+    typeof parent.height !== 'number'
+  ) {
+    return
+  }
+
+  if (node.width >= parent.width && node.height >= parent.height) return
+  const liveNode = figma.getNodeById(node.id)
+  if (!liveNode) return
+  liveNode.x = 0
+  liveNode.y = 0
+  liveNode.resize(parent.width, parent.height)
+}
+
 export async function applyPhoto(
   figma: FigmaAPI,
   provider: StockPhotoProvider,
@@ -32,6 +86,9 @@ export async function applyPhoto(
 ): Promise<PhotoResult> {
   const node = figma.getNodeById(req.id)
   if (!node) return { id: req.id, error: 'Not found' }
+  if (!isImageFillTarget(node.type)) {
+    return { id: req.id, error: `"${node.name}" is ${node.type}; use a shape for image fills` }
+  }
 
   const children = 'children' in node ? (node as NodeWithChildren).children : []
   if (children.length > 0) {
@@ -54,14 +111,20 @@ export async function applyPhoto(
 
   let imageBytes: Uint8Array
   try {
-    const response = await fetch(photo.url)
-    if (!response.ok) return { id: req.id, error: `Download ${response.status}` }
-    imageBytes = new Uint8Array(await response.arrayBuffer())
+    const dataUrlBytes = bytesFromDataUrl(photo.url)
+    if (dataUrlBytes) {
+      imageBytes = dataUrlBytes
+    } else {
+      const response = await fetch(photo.url)
+      if (!response.ok) return { id: req.id, error: `Download ${response.status}` }
+      imageBytes = new Uint8Array(await response.arrayBuffer())
+    }
   } catch (err) {
     return { id: req.id, error: `Download: ${err instanceof Error ? err.message : String(err)}` }
   }
 
   const image = figma.createImage(imageBytes)
+  fitCoverLikeNodeToParent(figma, node)
   node.fills = [
     {
       type: 'IMAGE',


### PR DESCRIPTION
- Reject image fills on text and unsupported node types

- Support data URL photo payloads from image providers

- Expand cover-like placeholders to their parent bounds before applying image fills

Fixes #

> Security vulnerability? Please do not open a public PR. Report it privately through GitHub Security Advisories: https://github.com/open-pencil/open-pencil/security/advisories/new

---

**Checklist:**
- [ ] `bun run check` passes (lint + typecheck)
- [ ] Tests added or updated
- [ ] CHANGELOG.md updated (if user-facing)
