### PR TITLE
fix(canvas): lazy load CJK fallback fonts

### DIFF
--- a/packages/core/src/canvas/index.ts
+++ b/packages/core/src/canvas/index.ts
@@ -6,3 +6,4 @@ export {
 } from './boolean'
 export { SkiaRenderer, type RenderOverlays, type RulerTheme } from './renderer'
 export { getAbsolutePositionFull, getAbsoluteRotation, getWorldHandles } from './coordinate'
+export { ensureMissingFallbackFonts } from './text'

--- a/packages/core/src/canvas/renderer.ts
+++ b/packages/core/src/canvas/renderer.ts
@@ -77,6 +77,8 @@ export class SkiaRenderer {
   fontMgr: FontMgr | null = null
   fontProvider: TypefaceFontProvider | null = null
   fontsLoaded = false
+  onFallbackFontsLoaded: (() => void) | null = null
+  pendingFallbackScripts = new Set<'cjk' | 'arabic'>()
   imageCache = new Map<string, CKImage>()
   vectorPathCache = new Map<string, Path[]>()
   vectorStrokePathCache = new Map<string, Path[]>()

--- a/packages/core/src/canvas/renderer/fonts.ts
+++ b/packages/core/src/canvas/renderer/fonts.ts
@@ -19,6 +19,8 @@ export async function loadFonts(
   onFallbackFontsLoaded?: () => void
 ): Promise<void> {
   if (r.isDestroyed()) return
+  r.onFallbackFontsLoaded = onFallbackFontsLoaded ?? null
+  r.pendingFallbackScripts.clear()
   r.fontProvider?.delete()
   r.fontProvider = r.ck.TypefaceFontProvider.Make()
 
@@ -47,19 +49,6 @@ export async function loadFonts(
 
   r.fontsLoaded = true
   r.invalidateAllPictures()
-
-  void fontManager.ensureCJKFallback().then((families) => {
-    if (!r.isDestroyed() && families.length > 0) {
-      r.invalidateAllPictures()
-      onFallbackFontsLoaded?.()
-    }
-  })
-  void fontManager.ensureArabicFallback().then((families) => {
-    if (!r.isDestroyed() && families.length > 0) {
-      r.invalidateAllPictures()
-      onFallbackFontsLoaded?.()
-    }
-  })
 }
 
 export async function prepareForExport(

--- a/packages/core/src/canvas/scene.ts
+++ b/packages/core/src/canvas/scene.ts
@@ -19,6 +19,7 @@ import {
   getStrokeCapEntity,
   getStrokeJoinEntity
 } from './strokes'
+import { ensureMissingFallbackFonts } from './text'
 import { drawFigmaDerivedText } from './text-derived'
 import { textNodeToOutlinePath } from './text-outlines'
 
@@ -662,6 +663,7 @@ export function renderText(r: SkiaRenderer, canvas: Canvas, node: SceneNode, fil
   }
 
   if (!r.isNodeFontLoaded(node)) {
+    ensureMissingFallbackFonts(r, node)
     canvas.restore()
     return
   }

--- a/packages/core/src/canvas/text.ts
+++ b/packages/core/src/canvas/text.ts
@@ -20,6 +20,10 @@ interface TextRenderer {
   ck: CanvasKit
   fontProvider: TypefaceFontProvider | null
   fontsLoaded: boolean
+  isDestroyed?(): boolean
+  invalidateAllPictures?(): void
+  onFallbackFontsLoaded?: (() => void) | null
+  pendingFallbackScripts?: Set<'cjk' | 'arabic'>
 }
 
 export interface ClipboardShapedGlyph {
@@ -49,6 +53,32 @@ function hasRequiredFallbackFonts(text: string): boolean {
   if (CJK_RE.test(text) && fontManager.getCJKFallbackFamilies().length === 0) return false
   if (ARABIC_RE.test(text) && fontManager.getArabicFallbackFamilies().length === 0) return false
   return true
+}
+
+export function ensureMissingFallbackFonts(r: TextRenderer, node: SceneNode): void {
+  const needsCJK = CJK_RE.test(node.text) && fontManager.getCJKFallbackFamilies().length === 0
+  const needsArabic =
+    ARABIC_RE.test(node.text) && fontManager.getArabicFallbackFamilies().length === 0
+
+  if (needsCJK) void ensureFallbackScript(r, 'cjk')
+  if (needsArabic) void ensureFallbackScript(r, 'arabic')
+}
+
+async function ensureFallbackScript(r: TextRenderer, script: 'cjk' | 'arabic'): Promise<void> {
+  if (r.pendingFallbackScripts?.has(script)) return
+  r.pendingFallbackScripts?.add(script)
+  try {
+    const families =
+      script === 'cjk'
+        ? await fontManager.ensureCJKFallback()
+        : await fontManager.ensureArabicFallback()
+    if (families.length > 0 && !r.isDestroyed?.()) {
+      r.invalidateAllPictures?.()
+      r.onFallbackFontsLoaded?.()
+    }
+  } finally {
+    r.pendingFallbackScripts?.delete(script)
+  }
 }
 
 export function isNodeFontLoaded(_r: TextRenderer, node: SceneNode): boolean {

--- a/packages/vue/src/canvas/text-edit/editing.ts
+++ b/packages/vue/src/canvas/text-edit/editing.ts
@@ -1,6 +1,7 @@
 import { useIntervalFn } from '@vueuse/core'
 import type { ShallowRef } from 'vue'
 
+import { ensureMissingFallbackFonts } from '@open-pencil/core/canvas'
 import type { Editor } from '@open-pencil/core/editor'
 import type { SceneNode } from '@open-pencil/core/scene-graph'
 import { adjustRunsForDelete, adjustRunsForInsert } from '@open-pencil/core/text'
@@ -94,6 +95,11 @@ export function createTextEditActions(store: Editor) {
     const changes: Partial<SceneNode> = { text }
     if (runs !== undefined) changes.styleRuns = runs
     store.graph.updateNode(nodeId, changes)
+    const node = store.graph.getNode(nodeId)
+    const rendererLike = 'renderer' in store ? store.renderer : null
+    if (node?.type === 'TEXT' && rendererLike) {
+      ensureMissingFallbackFonts(rendererLike, node)
+    }
     store.requestRender()
   }
 

--- a/src/app/editor/fonts/index.ts
+++ b/src/app/editor/fonts/index.ts
@@ -39,6 +39,9 @@ interface TauriFontFamily {
 let tauriFontsCache: TauriFontFamily[] | null = null
 let tauriFontsPromise: Promise<TauriFontFamily[]> | null = null
 
+const CJK_TEXT_RE = /[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff\uac00-\ud7af]/u
+const ARABIC_TEXT_RE = /[\u0600-\u06ff\u0750-\u077f\u08a0-\u08ff\ufb50-\ufdff\ufe70-\ufeff]/u
+
 async function getTauriFonts(): Promise<TauriFontFamily[]> {
   if (tauriFontsCache) return tauriFontsCache
   if (!tauriFontsPromise) {
@@ -117,12 +120,45 @@ export async function listFonts(): Promise<TauriFontFamily[]> {
 export async function ensureGraphFonts(graph: SceneGraph, nodeIds: string[]): Promise<boolean> {
   const fontKeys = fontManager.collectFontKeys(graph, nodeIds)
   const missing = fontKeys.filter(([family, style]) => !fontManager.isStyleLoaded(family, style))
-  if (missing.length === 0) return false
+  const needsFallback = graphFallbackNeeds(graph, nodeIds)
+  if (missing.length === 0 && !needsFallback.cjk && !needsFallback.arabic) return false
 
   const results = await Promise.all(missing.map(([family, style]) => loadFont(family, style)))
-  const loaded = results.some((result) => result !== null)
+  const [cjkFallbacks, arabicFallbacks] = await Promise.all([
+    needsFallback.cjk ? fontManager.ensureCJKFallback() : Promise.resolve([]),
+    needsFallback.arabic ? fontManager.ensureArabicFallback() : Promise.resolve([])
+  ])
+  const loaded =
+    results.some((result) => result !== null) ||
+    cjkFallbacks.length > 0 ||
+    arabicFallbacks.length > 0
   if (loaded) clearTextPictures(graph)
   return loaded
+}
+
+function graphFallbackNeeds(
+  graph: SceneGraph,
+  nodeIds: string[]
+): { cjk: boolean; arabic: boolean } {
+  let cjk = false
+  let arabic = false
+
+  const visit = (id: string) => {
+    if (cjk && arabic) return
+    const node = graph.getNode(id)
+    if (!node) return
+    if (node.type === 'TEXT') {
+      if (!cjk && CJK_TEXT_RE.test(node.text)) cjk = true
+      if (!arabic && ARABIC_TEXT_RE.test(node.text)) arabic = true
+    }
+    for (const childId of node.childIds) visit(childId)
+  }
+
+  for (const id of nodeIds) visit(id)
+  return {
+    cjk: cjk && fontManager.getCJKFallbackFamilies().length === 0,
+    arabic: arabic && fontManager.getArabicFallbackFamilies().length === 0
+  }
 }
 
 function clearTextPictures(graph: SceneGraph): void {

--- a/src/app/editor/fonts/index.ts
+++ b/src/app/editor/fonts/index.ts
@@ -140,24 +140,23 @@ function graphFallbackNeeds(
   graph: SceneGraph,
   nodeIds: string[]
 ): { cjk: boolean; arabic: boolean } {
-  let cjk = false
-  let arabic = false
+  const texts: string[] = []
 
   const visit = (id: string) => {
-    if (cjk && arabic) return
     const node = graph.getNode(id)
     if (!node) return
     if (node.type === 'TEXT') {
-      cjk ||= CJK_TEXT_RE.test(node.text)
-      arabic ||= ARABIC_TEXT_RE.test(node.text)
+      texts.push(node.text)
     }
     for (const childId of node.childIds) visit(childId)
   }
 
   for (const id of nodeIds) visit(id)
+  const hasCJK = texts.some((text) => CJK_TEXT_RE.test(text))
+  const hasArabic = texts.some((text) => ARABIC_TEXT_RE.test(text))
   return {
-    cjk: cjk && fontManager.getCJKFallbackFamilies().length === 0,
-    arabic: arabic && fontManager.getArabicFallbackFamilies().length === 0
+    cjk: hasCJK && fontManager.getCJKFallbackFamilies().length === 0,
+    arabic: hasArabic && fontManager.getArabicFallbackFamilies().length === 0
   }
 }
 

--- a/src/app/editor/fonts/index.ts
+++ b/src/app/editor/fonts/index.ts
@@ -148,8 +148,8 @@ function graphFallbackNeeds(
     const node = graph.getNode(id)
     if (!node) return
     if (node.type === 'TEXT') {
-      if (!cjk && CJK_TEXT_RE.test(node.text)) cjk = true
-      if (!arabic && ARABIC_TEXT_RE.test(node.text)) arabic = true
+      cjk ||= CJK_TEXT_RE.test(node.text)
+      arabic ||= ARABIC_TEXT_RE.test(node.text)
     }
     for (const childId of node.childIds) visit(childId)
   }

--- a/tests/e2e/fonts/cjk-fallback.spec.ts
+++ b/tests/e2e/fonts/cjk-fallback.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 import { CanvasHelper } from '#tests/helpers/canvas'
 
-test('CJK text waits for fallback fonts and repaints after they load', async ({ page }) => {
+test('CJK fallback fonts load only after CJK text is added', async ({ page }) => {
   const canvas = new CanvasHelper(page)
   await page.goto('http://localhost:1420/?test&no-chrome&no-rulers')
   await canvas.waitForInit()
@@ -13,7 +13,10 @@ test('CJK text waits for fallback fonts and repaints after they load', async ({ 
     const renderer = store.renderer
     if (!renderer) throw new Error('OpenPencil renderer not initialized')
 
-    const { fontManager } = await import('/packages/core/src/text/fonts.ts')
+    const [{ fontManager }, { ensureGraphFonts }] = await Promise.all([
+      import('/packages/core/src/text/fonts.ts'),
+      import('/src/app/editor/fonts/index.ts')
+    ])
     const manager = fontManager as typeof fontManager & {
       cjkFallbackFamilies: string[]
       cjkFallbackPromise: Promise<string[]> | null
@@ -27,76 +30,59 @@ test('CJK text waits for fallback fonts and repaints after they load', async ({ 
     const originalEnsureCJKFallback = fontManager.ensureCJKFallback.bind(fontManager)
     const originalEnsureArabicFallback = fontManager.ensureArabicFallback.bind(fontManager)
 
-    let releaseCJKFallback: (() => void) | null = null
-    const fallbackGate = new Promise<void>((resolve) => {
-      releaseCJKFallback = resolve
-    })
-
     manager.cjkFallbackFamilies = []
     manager.cjkFallbackPromise = null
     manager.arabicFallbackFamilies = []
     manager.arabicFallbackPromise = null
 
-    let fallbackRenderCount = 0
-    let renderCount = 0
-    const originalRender = renderer.renderFromEditorState.bind(renderer)
-
+    let ensureCJKFallbackCalls = 0
     fontManager.ensureCJKFallback = async () => {
-      await fallbackGate
+      ensureCJKFallbackCalls += 1
       fontManager.setCJKFallbackFamily('Regression CJK Fallback')
       return ['Regression CJK Fallback']
     }
     fontManager.ensureArabicFallback = async () => []
-    renderer.renderFromEditorState = (
-      ...args: Parameters<typeof renderer.renderFromEditorState>
-    ) => {
-      renderCount += 1
-      return originalRender(...args)
-    }
 
     const pageNode = store.graph.getNode(store.state.currentPageId)
     if (!pageNode) throw new Error(`Page ${store.state.currentPageId} not found`)
-    const text = store.graph.createNode('TEXT', pageNode.id, {
-      name: 'CJK Regression',
-      x: 80,
-      y: 80,
-      width: 300,
-      height: 60,
-      text: '上班打卡App',
-      fontSize: 32,
-      fontFamily: 'Inter',
-      fills: [{ type: 'SOLID', color: { r: 0, g: 0, b: 0, a: 1 }, visible: true, opacity: 1 }]
-    })
 
     try {
-      await renderer.loadFonts(() => {
-        fallbackRenderCount += 1
-        renderer.renderFromEditorState(
-          store.state,
-          store.graph,
-          store.textEditor,
-          800,
-          600,
-          false,
-          'full'
-        )
-      })
+      await renderer.loadFonts()
+      const fallbackCountAfterStartup = ensureCJKFallbackCalls
 
-      const loadedBeforeFallback = renderer.isNodeFontLoaded(text)
-      const beforeFallbackRenderCount = fallbackRenderCount
-
-      releaseCJKFallback?.()
-      await new Promise((resolve) => {
-        setTimeout(resolve, 0)
+      const latinText = store.graph.createNode('TEXT', pageNode.id, {
+        name: 'Latin Regression',
+        x: 80,
+        y: 80,
+        width: 300,
+        height: 60,
+        text: 'OpenPencil text',
+        fontSize: 32,
+        fontFamily: 'Inter',
+        fills: [{ type: 'SOLID', color: { r: 0, g: 0, b: 0, a: 1 }, visible: true, opacity: 1 }]
       })
-      await new Promise(requestAnimationFrame)
+      await ensureGraphFonts(store.graph, [latinText.id])
+      const fallbackCountAfterLatin = ensureCJKFallbackCalls
+
+      const cjkText = store.graph.createNode('TEXT', pageNode.id, {
+        name: 'CJK Regression',
+        x: 80,
+        y: 150,
+        width: 420,
+        height: 70,
+        text: '中文字体回退测试',
+        fontSize: 32,
+        fontFamily: 'Inter',
+        fills: [{ type: 'SOLID', color: { r: 0, g: 0, b: 0, a: 1 }, visible: true, opacity: 1 }]
+      })
+      const loaded = await ensureGraphFonts(store.graph, [cjkText.id])
 
       return {
-        loadedBeforeFallback,
-        loadedAfterFallback: renderer.isNodeFontLoaded(text),
-        beforeFallbackRenderCount,
-        fallbackRenderCount,
-        renderCount
+        loaded,
+        fallbackCountAfterStartup,
+        fallbackCountAfterLatin,
+        fallbackCountAfterCJK: ensureCJKFallbackCalls,
+        loadedAfterFallback: renderer.isNodeFontLoaded(cjkText)
       }
     } finally {
       manager.cjkFallbackFamilies = originalCJKFamilies
@@ -105,14 +91,13 @@ test('CJK text waits for fallback fonts and repaints after they load', async ({ 
       manager.arabicFallbackPromise = originalArabicPromise
       fontManager.ensureCJKFallback = originalEnsureCJKFallback
       fontManager.ensureArabicFallback = originalEnsureArabicFallback
-      renderer.renderFromEditorState = originalRender
     }
   })
 
-  expect(result.loadedBeforeFallback).toBe(false)
+  expect(result.fallbackCountAfterStartup).toBe(0)
+  expect(result.fallbackCountAfterLatin).toBe(0)
+  expect(result.fallbackCountAfterCJK).toBe(1)
+  expect(result.loaded).toBe(true)
   expect(result.loadedAfterFallback).toBe(true)
-  expect(result.beforeFallbackRenderCount).toBe(0)
-  expect(result.fallbackRenderCount).toBe(1)
-  expect(result.renderCount).toBeGreaterThan(0)
   canvas.assertNoErrors()
 })


### PR DESCRIPTION
Fixes #

> Security vulnerability? Please do not open a public PR. Report it privately through GitHub Security Advisories: https://github.com/open-pencil/open-pencil/security/advisories/new

---

**Checklist:**
- [ ] `bun run check` passes (lint + typecheck)
- [ ] Tests added or updated
- [ ] CHANGELOG.md updated (if user-facing)

Thanks for the review. I updated the approach to follow the existing paragraph/font fallback path instead of rendering CJK text through a separate outline-only path.

Changes in the new branch:
- Removed eager CJK/Arabic fallback loading during renderer startup.
- Added lazy fallback requests when text rendering actually encounters missing CJK/Arabic fallback fonts.
- Trigger the same lazy fallback path while editing text, so manually typed Chinese text repaints once the fallback is ready.
- Extended ensureGraphFonts so AI/automation-created CJK text also loads fallback fonts on demand.
- Updated the CJK fallback regression test to assert fallback fonts are not loaded at startup or for Latin text, and are only requested after CJK text is present.

I manually verified that typing Chinese text in the editor now renders correctly.

Note: this reply was drafted with AI assistance and reviewed before posting.