### PR TITLE
fix(fonts): add Traditional Chinese (TC) to CJK font fallback chain

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -341,6 +341,7 @@ export const AUTOMATION_WS_PORT = 7601
 export const GOOGLE_FONTS_API_KEY = 'AIzaSyD1tYDR_dUEiV-Tw1vksEhZbUytgKW5pc8'
 
 export const CJK_FALLBACK_FAMILIES_MACOS = [
+  'PingFang TC',
   'PingFang SC',
   'Hiragino Sans',
   'Apple SD Gothic Neo',
@@ -348,9 +349,10 @@ export const CJK_FALLBACK_FAMILIES_MACOS = [
 ]
 
 export const CJK_FALLBACK_FAMILIES_WINDOWS = [
+  'Microsoft JhengHei',
+  'Microsoft JhengHei UI',
   'Microsoft YaHei',
   'Microsoft YaHei UI',
-  'Microsoft JhengHei',
   'Yu Gothic',
   'Malgun Gothic',
   'SimHei',
@@ -358,6 +360,7 @@ export const CJK_FALLBACK_FAMILIES_WINDOWS = [
 ]
 
 export const CJK_FALLBACK_FAMILIES_LINUX = [
+  'Noto Sans CJK TC',
   'Noto Sans CJK SC',
   'Noto Sans CJK JP',
   'Noto Sans CJK KR',
@@ -365,7 +368,7 @@ export const CJK_FALLBACK_FAMILIES_LINUX = [
   'Droid Sans Fallback'
 ]
 
-export const CJK_GOOGLE_FONTS = ['Noto Sans SC', 'Noto Sans JP', 'Noto Sans KR']
+export const CJK_GOOGLE_FONTS = ['Noto Sans TC', 'Noto Sans SC', 'Noto Sans JP', 'Noto Sans KR']
 
 export const DEFAULT_SHAPE_FILL: Fill = {
   type: 'SOLID',


### PR DESCRIPTION
## Problem

Traditional Chinese characters (繁體中文) display as tofu boxes (□□□) in the live canvas because `Noto Sans TC` was missing from the Google Fonts fallback list. This affects users on Windows (Tauri desktop) where `queryLocalFonts()` is unavailable, leaving no CJK fallback font loaded into CanvasKit.

Simplified Chinese, Japanese and Korean already had Google Fonts fallbacks — Traditional Chinese was the only CJK script left out.

## Changes

**`packages/core/src/constants.ts`**

| List | Before | After |
|------|--------|-------|
| `CJK_GOOGLE_FONTS` | `['Noto Sans SC', 'Noto Sans JP', 'Noto Sans KR']` | `['Noto Sans TC', 'Noto Sans SC', 'Noto Sans JP', 'Noto Sans KR']` |
| `CJK_FALLBACK_FAMILIES_MACOS` | `PingFang SC` first | `PingFang TC` first (TC-first systems get TC font) |
| `CJK_FALLBACK_FAMILIES_WINDOWS` | `Microsoft YaHei` (SC) first | `Microsoft JhengHei` (TC) first |
| `CJK_FALLBACK_FAMILIES_LINUX` | SC/JP/KR only | `Noto Sans CJK TC` added |

## Why TC should be prioritised

`Microsoft JhengHei` (Traditional Chinese) and `PingFang TC` are the primary CJK fonts on Traditional Chinese Windows and macOS systems respectively. Listing SC fonts first caused TC users to get a Simplified Chinese font as their fallback, which renders TC glyphs with different stroke styles. This reorders the lists so TC fonts are tried first, with SC/JP/KR remaining as further fallbacks.

## Testing

- Open a document with Traditional Chinese text (e.g. 你好，世界)
- Without this fix: characters render as □ in the live canvas
- With this fix: characters render correctly via `Noto Sans TC` (Google Fonts) or local `Microsoft JhengHei` / `PingFang TC`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)