### PR TITLE
docs: fix mermaid syntax in architecture.md

### DIFF
--- a/packages/docs/guide/architecture.md
+++ b/packages/docs/guide/architecture.md
@@ -2,7 +2,7 @@
 
 ## System Overview
 
-`mermaid
+```mermaid
 graph TB
     subgraph Tauri["Tauri v2 Shell"]
         subgraph Editor["Editor (Web)"]
@@ -22,7 +22,7 @@ graph TB
         MCP["MCP Server (90 tools, stdio+HTTP)"]
         Collab["P2P Collab (Trystero + Yjs)"]
     end
-`
+```
 
 ## Editor Layout
 


### PR DESCRIPTION
Fixed formatting for the mermaid diagram in the architecture documentation.

at the moment the diagram is not rendered in GitHub or https://openpencil.dev/guide/architecture

---

**Checklist:**
- [ ] `bun run check` passes (lint + typecheck)
- [ ] Tests added or updated
- [ ] CHANGELOG.md updated (if user-facing)