### PR TITLE
fix: make fill hex editable and suppress premature local font warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ vue-stream-markdown/
 
 # Agent scratch space (reviews, test artifacts)
 scratch/
+
+# OpenCode
+.opencode/

--- a/packages/core/src/text/fonts.ts
+++ b/packages/core/src/text/fonts.ts
@@ -528,6 +528,7 @@ export class FontManager {
     options: FindLocalFontOptions = {}
   ): Promise<ArrayBuffer | null> {
     if (!IS_BROWSER || !window.queryLocalFonts) return null
+    if (this.localFontAccessState !== 'granted') return null
     try {
       const fonts = await window.queryLocalFonts()
       const match = chooseLocalFontMatch(fonts, family, style)

--- a/src/components/properties/FillSection.vue
+++ b/src/components/properties/FillSection.vue
@@ -95,7 +95,9 @@ function updateFillHex(
         />
 
         <input
-          v-if="fill.type === 'SOLID' && !(activeNode && fillCtx.getBoundVariable(activeNode.id, i))"
+          v-if="
+            fill.type === 'SOLID' && !(activeNode && fillCtx.getBoundVariable(activeNode.id, i))
+          "
           data-test-id="fill-hex-input"
           class="min-w-0 flex-1 border-none bg-transparent font-mono text-xs text-surface outline-none"
           :value="colorToHexRaw(fill.color)"

--- a/src/components/properties/FillSection.vue
+++ b/src/components/properties/FillSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { PropertyListRoot, useFillControls, useOkHCL, useI18n } from '@open-pencil/vue'
+import { PropertyListRoot, useFillControls, useOkHCL, useI18n, inputValue } from '@open-pencil/vue'
+import { colorToHexRaw, parseColor } from '@open-pencil/core/color'
 
 import FillPicker from '@/components/FillPicker.vue'
 import Tip from '@/components/ui/Tip.vue'
@@ -30,6 +31,19 @@ function updateFill(
     fillCtx.unbindVariable(activeNode.id, index)
   }
   update(index, fill)
+}
+
+function updateFillHex(
+  activeNode: SceneNode | null | undefined,
+  index: number,
+  fill: Fill,
+  hex: string,
+  update: (index: number, fill: Fill) => void
+) {
+  if (fill.type !== 'SOLID') return
+  const parsed = parseColor(hex.startsWith('#') ? hex : `#${hex}`)
+  if (!parsed) return
+  updateFill(activeNode, index, { ...fill, color: { ...parsed, a: fill.color.a } }, update)
 }
 </script>
 
@@ -80,7 +94,16 @@ function updateFill(
           @update="updateFill(activeNode, i, $event, actions.update)"
         />
 
+        <input
+          v-if="fill.type === 'SOLID' && !(activeNode && fillCtx.getBoundVariable(activeNode.id, i))"
+          data-test-id="fill-hex-input"
+          class="min-w-0 flex-1 border-none bg-transparent font-mono text-xs text-surface outline-none"
+          :value="colorToHexRaw(fill.color)"
+          maxlength="6"
+          @change="updateFillHex(activeNode, i, fill, inputValue($event), actions.update)"
+        />
         <span
+          v-else
           class="min-w-0 flex-1 truncate font-mono text-xs"
           :class="
             activeNode && fillCtx.getBoundVariable(activeNode.id, i)


### PR DESCRIPTION
## Summary

- **Fill hex input**: The hex value in the Fill section of the properties panel was a read-only `<span>`. It now renders as an editable `<input>` for solid fills (matching the existing behavior in the Stroke section). Gradient, image, and variable-bound fills keep the display span.
- **Local font warnings suppressed**: `FontManager.findLocalFont` was calling `queryLocalFonts()` before the user granted Local Font Access permission, causing `SecurityError` console warnings on every page load. Added a guard on `localFontAccessState === 'granted'` so it returns early until the user explicitly grants access via the font settings UI.
- **`.gitignore`**: Added `.opencode/`.

## Test plan

- [ ] Select a shape with a solid fill — click the hex value in the Fill panel and type a new hex color, confirm it updates
- [ ] Select a shape with a gradient fill — confirm the fill type label is still shown as read-only
- [ ] Select a shape with a variable-bound fill — confirm the variable name is still shown as read-only
- [ ] Open the app fresh — confirm no `SecurityError: User activation is required` warnings in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)