### PR TITLE
fix(resize): scale children when resizing GROUP or BOOLEAN_OPERATION

### DIFF
--- a/packages/core/src/editor/bridges/undo.ts
+++ b/packages/core/src/editor/bridges/undo.ts
@@ -10,6 +10,7 @@ export function createUndoBridge(undoActions: UndoActions, selection: SelectionA
     commitMoveWithReparent: undoActions.commitMoveWithReparent,
     commitDuplicateMove: undoActions.commitDuplicateMove,
     commitResize: undoActions.commitResize,
+    commitGroupResize: undoActions.commitGroupResize,
     commitRotation: undoActions.commitRotation,
     commitNodeUpdate: undoActions.commitNodeUpdate,
     undoAction: () => undoActions.undoAction(selection.validateEnteredContainer),

--- a/packages/core/src/editor/undo.ts
+++ b/packages/core/src/editor/undo.ts
@@ -1,5 +1,6 @@
 import { pick } from 'es-toolkit/object'
 
+import { cloneVectorNetwork } from '#core/scene-graph'
 import type { SceneNode } from '#core/scene-graph'
 import type { UndoEntry } from '#core/scene-graph/undo'
 import type { Rect, Vector } from '#core/types'
@@ -12,6 +13,18 @@ import {
   type PageSnapshot
 } from './history/snapshot'
 import type { EditorContext } from './types'
+
+type ResizeSnapshot = Pick<SceneNode, 'x' | 'y' | 'width' | 'height' | 'vectorNetwork'>
+
+function createResizeSnapshot(node: SceneNode): ResizeSnapshot {
+  return {
+    x: node.x,
+    y: node.y,
+    width: node.width,
+    height: node.height,
+    vectorNetwork: node.vectorNetwork ? cloneVectorNetwork(node.vectorNetwork) : null
+  }
+}
 
 export function createUndoActions(ctx: EditorContext) {
   function commitMove(originals: Map<string, Vector>) {
@@ -94,20 +107,18 @@ export function createUndoActions(ctx: EditorContext) {
     })
   }
 
-  function commitGroupResize(nodeId: string, origRect: Rect, origChildren: Map<string, Rect>) {
+  function commitGroupResize(
+    nodeId: string,
+    origRect: Rect,
+    origChildren: Map<string, ResizeSnapshot>
+  ) {
     const node = ctx.graph.getNode(nodeId)
     if (!node) return
     const finalRect = { x: node.x, y: node.y, width: node.width, height: node.height }
-    const finalChildren = new Map<string, Rect>()
+    const finalChildren = new Map<string, ResizeSnapshot>()
     for (const [childId] of origChildren) {
       const child = ctx.graph.getNode(childId)
-      if (child)
-        finalChildren.set(childId, {
-          x: child.x,
-          y: child.y,
-          width: child.width,
-          height: child.height
-        })
+      if (child) finalChildren.set(childId, createResizeSnapshot(child))
     }
     ctx.undo.push({
       label: 'Resize',

--- a/packages/core/src/editor/undo.ts
+++ b/packages/core/src/editor/undo.ts
@@ -94,6 +94,36 @@ export function createUndoActions(ctx: EditorContext) {
     })
   }
 
+  function commitGroupResize(nodeId: string, origRect: Rect, origChildren: Map<string, Rect>) {
+    const node = ctx.graph.getNode(nodeId)
+    if (!node) return
+    const finalRect = { x: node.x, y: node.y, width: node.width, height: node.height }
+    const finalChildren = new Map<string, Rect>()
+    for (const [childId] of origChildren) {
+      const child = ctx.graph.getNode(childId)
+      if (child)
+        finalChildren.set(childId, {
+          x: child.x,
+          y: child.y,
+          width: child.width,
+          height: child.height
+        })
+    }
+    ctx.undo.push({
+      label: 'Resize',
+      forward: () => {
+        ctx.graph.updateNode(nodeId, finalRect)
+        for (const [childId, final] of finalChildren) ctx.graph.updateNode(childId, final)
+        ctx.runLayoutForNode(nodeId)
+      },
+      inverse: () => {
+        ctx.graph.updateNode(nodeId, origRect)
+        for (const [childId, orig] of origChildren) ctx.graph.updateNode(childId, orig)
+        ctx.runLayoutForNode(nodeId)
+      }
+    })
+  }
+
   function commitRotation(nodeId: string, origRotation: number) {
     const node = ctx.graph.getNode(nodeId)
     if (!node) return
@@ -155,6 +185,7 @@ export function createUndoActions(ctx: EditorContext) {
     commitMoveWithReparent,
     commitDuplicateMove,
     commitResize,
+    commitGroupResize,
     commitRotation,
     commitNodeUpdate,
     undoAction,

--- a/packages/vue/src/shared/input/resize.ts
+++ b/packages/vue/src/shared/input/resize.ts
@@ -22,7 +22,7 @@ function resizeChanges(d: DragResize, cx: number, cy: number, constrain: boolean
     newRect.height
   )
   if (resizedVectorNetwork) changes.vectorNetwork = resizedVectorNetwork
-  return changes
+  return { changes, newRect }
 }
 
 export function applyResize(
@@ -32,7 +32,36 @@ export function applyResize(
   constrain: boolean,
   editor: Editor
 ) {
-  editor.graph.updateNodePreview(d.nodeId, resizeChanges(d, cx, cy, constrain))
+  const { changes, newRect } = resizeChanges(d, cx, cy, constrain)
+  editor.graph.updateNodePreview(d.nodeId, changes)
+
+  if (d.origChildren && d.origRect.width > 0 && d.origRect.height > 0) {
+    const sx = newRect.width / d.origRect.width
+    const sy = newRect.height / d.origRect.height
+    for (const [childId, orig] of d.origChildren) {
+      const childWidth = Math.round(Math.max(1, orig.width * sx))
+      const childHeight = Math.round(Math.max(1, orig.height * sy))
+      const childChanges: Partial<SceneNode> = {
+        x: Math.round(orig.x * sx),
+        y: Math.round(orig.y * sy),
+        width: childWidth,
+        height: childHeight
+      }
+      if (orig.vectorNetwork) {
+        const scaledVN = scaleVectorNetworkForResize(
+          orig.vectorNetwork,
+          orig.width,
+          orig.height,
+          childWidth,
+          childHeight
+        )
+        if (scaledVN) childChanges.vectorNetwork = scaledVN
+      }
+      editor.graph.updateNodePreview(childId, childChanges)
+      editor.renderer?.invalidateVectorPath(childId)
+    }
+  }
+
   const node = editor.graph.getNode(d.nodeId)
   if (node?.layoutMode !== 'NONE') {
     editor.graph.runPreviewUpdates(() => computeLayout(editor.graph, d.nodeId))
@@ -50,7 +79,34 @@ export function commitResizePreview(d: DragResize, editor: Editor) {
     height: node.height
   }
   if (node.vectorNetwork) finalChanges.vectorNetwork = node.vectorNetwork
-  editor.graph.updateNodePreview(d.nodeId, d.origRect)
-  editor.updateNode(d.nodeId, finalChanges)
-  editor.commitResize(d.nodeId, d.origRect)
+
+  if (d.origChildren) {
+    const finalChildren = new Map<string, Partial<SceneNode>>()
+    for (const [childId] of d.origChildren) {
+      const child = editor.graph.getNode(childId)
+      if (!child) continue
+      const final: Partial<SceneNode> = {
+        x: child.x,
+        y: child.y,
+        width: child.width,
+        height: child.height
+      }
+      if (child.vectorNetwork) final.vectorNetwork = child.vectorNetwork
+      finalChildren.set(childId, final)
+    }
+    editor.graph.updateNodePreview(d.nodeId, d.origRect)
+    for (const [childId, orig] of d.origChildren) {
+      editor.graph.updateNodePreview(childId, orig)
+    }
+    editor.updateNode(d.nodeId, finalChanges)
+    for (const [childId, final] of finalChildren) {
+      editor.updateNode(childId, final)
+    }
+    editor.commitGroupResize(d.nodeId, d.origRect, d.origChildren)
+    editor.requestRepaint()
+  } else {
+    editor.graph.updateNodePreview(d.nodeId, d.origRect)
+    editor.updateNode(d.nodeId, finalChanges)
+    editor.commitResize(d.nodeId, d.origRect)
+  }
 }

--- a/packages/vue/src/shared/input/resize/start.ts
+++ b/packages/vue/src/shared/input/resize/start.ts
@@ -2,7 +2,29 @@ import type { Editor } from '@open-pencil/core/editor'
 import { cloneVectorNetwork } from '@open-pencil/core/scene-graph'
 
 import { getHitHandleByMatrix } from '#vue/shared/input/geometry'
-import type { DragResize } from '#vue/shared/input/types'
+import type { DragResize, OrigChildState } from '#vue/shared/input/types'
+
+function collectDescendants(id: string, editor: Editor): Map<string, OrigChildState> | null {
+  const node = editor.graph.getNode(id)
+  if (!node || (node.type !== 'GROUP' && node.type !== 'BOOLEAN_OPERATION')) return null
+  const map = new Map<string, OrigChildState>()
+  const stack = [...node.childIds]
+  while (stack.length > 0) {
+    const childId = stack.pop()
+    if (childId === undefined) break
+    const child = editor.graph.getNode(childId)
+    if (!child) continue
+    map.set(childId, {
+      x: child.x,
+      y: child.y,
+      width: child.width,
+      height: child.height,
+      vectorNetwork: child.vectorNetwork ? cloneVectorNetwork(child.vectorNetwork) : null
+    })
+    stack.push(...child.childIds)
+  }
+  return map.size > 0 ? map : null
+}
 
 export function tryStartResize(cx: number, cy: number, editor: Editor): DragResize | null {
   for (const id of editor.state.selectedIds) {
@@ -17,7 +39,8 @@ export function tryStartResize(cx: number, cy: number, editor: Editor): DragResi
         startY: cy,
         origRect: { x: node.x, y: node.y, width: node.width, height: node.height },
         nodeId: id,
-        origVectorNetwork: node.vectorNetwork ? cloneVectorNetwork(node.vectorNetwork) : null
+        origVectorNetwork: node.vectorNetwork ? cloneVectorNetwork(node.vectorNetwork) : null,
+        origChildren: collectDescendants(id, editor)
       }
     }
   }

--- a/packages/vue/src/shared/input/types.ts
+++ b/packages/vue/src/shared/input/types.ts
@@ -37,6 +37,14 @@ export interface DragPan {
   startPanY: number
 }
 
+export interface OrigChildState {
+  x: number
+  y: number
+  width: number
+  height: number
+  vectorNetwork: VectorNetwork | null
+}
+
 export interface DragResize {
   type: 'resize'
   handle: HandlePosition
@@ -45,6 +53,7 @@ export interface DragResize {
   origRect: Rect
   nodeId: string
   origVectorNetwork: VectorNetwork | null
+  origChildren: Map<string, OrigChildState> | null
 }
 
 export interface DragMarquee {

--- a/tests/engine/editor/undo/group-resize.test.ts
+++ b/tests/engine/editor/undo/group-resize.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createEditor } from '@open-pencil/core/editor'
+import type { VectorNetwork } from '@open-pencil/core/scene-graph'
+
+import { getNodeOrThrow } from '#tests/helpers/assert'
+
+const originalVectorNetwork: VectorNetwork = {
+  vertices: [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 10 },
+    { x: 0, y: 10 }
+  ],
+  segments: [
+    { start: 0, end: 1, tangentStart: { x: 0, y: 0 }, tangentEnd: { x: 0, y: 0 } },
+    { start: 1, end: 2, tangentStart: { x: 0, y: 0 }, tangentEnd: { x: 0, y: 0 } },
+    { start: 2, end: 3, tangentStart: { x: 0, y: 0 }, tangentEnd: { x: 0, y: 0 } },
+    { start: 3, end: 0, tangentStart: { x: 0, y: 0 }, tangentEnd: { x: 0, y: 0 } }
+  ],
+  regions: []
+}
+
+const scaledVectorNetwork: VectorNetwork = {
+  ...originalVectorNetwork,
+  vertices: originalVectorNetwork.vertices.map((vertex) => ({
+    x: vertex.x * 2,
+    y: vertex.y * 2
+  }))
+}
+
+describe('group resize undo', () => {
+  test('restores descendant vector geometry', () => {
+    const editor = createEditor()
+    const page = editor.graph.getPages()[0]
+    const group = editor.graph.createNode('GROUP', page.id, {
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10
+    })
+    const vector = editor.graph.createNode('VECTOR', group.id, {
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      vectorNetwork: originalVectorNetwork
+    })
+
+    editor.graph.updateNode(group.id, { width: 20, height: 20 })
+    editor.graph.updateNode(vector.id, {
+      width: 20,
+      height: 20,
+      vectorNetwork: scaledVectorNetwork
+    })
+    editor.commitGroupResize(
+      group.id,
+      { x: 0, y: 0, width: 10, height: 10 },
+      new Map([
+        [
+          vector.id,
+          {
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+            vectorNetwork: originalVectorNetwork
+          }
+        ]
+      ])
+    )
+
+    editor.undo.undo()
+    const restored = getNodeOrThrow(editor.graph, vector.id)
+    expect(restored.width).toBe(10)
+    expect(restored.height).toBe(10)
+    expect(restored.vectorNetwork?.vertices).toEqual(originalVectorNetwork.vertices)
+
+    editor.undo.redo()
+    const redone = getNodeOrThrow(editor.graph, vector.id)
+    expect(redone.width).toBe(20)
+    expect(redone.height).toBe(20)
+    expect(redone.vectorNetwork?.vertices).toEqual(scaledVectorNetwork.vertices)
+  })
+})


### PR DESCRIPTION
## Problem

Resizing a **group** (or a **boolean operation**) only moved the bounding box and rescaled the selection outline — the rendered fill stayed at its original size. The blue selection outline and the filled content visibly diverged, both during the drag and after release.

### Before
![Group resize — outline scales but fill stays small](https://raw.githubusercontent.com/rcoenen/open-pencil/pr-assets-group-resize/.pr-assets/group-resize-before.png)

## Root causes

Both in the resize preview path:

1. **Stale render caches during drag.** Children were scaled in the preview graph via `updateNodePreview()`, which mutates nodes **without** emitting a `node:updated` event. The renderer's vector/geometry caches (`vectorPathCache`, `fillGeometryCache`, `strokeGeometryCache`) were therefore never invalidated, so fills kept drawing from stale, unscaled cached paths while outlines drew live from the new dimensions.

2. **No repaint on commit.** On mouse-up the final scaled values were written with `updateNode()`, but no repaint was requested — leaving the canvas frozen on the last mismatched drag frame until the next interaction.

## Fix

- After each child preview update, call `renderer.invalidateVectorPath(childId)` so the renderer recompiles paths from the scaled coordinates every frame.
- Call `requestRepaint()` after `commitGroupResize()` so the canvas redraws immediately on release.
- Extend `collectDescendants()` to also handle **`BOOLEAN_OPERATION`** nodes. Boolean results render purely from child geometry with no node-level scale factor (`nodePathTransform` only applies translate/rotate/flip), so scaling the children is the only way to scale the result — the same mechanism as `GROUP`, with no risk of a double-transform.

### After
![Group resize — fill and outline scale together](https://raw.githubusercontent.com/rcoenen/open-pencil/pr-assets-group-resize/.pr-assets/group-resize-after.png)

## Testing

- **Group resize** — verified visually (108→111, 130×130): fill and per-child outlines scale in lockstep, during drag and after release.
- **Boolean resize** — verified in-browser via the editor automation API (create two shapes → SUBTRACT → resize): the combined boolean fill scales with the bounding box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)