### PR TITLE
fix(boolean-ops): make operations dropdown menu appear on screen

### DIFF
--- a/src/components/properties/BooleanOperationsControl.vue
+++ b/src/components/properties/BooleanOperationsControl.vue
@@ -16,7 +16,6 @@ import IconSquaresIntersect from '~icons/lucide/squares-intersect'
 import { editorCommandMetadata, formatShortcut, useEditorCommands, useI18n } from '@open-pencil/vue'
 import type { EditorCommandId } from '@open-pencil/vue'
 
-import Tip from '@/components/ui/Tip.vue'
 import { menuItem, useMenuUI } from '@/components/ui/menu'
 
 const { getCommand, runCommand } = useEditorCommands()
@@ -36,17 +35,16 @@ const itemCls = menuItem({ justify: 'between' })
 
 <template>
   <DropdownMenuRoot>
-    <Tip :label="commands.booleanOperations">
-      <DropdownMenuTrigger as-child>
-        <button
-          data-test-id="boolean-operations-trigger"
-          class="flex h-7 items-center gap-1 rounded-md px-1.5 text-muted hover:bg-hover hover:text-surface data-[state=open]:bg-active data-[state=open]:text-surface"
-        >
-          <IconCombine class="size-4" />
-          <IconChevronDown class="size-3" />
-        </button>
-      </DropdownMenuTrigger>
-    </Tip>
+    <DropdownMenuTrigger as-child>
+      <button
+        data-test-id="boolean-operations-trigger"
+        :title="commands.booleanOperations"
+        class="flex h-7 items-center gap-1 rounded-md px-1.5 text-muted hover:bg-hover hover:text-surface data-[state=open]:bg-active data-[state=open]:text-surface"
+      >
+        <IconCombine class="size-4" />
+        <IconChevronDown class="size-3" />
+      </button>
+    </DropdownMenuTrigger>
     <DropdownMenuPortal>
       <DropdownMenuContent align="end" side="bottom" :side-offset="4" :class="menuCls.content">
         <DropdownMenuItem


### PR DESCRIPTION
## Problem

The boolean operations dropdown (Union / Subtract / Intersect / Exclude / Flatten) **opened but rendered off-screen** — its menu items were positioned at roughly `x=5, y=-295…-183`, entirely above the top-left of the window — so the menu was effectively invisible and the feature was unusable from the GUI. (Keyboard shortcuts ⌥⇧U/S/I/E/F still worked, which is why it wasn't caught.)

## Root cause

In `BooleanOperationsControl.vue` the trigger button was wrapped in `<Tip>` (a `Tooltip` + `TooltipTrigger as-child`) **between** `<DropdownMenuRoot>` and `<DropdownMenuTrigger as-child>`:

```
<DropdownMenuRoot>
  <Tip>                              <!-- TooltipTrigger as-child -->
    <DropdownMenuTrigger as-child>   <!-- second as-child on the same button -->
      <button>…</button>
    </DropdownMenuTrigger>
  </Tip>
  <DropdownMenuPortal>…</DropdownMenuPortal>
</DropdownMenuRoot>
```

Chaining **two `as-child` triggers** onto the same button means the `DropdownMenuTrigger` never gets a clean ref to the button element, so the dropdown's floating content has no anchor to position against and falls back to an off-screen default.

## Fix

Match the working pattern used elsewhere in the app (e.g. `VariablesDialog.vue`): let `DropdownMenuTrigger` wrap the `<button>` **directly**, with no tooltip trigger in between. The tooltip label is preserved via a native `title` attribute on the button.

```
<DropdownMenuRoot>
  <DropdownMenuTrigger as-child>
    <button :title="commands.booleanOperations">…</button>
  </DropdownMenuTrigger>
  <DropdownMenuPortal>…</DropdownMenuPortal>
</DropdownMenuRoot>
```

## Testing

Verified in-browser: with two shapes selected, clicking the trigger now opens the menu **directly below the button** (items on-screen at `x≈1205, y≈126–238`), and selecting an operation performs the boolean as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)