### PR TITLE
fix: react to edited CodeRabbit hygiene comments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,12 +11,21 @@ reviews:
     enabled: true
     drafts: false
   pre_merge_checks:
+    title:
+      mode: "error"
+      requirements: "Apply CONTRIBUTING.md → Pull requests → PR title. Fail titles that are non-English, vague, placeholder-like, or do not identify the actual change."
     description:
       mode: "error"
     custom_checks:
-      - name: "PR Hygiene"
+      - name: "PR Hygiene: English"
         mode: "error"
-        instructions: "Fail if the PR title or description is not written in English, does not follow the repository PR template, contains leftover template comments or placeholders such as 'Fixes #', TODO, TBD, has no meaningful summary, has no concrete list of changes, or does not document validation. Pass only when the PR clearly explains what changed, why it changed, and how it was validated."
+        instructions: "Use CONTRIBUTING.md → Pull requests as the source of truth. Fail when the PR title or body is not primarily English, except for code identifiers, file paths, logs, error messages, and short quoted examples."
+      - name: "PR Hygiene: Template"
+        mode: "error"
+        instructions: "Use CONTRIBUTING.md → Pull requests as the source of truth. Fail when the PR body contains unfilled template placeholders, dangling issue references, TODO/TBD text, empty headings, or template comments."
+      - name: "PR Hygiene: Substance"
+        mode: "error"
+        instructions: "Use CONTRIBUTING.md → Pull requests as the source of truth. Fail when the PR body does not explain what changed, why it changed, and how it was validated."
 
 chat:
   auto_reply: true

--- a/.github/scripts/close-invalid-prs.ts
+++ b/.github/scripts/close-invalid-prs.ts
@@ -63,6 +63,10 @@ const hygieneFailed = text
   .split('\n')
   .some((line) => /\bPR Hygiene\b/i.test(line) && /(?:❌|\berror\b|\bfailed\b|\bfail\b)/i.test(line))
 
+if (hygieneFailed) {
+  console.log('Detected failed PR Hygiene check from CodeRabbit signal.')
+}
+
 if (!hygieneFailed) {
   console.log('CodeRabbit signal did not reference a failed PR Hygiene check.')
   process.exit(0)

--- a/.github/scripts/close-invalid-prs.ts
+++ b/.github/scripts/close-invalid-prs.ts
@@ -4,6 +4,7 @@ const owner = process.env.GITHUB_REPOSITORY_OWNER
 const repo = process.env.GITHUB_REPOSITORY?.split('/')[1]
 const eventPath = process.env.GITHUB_EVENT_PATH
 const token = process.env.GITHUB_TOKEN
+const githubAPIURL = process.env.GITHUB_API_URL ?? 'https://api.github.com'
 
 if (!owner || !repo || !eventPath || !token) {
   throw new Error('Missing required GitHub Actions environment')
@@ -59,12 +60,35 @@ if (!issueNumber || !shouldInspect) {
   process.exit(0)
 }
 
-const hygieneFailed = text
-  .split('\n')
-  .some((line) => /\bPR Hygiene\b/i.test(line) && /(?:❌|\berror\b|\bfailed\b|\bfail\b)/i.test(line))
+function tableCells(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split('|')
+    .map((cell) => cell.trim())
+}
+
+function normalizedCheckName(value: string): string {
+  return value.replace(/[^a-z0-9]+/gi, ' ').trim().toLowerCase()
+}
+
+function isPRHygieneFailure(line: string): boolean {
+  const cells = tableCells(line)
+  const checkName = cells[0] ?? ''
+  const status = cells[1] ?? ''
+  const fullLine = line.toLowerCase()
+
+  if (fullLine.includes('[ignored]')) return false
+  if (!normalizedCheckName(checkName).startsWith('pr hygiene')) return false
+
+  return /❌/u.test(status) || /\berror\b/i.test(status)
+}
+
+const hygieneFailed = text.split('\n').some(isPRHygieneFailure)
 
 if (hygieneFailed) {
-  console.log('Detected failed PR Hygiene check from CodeRabbit signal.')
+  console.log('Detected failed PR Hygiene check from CodeRabbit pre-merge table.')
 }
 
 if (!hygieneFailed) {
@@ -73,7 +97,7 @@ if (!hygieneFailed) {
 }
 
 async function github<T>(path: string, options: RequestInit = {}): Promise<T | null> {
-  const response = await fetch(`https://api.github.com${path}`, {
+  const response = await fetch(`${githubAPIURL}${path}`, {
     ...options,
     headers: {
       Accept: 'application/vnd.github+json',

--- a/.github/scripts/close-invalid-prs.ts
+++ b/.github/scripts/close-invalid-prs.ts
@@ -77,9 +77,7 @@ function isPRHygieneFailure(line: string): boolean {
   const cells = tableCells(line)
   const checkName = cells[0] ?? ''
   const status = cells[1] ?? ''
-  const fullLine = line.toLowerCase()
-
-  if (fullLine.includes('[ignored]')) return false
+  if (checkName.toLowerCase().includes('[ignored]')) return false
   if (!normalizedCheckName(checkName).startsWith('pr hygiene')) return false
 
   return /❌/u.test(status) || /\berror\b/i.test(status)

--- a/.github/workflows/close-invalid-prs.yml
+++ b/.github/workflows/close-invalid-prs.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # This job only reacts to trusted CodeRabbit review signals and then labels/closes PRs.
+  # This job only reacts to CodeRabbit PR Hygiene pre-merge failures and never runs contributor code.
   close-invalid:
     name: Close PRs failed by PR Hygiene
     runs-on: ubuntu-latest

--- a/.github/workflows/close-invalid-prs.yml
+++ b/.github/workflows/close-invalid-prs.yml
@@ -4,7 +4,7 @@ on:
   pull_request_review:
     types: [submitted]
   issue_comment:
-    types: [created]
+    types: [created, edited]
 
 concurrency:
   group: close-invalid-prs-${{ github.event.pull_request.number || github.event.issue.number }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,25 @@ APPLE_SIGNING_IDENTITY=- bun run tauri build -c '{"bundle": { "createUpdaterArti
 
 ## Pull requests
 
-Pull requests must be written in English and must follow the PR template. The title and body should clearly explain what changed, why it changed, and how it was validated.
+Pull requests must be reviewable without guessing the author's intent.
 
-Do not submit placeholder PRs. Remove template comments before opening a PR. Do not leave dangling issue references such as `Fixes #`, `TODO`, `TBD`, or similar unfinished text.
+### PR title
+
+- Write the title in English.
+- Be specific about the actual change; avoid vague titles such as `fix`, `update`, `some fixes`, `changes`, or `WIP`.
+- Use Conventional Commits when it fits the change, for example `fix: handle empty exports` or `docs: clarify CLI setup`.
+
+### PR body
+
+- Follow the PR template when one is provided.
+- Explain what changed and why it changed.
+- Include a concrete list or paragraph of meaningful changes.
+- Document validation, such as `bun run check`, targeted tests, docs-only review, or an explicit reason validation was not run.
+- Keep the body primarily in English. Code identifiers, file paths, logs, error messages, and short quoted examples may use their original language.
+
+### Invalid PRs
+
+Do not submit placeholder PRs. Remove template comments before opening a PR. Do not leave dangling issue references such as `Fixes #`, `TODO`, `TBD`, empty headings, unfilled sections, or similar unfinished text.
 
 PRs from external contributors that ignore the template, omit validation, are not written in English, or otherwise do not follow these guidelines may be labeled `invalid` and closed automatically.
 


### PR DESCRIPTION
## Summary

- Run the invalid-PR close workflow when CodeRabbit edits its walkthrough comment
- Parse CodeRabbit pre-merge check tables instead of broad text matches
- Keep detailed PR hygiene rules centralized in `CONTRIBUTING.md`

## Validation

- Replayed the production close script against the actual CodeRabbit #329 walkthrough comment with a local fake GitHub API
- Verified external-author flow labels and closes the PR
- Verified trusted-author flow detects the failure but does not close
- Verified `[IGNORED]` pre-merge rows do not close


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * PR validation now re-processes edited comments as well as newly created ones.
  * Detection and logging for PR-hygiene failures made more robust and configurable.

* **Configuration**
  * Pre-merge validation split into explicit, granular PR-hygiene checks enforcing English, template completeness, and clear change/validation descriptions.

* **Documentation**
  * CONTRIBUTING expanded with detailed PR title/body expectations, reviewability rules, examples, and rules to avoid placeholder or invalid PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->