### PR TITLE
ci: block AI tool product placement

### DIFF
--- a/.github/workflows/attribution-policy.yml
+++ b/.github/workflows/attribution-policy.yml
@@ -25,6 +25,6 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - uses: ./.github/actions/setup-bun
-      - run: node --experimental-strip-types tools/attribution-policy/src/check.ts
+      - run: bun ./tools/attribution-policy/src/check.ts
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/attribution-policy.yml
+++ b/.github/workflows/attribution-policy.yml
@@ -4,8 +4,15 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# Minimal read-only permissions for checking PR metadata on the trusted default branch.
 permissions:
+  # Checkout trusted repository content.
   contents: read
+  # Read PR commits, files, title, and body through the GitHub API.
   pull-requests: read
 
 jobs:
@@ -13,9 +20,10 @@ jobs:
     name: No AI-tool product placement
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-bun
       - run: node --experimental-strip-types tools/attribution-policy/src/check.ts
         env:

--- a/.github/workflows/attribution-policy.yml
+++ b/.github/workflows/attribution-policy.yml
@@ -1,0 +1,22 @@
+name: Attribution policy
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    name: No AI-tool product placement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - uses: ./.github/actions/setup-bun
+      - run: node --experimental-strip-types tools/attribution-policy/src/check.ts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,8 @@ vue-stream-markdown/
 # Agent scratch space (reviews, test artifacts)
 scratch/
 
+# Agent local config and scratch space
+.claude/
+
 # OpenCode
 .opencode/

--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,8 @@ components.d.ts
 # Agent scratch space (reviews, plans, test artifacts)
 scratch/
 
+# Agent local config and scratch space
+.claude/
+
 # OpenCode
 .opencode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,8 @@ Use Conventional Commits for regular development commits: `feat`, `fix`, `refact
 - Keep the commit type lowercase (`fix:`, `feat:`, `docs:`), but start each body line/bullet with an uppercase word
 - Prefer scopes that match the project structure: `app`, `tauri`, `core`, `cli`, `mcp`, `vue`, `docs`, or focused domains like `editor`, `scene-graph`, `canvas`, `tools`, `kiwi`, `io`, `text`, `vector`, `color`, `acp`, `ai`, `collab`, `automation`, `i18n`
 - Use the narrowest honest scope, or omit it if the change spans multiple unrelated areas
+- Do not add coding-harness attribution, vendor branding, or product-placement text to commits, PR bodies, comments, or generated files; this includes `Co-authored-by: Claude`, `Made with Cursor`, `Generated with Claude Code`, and similar trailers from any AI coding tool
+- If AI-generated code is substantial and the context is useful for review, mention only the model identifier, for example `Model: claude-sonnet-4.5`; do not credit or advertise the coding harness/agent
 
 Example:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,8 @@ Use Conventional Commits for regular development commits: `feat`, `fix`, `refact
 - Preserve product/domain casing in subjects and bodies: `DOM/CSS`, `CSS`, `HTML`, `JSX`, `Tailwind`, `Kiwi`, `.fig`, `MCP`, `CLI`, `AI`, `ACP`, `i18n`. Do not flatten acronyms to lowercase prose such as `dom css documents`.
 - Prefer scopes that match the project structure: `app`, `tauri`, `core`, `cli`, `dom-css`, `mcp`, `vue`, `docs`, or focused domains like `editor`, `scene-graph`, `canvas`, `tools`, `kiwi`, `io`, `text`, `vector`, `color`, `acp`, `ai`, `collab`, `automation`, `i18n`
 - Use the narrowest honest scope, or omit it if the change spans multiple unrelated areas
+- Do not add coding-harness attribution, vendor branding, or product-placement text to commits, PR bodies, comments, or generated files; this includes `Co-authored-by: Claude`, `Made with Cursor`, `Generated with Claude Code`, and similar trailers from any AI coding tool
+- If AI-generated code is substantial and the context is useful for review, mention only the model identifier, for example `Model: claude-sonnet-4.5`; do not credit or advertise the coding harness/agent
 
 Example:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+@AGENTS.md
+
+# Claude Code shim
+
+`AGENTS.md` is OpenPencil's source of truth. This file exists only because Claude Code reads `CLAUDE.md` first instead of natively supporting `AGENTS.md`:
+https://github.com/anthropics/claude-code/issues/6235
+
+Do not add Claude/Anthropic branding or attribution anywhere: no `Co-authored-by: Claude`, `Generated with Claude Code`, Claude-branded PR text/comments, committed `.claude/**`, or similar product placement.
+
+If AI context is useful for review, mention only the model identifier, for example `Model: claude-sonnet-4.5`. Do not credit or advertise the coding harness/agent.
+
+We welcome any coding tools, but repo history and config are project metadata, not vendor advertising space.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ Pull requests must be reviewable without guessing the author's intent.
 - Explain what changed and why it changed.
 - Include a concrete list or paragraph of meaningful changes.
 - Document validation, such as `bun run check`, targeted tests, docs-only review, or an explicit reason validation was not run.
+- If AI-generated code is substantial, add one model identifier line when it helps reviewers calibrate risk, for example `Model: claude-sonnet-4.5`. Do not add coding-harness branding, `Co-authored-by` AI trailers, or generated-with footers.
 - Keep the body primarily in English. Code identifiers, file paths, logs, error messages, and short quoted examples may use their original language.
 
 ### Reviewability

--- a/tools/attribution-policy/package.json
+++ b/tools/attribution-policy/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@open-pencil/attribution-policy",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "bun test tests"
+  }
+}

--- a/tools/attribution-policy/src/check.ts
+++ b/tools/attribution-policy/src/check.ts
@@ -134,7 +134,7 @@ async function inputFromGitHubEvent(eventPath: string): Promise<PullRequestPolic
   if (!pullRequest || !repo || !number)
     throw new Error('This check only supports pull request events')
 
-  const commits = await githubJSON<GitHubCommit[]>(apiURL(`/repos/${repo}/pulls/${number}/commits`))
+  const commits = await githubArrayPages<GitHubCommit>(`/repos/${repo}/pulls/${number}/commits`)
   const files = await githubArrayPages<GitHubFile>(`/repos/${repo}/pulls/${number}/files`)
 
   return {

--- a/tools/attribution-policy/src/check.ts
+++ b/tools/attribution-policy/src/check.ts
@@ -1,0 +1,157 @@
+import { readFile } from 'node:fs/promises'
+
+const FORBIDDEN_TEXT_PATTERNS = [
+  /co-authored-by:\s*(?:claude|cursor|(?:github\s+)?copilot|opencode)/i,
+  /generated\s+(?:with|by)\s+(?:claude\s+code|cursor|(?:github\s+)?copilot|opencode)/i,
+  /made\s+with\s+cursor/i,
+  /🤖\s*generated\s+with/i
+]
+
+const FORBIDDEN_CLAUDE_CONFIG_PATTERNS = [/^\.claude\//, /\.claude\/(?:\*\*)?/]
+
+export type PullRequestPolicyInput = {
+  title: string
+  body: string
+  commitMessages: string[]
+  changedFiles: string[]
+}
+
+export type PolicyViolation = {
+  location: string
+  message: string
+}
+
+type GitHubPullRequestEvent = {
+  pull_request?: {
+    number?: number
+    title?: string
+    body?: string | null
+    commits_url?: string
+    url?: string
+    issue_url?: string
+  }
+  repository?: {
+    full_name?: string
+  }
+}
+
+type GitHubCommit = {
+  commit?: {
+    message?: string
+  }
+}
+
+type GitHubFile = {
+  filename?: string
+}
+
+function hasForbiddenText(value: string) {
+  return FORBIDDEN_TEXT_PATTERNS.some((pattern) => pattern.test(value))
+}
+
+function hasForbiddenClaudeConfig(value: string) {
+  return FORBIDDEN_CLAUDE_CONFIG_PATTERNS.some((pattern) => pattern.test(value))
+}
+
+export function findPolicyViolations(input: PullRequestPolicyInput): PolicyViolation[] {
+  const violations: PolicyViolation[] = []
+
+  if (hasForbiddenText(input.title)) {
+    violations.push({
+      location: 'PR title',
+      message:
+        'Remove coding-harness branding from the PR title; review-relevant model identifiers are allowed.'
+    })
+  }
+
+  if (hasForbiddenText(input.body)) {
+    violations.push({
+      location: 'PR body',
+      message:
+        'Remove coding-harness branding from the PR body; review-relevant model identifiers are allowed.'
+    })
+  }
+
+  for (const [index, message] of input.commitMessages.entries()) {
+    if (!hasForbiddenText(message)) continue
+    violations.push({
+      location: `commit ${index + 1}`,
+      message:
+        'Remove coding-harness attribution or branding from the commit message; review-relevant model identifiers are allowed.'
+    })
+  }
+
+  for (const file of input.changedFiles) {
+    if (!hasForbiddenClaudeConfig(file)) continue
+    violations.push({
+      location: file,
+      message: 'Do not commit vendor-specific Claude Code project configuration.'
+    })
+  }
+
+  return violations
+}
+
+function requireEnv(name: string) {
+  const value = process.env[name]
+  if (!value) throw new Error(`${name} is required`)
+  return value
+}
+
+async function githubJSON<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${requireEnv('GITHUB_TOKEN')}`,
+      'x-github-api-version': '2022-11-28'
+    }
+  })
+
+  if (!response.ok)
+    throw new Error(`GitHub API request failed: ${response.status} ${response.statusText}`)
+  return (await response.json()) as T
+}
+
+function apiURL(path: string) {
+  return `https://api.github.com${path}`
+}
+
+async function inputFromGitHubEvent(eventPath: string): Promise<PullRequestPolicyInput> {
+  const event = JSON.parse(await readFile(eventPath, 'utf8')) as GitHubPullRequestEvent
+  const pullRequest = event.pull_request
+  const repo = event.repository?.full_name
+  const number = pullRequest?.number
+  if (!pullRequest || !repo || !number)
+    throw new Error('This check only supports pull request events')
+
+  const commits = await githubJSON<GitHubCommit[]>(apiURL(`/repos/${repo}/pulls/${number}/commits`))
+  const files = await githubJSON<GitHubFile[]>(
+    apiURL(`/repos/${repo}/pulls/${number}/files?per_page=100`)
+  )
+
+  return {
+    title: pullRequest.title ?? '',
+    body: pullRequest.body ?? '',
+    commitMessages: commits.map((commit) => commit.commit?.message ?? ''),
+    changedFiles: files.map((file) => file.filename ?? '')
+  }
+}
+
+async function main() {
+  const input = await inputFromGitHubEvent(requireEnv('GITHUB_EVENT_PATH'))
+  const violations = findPolicyViolations(input)
+  if (violations.length === 0) return
+
+  console.error('AI-tool attribution/product-placement policy failed.\n')
+  for (const violation of violations) {
+    console.error(`- ${violation.location}: ${violation.message}`)
+  }
+  console.error(
+    '\nOpenPencil welcomes contributors using any coding tools. If AI context is useful for review, mention the model identifier without advertising the coding harness; repository history and config are project metadata, not vendor advertising space.'
+  )
+  process.exitCode = 1
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/tools/attribution-policy/src/check.ts
+++ b/tools/attribution-policy/src/check.ts
@@ -116,6 +116,16 @@ function apiURL(path: string) {
   return `https://api.github.com${path}`
 }
 
+async function githubArrayPages<T>(path: string): Promise<T[]> {
+  const items: T[] = []
+
+  for (let page = 1; ; page += 1) {
+    const pageItems = await githubJSON<T[]>(apiURL(`${path}?per_page=100&page=${page}`))
+    items.push(...pageItems)
+    if (pageItems.length < 100) return items
+  }
+}
+
 async function inputFromGitHubEvent(eventPath: string): Promise<PullRequestPolicyInput> {
   const event = JSON.parse(await readFile(eventPath, 'utf8')) as GitHubPullRequestEvent
   const pullRequest = event.pull_request
@@ -125,9 +135,7 @@ async function inputFromGitHubEvent(eventPath: string): Promise<PullRequestPolic
     throw new Error('This check only supports pull request events')
 
   const commits = await githubJSON<GitHubCommit[]>(apiURL(`/repos/${repo}/pulls/${number}/commits`))
-  const files = await githubJSON<GitHubFile[]>(
-    apiURL(`/repos/${repo}/pulls/${number}/files?per_page=100`)
-  )
+  const files = await githubArrayPages<GitHubFile>(`/repos/${repo}/pulls/${number}/files`)
 
   return {
     title: pullRequest.title ?? '',

--- a/tools/attribution-policy/tests/check.test.ts
+++ b/tools/attribution-policy/tests/check.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test'
+
+import { findPolicyViolations } from '../src/check'
+
+describe('findPolicyViolations', () => {
+  test('accepts neutral PR metadata and commits', () => {
+    expect(
+      findPolicyViolations({
+        title: 'fix(editor): preserve selection',
+        body: 'Tightens selection state updates.',
+        commitMessages: ['fix(editor): preserve selection'],
+        changedFiles: ['src/app/editor/selection.ts']
+      })
+    ).toEqual([])
+  })
+
+  test('rejects Claude attribution and generated branding', () => {
+    const violations = findPolicyViolations({
+      title: 'fix(editor): preserve selection',
+      body: 'Generated with Claude Code.',
+      commitMessages: [
+        'fix(editor): preserve selection\n\nCo-authored-by: Claude <noreply@anthropic.com>'
+      ],
+      changedFiles: []
+    })
+
+    expect(violations.map((violation) => violation.location)).toEqual(['PR body', 'commit 1'])
+  })
+
+  test('rejects aggressive coding-harness product placement', () => {
+    const violations = findPolicyViolations({
+      title: 'feat: update export flow',
+      body: 'Made with Cursor',
+      commitMessages: [
+        'feat: update export flow\n\nCo-authored-by: Cursor <cursoragent@cursor.com>',
+        'fix: update tool prompt\n\n🤖 Generated with opencode',
+        'docs: update notes\n\nCo-authored-by: GitHub Copilot <copilot@github.com>'
+      ],
+      changedFiles: []
+    })
+
+    expect(violations.map((violation) => violation.location)).toEqual([
+      'PR body',
+      'commit 1',
+      'commit 2',
+      'commit 3'
+    ])
+  })
+
+  test('allows review-relevant model disclosure without coding-harness branding', () => {
+    expect(
+      findPolicyViolations({
+        title: 'fix(editor): preserve selection',
+        body: 'Model: claude-sonnet-4.5',
+        commitMessages: ['fix(editor): preserve selection\n\nModel: gpt-5.1-codex'],
+        changedFiles: []
+      })
+    ).toEqual([])
+  })
+
+  test('rejects committed Claude project configuration', () => {
+    expect(
+      findPolicyViolations({
+        title: 'chore: add agent settings',
+        body: '',
+        commitMessages: ['chore: add agent settings'],
+        changedFiles: ['.claude/settings.json']
+      })
+    ).toEqual([
+      {
+        location: '.claude/settings.json',
+        message: 'Do not commit vendor-specific Claude Code project configuration.'
+      }
+    ])
+  })
+
+  test('allows committed tooling ignore references', () => {
+    expect(
+      findPolicyViolations({
+        title: 'fix(steiger): ignore local claude config',
+        body: '',
+        commitMessages: ['fix(steiger): ignore local claude config'],
+        changedFiles: ['steiger.config.ts']
+      })
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
### Summary

Add an opt-in repository policy check that keeps coding-harness product placement and vendor-specific agent configuration out of project history while continuing to allow concise model disclosure for review.

### What changed

- Add a read-only `pull_request_target` workflow that checks trusted default-branch policy code against PR metadata, commit messages, and changed paths.
- Reject common coding-harness attribution and branding trailers without blocking neutral model identifiers.
- Reject committed `.claude/` project configuration while allowing ignore references.
- Add focused policy tests and contributor guidance.

### AI assistance

Models: OpenAI Codex GPT-5.6

### Validation

- [x] `bun run check`
- [x] Attribution policy tests: 6 passed
- [x] Duplication check: 0 clones
- [x] Current-master adaptation validated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks for prohibited AI-tool attribution, branding, and configuration references in pull requests.
  * Added policy validation for pull request titles, descriptions, commits, and changed files.
* **Chores**
  * Added contributor guidance for neutral AI references and prohibited promotional content.
  * Added local configuration files to ignore rules.
* **Tests**
  * Added coverage for accepted disclosures, detected violations, and allowed tooling references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->