### PR TITLE
fix(desktop): enable image drag-and-drop in the Tauri window

### DIFF
--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -14,7 +14,8 @@
       {
         "title": "OpenPencil",
         "width": 1280,
-        "height": 800
+        "height": 800,
+        "dragDropEnabled": false
       }
     ],
     "security": {


### PR DESCRIPTION
## Summary

Dragging an image onto the canvas works in the browser but **silently fails in the desktop (Tauri) app**.

Tauri's `dragDropEnabled` window option defaults to **`true`**, which makes the native OS file-drop intercept and consume the event — so the webview's HTML5 `drop` handler (`useCanvasDrop`, `packages/vue/src/canvas/drop/use.ts`) never fires, and there's no Tauri-native drop handler to take over.

Setting `dragDropEnabled: false` lets the webview receive native HTML5 drag/drop, so the **existing** web handler works on desktop too.

## Change

One line in `desktop/tauri.conf.json`:

```diff
       {
         "title": "OpenPencil",
         "width": 1280,
-        "height": 800
+        "height": 800,
+        "dragDropEnabled": false
       }
```

## Scope / safety

- Desktop-only: `desktop/tauri.conf.json` is never read by the web build, so web drag-and-drop behavior is unchanged.
- No application/code changes — the shared `useCanvasDrop` composable is untouched.

## Testing

Built the Tauri app locally with this change and confirmed dragging a PNG onto the canvas now places it in the desktop app (and the browser is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled drag and drop functionality in the main application window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->