### PR TITLE
fix(core): stop fig writer from destroying existing nodes on save (sessionID:1 GUID collision)

### DIFF
--- a/packages/core/src/io/formats/fig/export.ts
+++ b/packages/core/src/io/formats/fig/export.ts
@@ -326,21 +326,15 @@ export async function exportFigFile(
   const glyphBlobMap = new Map<string, number>()
   const blobIndexByHex = new Map<string, number>()
 
-  const { canvasEntries, internalCanvasGuid } = buildCanvasEntries(
-    graph,
-    pages,
-    docGuid,
-    localIdCounter,
-    nodeIdToGuid
-  )
-
-  // Scan ALL imported source.ids to find the max localID across EVERY session.
-  // localIdCounter is shared by both the sessionID:0 GUIDs minted here (canvases,
-  // variables) and the sessionID:1 GUIDs minted for new nodes in
-  // getOrCreateNodeGuid. So the high-water mark must consider every session, not
-  // just sessionID:0 — otherwise new sessionID:1 node GUIDs are minted at low
-  // localIDs that collide with existing sessionID:1 content, and the importer's
-  // by-GUID resolution (last write wins) silently destroys those existing nodes.
+  // Scan ALL imported source.ids to find the max localID across EVERY session,
+  // and lift localIdCounter past it BEFORE minting any new GUID below.
+  // localIdCounter is shared by the sessionID:0 GUIDs minted for canvases and
+  // variables and the sessionID:1 GUIDs minted for new nodes in
+  // getOrCreateNodeGuid. The high-water mark must therefore consider every
+  // session — otherwise freshly minted GUIDs (a new canvas, the internal
+  // canvas, a variable, or a new node) reuse a low localID that collides with
+  // existing content, and the importer's by-GUID resolution (last write wins)
+  // silently destroys those existing nodes on save.
   let maxLocalId = localIdCounter.value - 1
   for (const node of graph.nodes.values()) {
     if (node.source.id) {
@@ -351,6 +345,14 @@ export async function exportFigFile(
     }
   }
   localIdCounter.value = Math.max(localIdCounter.value, maxLocalId + 1)
+
+  const { canvasEntries, internalCanvasGuid } = buildCanvasEntries(
+    graph,
+    pages,
+    docGuid,
+    localIdCounter,
+    nodeIdToGuid
+  )
 
   // Assign variable GUIDs AFTER canvas entries so that source.id-derived
   // canvas GUIDs don't collide with generated variable GUIDs.

--- a/packages/core/src/io/formats/fig/export.ts
+++ b/packages/core/src/io/formats/fig/export.ts
@@ -334,18 +334,23 @@ export async function exportFigFile(
     nodeIdToGuid
   )
 
-  // Scan ALL imported source.ids to find max sessionID:0 localID,
-  // preventing collisions between variable GUIDs and any imported node GUID.
-  let maxLocalId0 = localIdCounter.value - 1
+  // Scan ALL imported source.ids to find the max localID across EVERY session.
+  // localIdCounter is shared by both the sessionID:0 GUIDs minted here (canvases,
+  // variables) and the sessionID:1 GUIDs minted for new nodes in
+  // getOrCreateNodeGuid. So the high-water mark must consider every session, not
+  // just sessionID:0 — otherwise new sessionID:1 node GUIDs are minted at low
+  // localIDs that collide with existing sessionID:1 content, and the importer's
+  // by-GUID resolution (last write wins) silently destroys those existing nodes.
+  let maxLocalId = localIdCounter.value - 1
   for (const node of graph.nodes.values()) {
     if (node.source.id) {
       const guid = stringToGuid(node.source.id)
-      if (guid.sessionID === 0 && guid.localID > maxLocalId0) {
-        maxLocalId0 = guid.localID
+      if (guid.localID > maxLocalId) {
+        maxLocalId = guid.localID
       }
     }
   }
-  localIdCounter.value = Math.max(localIdCounter.value, maxLocalId0 + 1)
+  localIdCounter.value = Math.max(localIdCounter.value, maxLocalId + 1)
 
   // Assign variable GUIDs AFTER canvas entries so that source.id-derived
   // canvas GUIDs don't collide with generated variable GUIDs.


### PR DESCRIPTION
Fixes #349.

### Problem
`exportFigFile`'s `localIdCounter` is shared by the `sessionID:0` GUIDs minted here (canvases, variables) and the `sessionID:1` GUIDs minted for new nodes in `getOrCreateNodeGuid` (`export-node.ts`). The high-water-mark scan that advances the counter only considered `sessionID === 0`, so for any document that already contains `sessionID:1` nodes (i.e. anything imported/pasted from Figma, **or** anything created in a previous save — new nodes persist as `sessionID:1`), the counter was not advanced past them. New nodes were then minted at colliding localIDs (`1:82, 1:83, …`), and the importer's by-GUID resolution (last write wins) **silently destroyed** the existing nodes on save.

### Repro (deterministic, no Figma import needed)
Add 5 frames + save, then add 5 more frames + save → reload shows **5 children, not 10**: the first batch is gone (full steps in #349).

### Fix
Scan the max `localID` across **every** session (the comment already said "Scan ALL"), so newly-minted GUIDs never collide with existing content. One-line change to the guard plus a clarifying comment. The shared counter may skip some localID values, which is harmless.

I verified the equivalent behavior in userland (assigning each new node a fresh, higher-session `source.id` before save): the same 5+5 sequence then keeps all 10 nodes with 0 duplicate GUIDs.

### Follow-up
Happy to add a regression test under `tests/engine` (build a graph with a `sessionID:1` node → add a node → export → re-import → assert all original IDs present, 0 duplicate GUIDs, count = original + 1) — pointers to the preferred graph/export test helper appreciated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of file export: identifier collisions across imported content are now prevented more effectively, reducing the chance of duplicated IDs and export-related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->