### PR TITLE
fix(i18n): correct translation of the duplicate command in zh-CN

### DIFF
--- a/packages/vue/src/locales/zh-CN.json
+++ b/packages/vue/src/locales/zh-CN.json
@@ -49,7 +49,7 @@
     "undo": "撤销",
     "redo": "重做",
     "selectAll": "全选",
-    "duplicate": "复制",
+    "duplicate": "克隆",
     "delete": "删除",
     "group": "编组",
     "ungroup": "取消编组",


### PR DESCRIPTION
### Summary

The `commands.duplicate` action was previously translated as "复制" (Copy) in `zh-CN.json`, identically to the native `menu.copy` action. This caused the context menu to display two identical "复制" options, creating confusion about which action copies to the clipboard and which one clones the object directly on the canvas.

This PR updates the translation of `commands.duplicate` to "克隆" (Clone) to accurately reflect its behavior and clearly distinguish it from the native clipboard copy command.

### What changed

- Changed the translation of `commands.duplicate` from `"复制"` to `"克隆"` in `packages/vue/src/locales/zh-CN.json`.

### Validation

- [x] `bun run check`
- [x] Tests added or updated, or not needed because: This is a pure localization string update in a JSON file, no logic changes requiring new tests.
- [x] CHANGELOG.md updated, or not needed because: This is a minor translation fix for the zh-CN locale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Chinese translation for the duplicate command functionality to enhance clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->