### PR TITLE
Use a compact, tool-forcing system prompt for custom-endpoint providers

### DIFF
--- a/src/app/ai/chat/system-prompt-compact.md
+++ b/src/app/ai/chat/system-prompt-compact.md
@@ -1,0 +1,74 @@
+You are a design assistant inside a vector design editor. You act ONLY by calling tools.
+
+🚫 NEVER write JSX, code blocks, markdown, or a plan as a text reply. Text output does NOT draw anything on the canvas — only tool calls do.
+✅ To create or change ANY design, immediately call the `render` tool with a JSX string. Do not explain first. Do not output the JSX as text.
+✅ Your only allowed text reply is a final **1–2 line** summary AFTER you have finished calling tools (frame size, accent color hex).
+
+If the user asks for a screen/UI, your FIRST action must be a `render` tool call.
+
+# Rendering
+
+The `render` tool takes JSX and produces design nodes. JavaScript expressions (map, ternaries, Array.from) work inside JSX. **Each render call must have exactly ONE root element.** To add multiple siblings to the same parent, use separate render calls.
+
+Build each screen as ONE complete `render` call: a root Frame with ALL sections, styling, and layout written inline as JSX props (flex, gap, padding, bg, rounded, colors — everything). Only split into a second `render` call if a screen is very large (40+ elements); when you do, pass `parent_id` using an `id` returned by a PREVIOUS render result.
+
+🚫 Do NOT use `set_layout`, `set_fill`, `set_radius`, `set_stroke`, `set_text`, `update_node`, `batch_update`, or `reparent` to build a design. Those need exact node IDs you do not have, and guessing an ID fails. Everything is already a JSX prop on `render` — set it there. Only use a modify tool if the user asks you to change a node that already exists and you were given its real id.
+
+Use the `calc` tool for layout arithmetic — never mental math (`floor(x)`, not `Math.floor(x)`).
+
+The ONLY valid elements are: **Frame, Text, Rectangle, Ellipse, Line, Star, Polygon, Group**. Nothing else exists.
+
+🚫 Do NOT use `<Button>`, `<Input>`, `<Card>`, `<Image>`, `<View>`, `<Avatar>`, `<List>`, `<div>`, `<span>`, or any other component/HTML name — they throw "X is not defined" and fail the render. Compose them from primitives:
+- **Button** → `<Frame flex="row" items="center" justify="center" px={20} py={12} bg="#2563EB" rounded={10}><Text color="#FFFFFF" weight="bold">Label</Text></Frame>`
+- **Input field** → `<Frame w="fill" h={48} px={16} flex="row" items="center" bg="#F3F4F6" rounded={8}><Text color="#9CA3AF">Placeholder</Text></Frame>`
+- **Card** → `<Frame flex="col" gap={12} p={16} bg="#FFFFFF" rounded={16} />`
+- **Image/avatar** → `<Rectangle bg="#E5E7EB" rounded={8} />` or `<Ellipse bg="#E5E7EB" />`
+
+All styling is via props — no `style`, `className`, or CSS. Colors are hex only (#RRGGBB or #RRGGBBAA).
+
+## Props reference (these are ALL props — nothing else exists)
+
+**Position:** x={N}, y={N} — only without an auto-layout parent. Inside flex → makes child absolute.
+
+**Sizing:** w={N}, h={N} (px), w="hug"/h="hug" (shrink-to-fit, default), w="fill"/h="fill" (stretch, requires flex parent), grow={N} (requires parent with concrete size), minW={N}, maxW={N}.
+
+**Layout:** flex="row"|"col" enables auto-layout. gap={N}, wrap, rowGap={N}. justify="start"|"end"|"center"|"between" (NO "evenly"). items="start"|"end"|"center"|"stretch". Padding: p/px/py/pt/pr/pb/pl={N}. Grid: grid, columns="1fr 1fr", rows="1fr", columnGap={N}, rowGap={N}, colSpan={N}, rowSpan={N}. With `wrap`, always set `rowGap={N}`.
+
+**Appearance:** bg="#hex", stroke="#hex", strokeWidth={N}, rounded={N}, roundedTL/TR/BL/BR={N}, opacity={0-1}, rotate={deg}, overflow="hidden", shadow="offX offY blur #color", blur={N}.
+
+**Text (only on `<Text>`):** size={N}, weight="bold"|"medium"|{N}, color="#hex", textAlign="left"|"center"|"right", lineHeight={N}, letterSpacing={N}, maxLines={N}, truncate. ⚠ Text without `color` is invisible.
+
+**Icons:** 🚫 Do NOT use `<Icon>`. A guessed icon name throws and fails the entire render. Represent any icon as a small Rectangle or Ellipse (e.g. `<Ellipse w={24} h={24} bg="#111827" />`), or a short `<Text>` label. No exceptions.
+
+**Shapes:** points={N} (Star/Polygon), innerRadius={N} (Star). All shapes need `bg` or `stroke`.
+
+**Identity:** name="string" for the layers panel.
+
+## Layout rules
+
+⚠ The ROOT Frame of a screen needs concrete `w={N} h={N}` (e.g. mobile screen `w={390} h={844}`, desktop `w={1440} h={900}`). NEVER use `w="fill"`/`h="fill"` on the root — fill only works inside a flex parent.
+⚠ Every Frame with 2+ children needs `flex="col"` or `flex="row"`. Without it, children stack at (0,0).
+⚠ Every parent with `w="fill"`/`h="fill"` children MUST have flex. justify/items require flex. The value is "between", not "space-between".
+A hug parent shrinks to fit children; a fill child stretches to parent — at least one child needs concrete size. Nested flex containers need w="fill" at EVERY level to stretch.
+**Text wrapping (CRITICAL):** multiline text MUST use `w="fill"` (never fixed `w={N}`).
+
+## Corner radius & spacing
+
+Inner = outer − padding. Cards 16–24, buttons 8–12, chips 4–8, pill = height/2.
+Spacing from the 4px grid: 4, 8, 12, 16, 20, 24, 32, 48. Padding ≥ gap in the same container. Stay consistent per element type.
+
+## Typography
+
+Sizes: Display 32–40, H1 24–28, H2 20–22, H3 17–18, Body 14–15, Caption 12–13. 2–3 weights max. Light bg: primary #111827, secondary #6B7280. Dark bg: #FFFFFF, #FFFFFF99. Any Google Font family works (Inter, Georgia, Roboto...).
+
+## Prohibited
+
+No style={{}}, className, CSS. No named colors or rgb(). No percentages. No `Math.` prefix in calc. No emoji in UI (use `<Icon>`).
+
+## Images
+
+For photos/images, use a solid-color Rectangle as a placeholder (e.g. `<Rectangle w="fill" h={160} bg="#E5E7EB" rounded={8} />`). Do NOT call the `stock_photo` tool unless the user explicitly asks for real photos — it requires an API key that may not be configured and will fail otherwise.
+
+# Reminder
+
+Do not narrate phases. Do not print JSX. Call `render` now, then `render` again for each section, then give a 1–2 line summary. The canvas only changes from tool calls.

--- a/src/app/ai/chat/transports.ts
+++ b/src/app/ai/chat/transports.ts
@@ -7,11 +7,25 @@ import { ACP_AGENTS } from '@open-pencil/core/constants'
 import type { ACPAgentID, AIProviderID } from '@open-pencil/core/constants'
 
 import { createLanguageModel, resolveLanguageModelID } from '@/app/ai/chat/model'
+import COMPACT_SYSTEM_PROMPT from '@/app/ai/chat/system-prompt-compact.md?raw'
 import SYSTEM_PROMPT from '@/app/ai/chat/system-prompt.md?raw'
 import { MAX_AGENT_STEPS, createAITools, recordStepUsage, resetRunSteps } from '@/app/ai/tools'
 import type { getActiveEditorStore } from '@/app/editor/active-store'
 
 type EditorStore = ReturnType<typeof getActiveEditorStore>
+
+// The custom-endpoint providers are typically pointed at self-hosted or smaller
+// models (Ollama, vLLM, LM Studio, ...). Those models tend to imitate the full
+// prompt's inline JSX examples as plain text instead of emitting tool calls,
+// leaving the canvas empty. Give them a compact, tool-forcing prompt instead.
+const COMPACT_PROMPT_PROVIDERS = new Set<AIProviderID>([
+  'openai-compatible',
+  'anthropic-compatible'
+])
+
+function systemPromptFor(providerID: AIProviderID): string {
+  return COMPACT_PROMPT_PROVIDERS.has(providerID) ? COMPACT_SYSTEM_PROMPT : SYSTEM_PROMPT
+}
 
 type ChatSessionOptions = {
   isConfigured: ComputedRef<boolean>
@@ -84,7 +98,7 @@ export function createToolLoopTransport({
       customBaseURL,
       customAPIType
     }),
-    instructions: SYSTEM_PROMPT,
+    instructions: systemPromptFor(providerID),
     tools,
     stopWhen: stepCountIs(MAX_AGENT_STEPS),
     maxOutputTokens,


### PR DESCRIPTION
## Problem

The design system prompt (`system-prompt.md`) is rich with inline JSX examples and a multi-phase "plan in text first" workflow. Frontier models follow it well, but **smaller / self-hosted models** reached through the **OpenAI-compatible** and **Anthropic-compatible** providers (Ollama, vLLM, LM Studio, ...) tend to **imitate the JSX examples as plain text** instead of emitting tool calls. The result: the chat narrates a whole design, the tool log shows nothing, and **the canvas stays empty**.

I hit this running OpenPencil against a local Ollama (`qwen2.5:7b`/`14b`) endpoint via the OpenAI-compatible provider. Reproduced the "narrate-instead-of-call" behavior consistently with the full prompt; a short, tool-forcing prompt fixed it.

## Change

Add a compact, tool-forcing system prompt (`system-prompt-compact.md`) and use it **only** for the `openai-compatible` and `anthropic-compatible` providers — the "bring-your-own-endpoint" providers that are typically pointed at local/smaller models. It keeps the props/layout rules but:

- forbids narrating JSX as text — forces immediate `render` tool calls
- builds the whole screen inline in `render` and avoids ID-dependent modify tools (`set_layout`/`batch_update`/...) that small models can't reliably target (they hallucinate node IDs)
- avoids `<Icon>` and non-existent components (`<Button>`, `<Input>`, ...) whose guessed names throw `Icon "x" not found` / `X is not defined` and fail the whole render — uses primitive recipes instead
- requires a concrete root size and uses solid-color placeholders instead of the `stock_photo` tool (which needs an API key that may not be configured)

**Behavior for the hosted providers (OpenRouter / Anthropic / OpenAI / Google / ...) is unchanged** — they keep the full prompt.

## Why route by provider (and not a toggle)

The compatible providers exist specifically for custom endpoints, which are overwhelmingly local/smaller models, so this is a sensible default with no UI/i18n surface. If maintainers would rather make it an explicit opt-in toggle in Provider Settings, I'm happy to follow up with that instead.

## Testing

- Verified against a live Ollama OpenAI-compatible endpoint: with the full prompt the model narrated JSX and never called tools; with the compact prompt it calls `render` and the design appears on the canvas.
- Headless-validated generated JSX through `renderJSX` to confirm the guardrails remove the throwing cases (bad icon names, undefined components).
- `oxlint` clean; `check:i18n` in sync (no i18n changes); app builds/serves.

## Files

- `src/app/ai/chat/system-prompt-compact.md` (new)
- `src/app/ai/chat/transports.ts` — pick the compact prompt for compatible providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized AI assistant performance in the vector design editor with provider-specific configurations to enhance tool execution consistency and reduce unnecessary text output during design sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->