### PR TITLE
Emit event on vectorNetwork update in preview

### DIFF
--- a/packages/core/src/scene-graph/index.ts
+++ b/packages/core/src/scene-graph/index.ts
@@ -360,6 +360,9 @@ export class SceneGraph {
   }
   updateNodePreview(id: string, changes: Partial<SceneNode>): void {
     updateNodePreview(this, id, changes)
+    if(changes?.vectorNetwork){
+      this.emitter.emit('node:updated', id, changes)
+    }
   }
   updateNode(id: string, changes: Partial<SceneNode>): void {
     if (this.previewMutationDepth > 0) {


### PR DESCRIPTION
Emit 'node:updated' event when vectorNetwork changes.

> Security vulnerability? Do not open a public PR. Report it privately through GitHub Security Advisories: https://github.com/open-pencil/open-pencil/security/advisories/new

Before opening a PR, read `CONTRIBUTING.md` and `AGENTS.md`. PRs should explain the intent, meaningful changes, and validation. Placeholder, non-English, unrelated, or otherwise unreviewable PRs may be closed by maintainers.

### Summary

<!-- Explain what this PR changes and why. Remove this comment before opening. -->

### What changed

- Add a concise summary here.

### Validation

- [ ] `bun run check`
- [ ] Tests added or updated, or not needed because: explain here
- [ ] CHANGELOG.md updated, or not needed because: explain here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event emission for vector network changes in node preview updates. The `node:updated` event is now properly triggered when vector network changes are detected, ensuring consistent notification behavior across all change types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->