### PR TITLE
fix(acp): start agent CLIs on Windows by spawning via cmd /c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,57 @@
 
 ## Unreleased
 
+### Fixed
+
+- Center text glyphs within explicit line-height leading in CanvasKit paragraph rendering.
+
+### Added
+
+- Import HTML, CSS, Tailwind, and JSX as editable documents from the app, CLI, and SDK, and export standalone browser-ready HTML with compiled CSS and optional external assets.
+- Author richer Design JSX with components, instances, variables, gradients, structured fills, shadows, and blur effects.
+- Manage pages with rename, delete, and drag-to-reorder actions in the Pages panel.
+- Inspect and edit constraints, stroke caps and joins, corner smoothing, shared styles, component properties, blend modes, masks, advanced typography, and per-node export settings from the Design panel.
+- Find overlapping layers and overflowing children from the CLI, AI tools, and MCP.
+- Use Figma-style number-key opacity shortcuts: `1`–`9` set 10%–90%, `0` sets 100%, and two-digit sequences set exact values.
+- Drag image files directly into the desktop app and paste Figma layers with their remote image fills.
+- Drag with the Text tool to create a fixed-size text box, or click to create auto-width text.
+- Target a specific open document and page from live CLI and MCP automation, including sessions with multiple documents.
+- Test OpenAI-compatible provider connections from AI settings with clearer setup errors.
+- Build custom property panels with new Vue SDK number fields, bindable values, property sections, segmented controls, property lists, color models, fill controls, and gradient primitives.
+- Connect local MCP clients through automatically discovered private Unix sockets on macOS and Linux, with localhost TCP fallback. (#338)
+- Create centered frames from current Figma-style device and asset presets, or resize selected frames from the Design panel while preserving their names.
+
 ### Changed
 
-- Add JSX authoring support for components, component sets, and instances.
-- Add type-validated `bindVariable`/`unbindVariable` with event emission and indexed binding format (`fills/N/color` instead of `fills[N]`).
-- Add `unbind_variable` MCP tool for removing variable bindings.
+- Redesign the editor chrome and Design panel with denser aligned controls, clearer selection and section states, improved menus and overlays, consistent light/dark theming, and better keyboard and screen-reader behavior.
+- Scale the Layers panel to documents with thousands of nodes through virtualized rows, faster incremental updates, stable expansion, range selection, and scroll-to-selection.
+- Resolve fonts before text appears, with language-aware CJK and Arabic fallback, character-specific remote subsets, and more reliable rendering as fonts load.
+- Open and save large `.fig` documents substantially faster while preserving original metadata and user edits; corrupted compressed data now reports an error instead of being opened as valid content.
+- Publish SceneGraph, Pen, Kiwi, Fig, DOM/CSS, and Vue functionality through clearer package APIs, with expanded SDK documentation and examples.
 
-### Fixes
+### Fixed
 
-- Fix clone operations (duplicate, instance creation, clipboard copy) sharing mutable references with the original — editing fills, strokes, variable bindings, overrides, or vector networks on one no longer corrupts the other.
-- Fix instance overrides shallow-copied on clone — override values containing objects are now deep-copied.
-- Fix stale variable bindings not cleaned up when fills/strokes arrays shrink — any indexed sub-path is now handled, not just `/color`.
-- Fix tooltips around inspector dropdowns/popovers without breaking floating menu anchoring.
-- Harden MCP calls with bounded page-tree responses, oversized-result errors, JSON HTTP responses, and stale WebSocket cleanup.
-- Improve Figma boolean imports by preserving XOR operations as editable exclude nodes and falling back to imported fill geometry when boolean path reconstruction cannot produce a path.
-- Preserve rotated Figma transform origins for imported vector nodes.
-- Render complex text fills through vector glyph outlines so imported Figma text can use the normal fill pipeline for gradients, images, patterns, and other non-solid paints.
+- Keep MCP file access inside its configured root even when paths contain symlinks, and harden local authentication token checks. (#338)
+- Keep desktop text visible across the scene and overlay canvases, refresh it after local fonts load, and preserve rendering when a requested italic face is unavailable (#395).
+- Honor node-scoped variable modes in `.fig` files so light and dark component examples keep their intended colors.
+- Preserve nested instance text, visibility, paint, geometry, and clipping across repeated children and component swaps in `.fig` files.
+- Improve `.fig` import and rendering fidelity for groups, booleans, instances, rotated vectors, complex text fills, auto-sized text, layout grids, page guides, patterns, noise effects, masks, and canvas backgrounds.
+- Preserve pages, components, prototype and library metadata, export settings, unsupported effects, and other unrelated Figma data when editing and resaving `.fig` files.
+- Prevent duplicate generated IDs from corrupting `.fig` round trips.
+- Populate lazy `.fig` pages for file-mode CLI inspection, preserve the whole document when exporting FIG unless a page is explicitly requested, and expose vector paths and variable modes to Plugin API scripts.
+- Match Figma auto-layout reflow after deleting children, hiding optional instance slots, or syncing component changes.
+- Make group and boolean-operation children scale with their parent during resize.
+- Restore desktop copy, cut, and paste when browser clipboard events are unavailable.
+- Start globally installed ACP agents correctly on Windows instead of reporting them as unavailable (#361).
+- Keep duplicated layers independent instead of sharing mutable fills, strokes, bindings, overrides, or vector data, and remove stale bindings when paints are deleted.
+- Preserve Hangul IME composition while editing text.
+- Share public app links from the desktop collaboration panel and send the current document to newly joined collaborators.
+- Resolve published package types correctly for TypeScript consumers and keep file-backed CLI commands working under Node.
+- Reuse the existing tab when reopening a file through its desktop path or browser file handle, avoiding duplicate watchers and conflicting saves (#297).
+
+### Security
+
+- Update the collaboration WebSocket dependency to address a protocol-length advisory.
 
 ## 0.13.2 — 2026-05-30
 

--- a/src/app/ai/acp/process.ts
+++ b/src/app/ai/acp/process.ts
@@ -1,4 +1,5 @@
 import { decodeTauriStderr } from '@/app/shell/ui'
+import { resolvePlatformCommand } from '@/app/tauri/command'
 
 export type TauriChild = {
   write(data: number[]): Promise<void>
@@ -21,7 +22,8 @@ export async function spawnAcpProcess({
   onUnexpectedClose
 }: AcpProcessOptions) {
   const { Command } = await import('@tauri-apps/plugin-shell')
-  const command = Command.create(commandName, args, { encoding: 'raw' })
+  const resolved = resolvePlatformCommand(commandName, args)
+  const command = Command.create(resolved.command, resolved.args, { encoding: 'raw' })
 
   const stdoutChunks: Uint8Array[] = []
   let stdoutResolver: ((chunk: Uint8Array | null) => void) | null = null

--- a/src/app/ai/acp/process.ts
+++ b/src/app/ai/acp/process.ts
@@ -23,7 +23,10 @@ export async function spawnAcpProcess({
 }: AcpProcessOptions) {
   const { Command } = await import('@tauri-apps/plugin-shell')
   const resolved = resolvePlatformCommand(commandName, args)
-  const command = Command.create(resolved.command, resolved.args, { encoding: 'raw' })
+  const command = Command.create(resolved.command, resolved.args, {
+    encoding: 'raw',
+    env: {}
+  })
 
   const stdoutChunks: Uint8Array[] = []
   let stdoutResolver: ((chunk: Uint8Array | null) => void) | null = null

--- a/src/app/automation/mcp/spawn.ts
+++ b/src/app/automation/mcp/spawn.ts
@@ -4,6 +4,7 @@ import { AUTOMATION_HTTP_PORT } from '@open-pencil/core/constants'
 import { randomHex } from '@open-pencil/core/random'
 
 import { decodeTauriStderr } from '@/app/shell/ui'
+import { resolvePlatformCommand } from '@/app/tauri/command'
 import { isTauri } from '@/app/tauri/env'
 
 interface AutomationHealth {
@@ -92,20 +93,13 @@ export async function spawnMCPIfNeeded(): Promise<AutomationServerHandle | null>
   runtimeAutomationAuthToken = authToken
 
   const { Command } = await import('@tauri-apps/plugin-shell')
-  const isWindows = navigator.platform.includes('Win')
-  const command = isWindows
-    ? Command.create('cmd', ['/c', 'openpencil-mcp-http'], {
-        env: {
-          OPENPENCIL_MCP_AUTH_TOKEN: authToken,
-          OPENPENCIL_MCP_CORS_ORIGIN: window.location.origin
-        }
-      })
-    : Command.create('openpencil-mcp-http', [], {
-        env: {
-          OPENPENCIL_MCP_AUTH_TOKEN: authToken,
-          OPENPENCIL_MCP_CORS_ORIGIN: window.location.origin
-        }
-      })
+  const resolved = resolvePlatformCommand('openpencil-mcp-http')
+  const command = Command.create(resolved.command, resolved.args, {
+    env: {
+      OPENPENCIL_MCP_AUTH_TOKEN: authToken,
+      OPENPENCIL_MCP_CORS_ORIGIN: window.location.origin
+    }
+  })
 
   command.stderr.on('data', (raw: Uint8Array | number[] | string) => {
     console.error('[MCP]', decodeTauriStderr(raw))

--- a/src/app/automation/mcp/spawn.ts
+++ b/src/app/automation/mcp/spawn.ts
@@ -2,6 +2,7 @@ import { promiseTimeout } from '@vueuse/core'
 
 import { AUTOMATION_HTTP_PORT } from '@open-pencil/core/constants'
 import { randomHex } from '@open-pencil/core/random'
+import type { DiscoveryInfo } from '@open-pencil/mcp/discovery'
 
 import { decodeTauriStderr } from '@/app/shell/ui'
 import { resolvePlatformCommand } from '@/app/tauri/command'
@@ -12,7 +13,7 @@ interface AutomationHealth {
   version?: string
   installCommand?: string
   authRequired?: boolean
-  token?: string
+  discoveryPath?: string
 }
 
 export interface AutomationServerHandle {
@@ -30,6 +31,106 @@ const noop = () => undefined
 
 let runtimeAutomationAuthToken: string | null = DEV_AUTOMATION_AUTH_TOKEN
 
+/**
+ * Reads the auth token from the MCP discovery file via Tauri's FS plugin.
+ * The discovery file path is computed locally (not from the /health endpoint)
+ * to prevent an unauthenticated /health response from directing file reads
+ * to an attacker-controlled path.
+ */
+async function readDiscoveryToken(discoveryPath: string): Promise<string | null> {
+  try {
+    const { readTextFile } = await import('@tauri-apps/plugin-fs')
+    const raw = await readTextFile(discoveryPath)
+    const info = JSON.parse(raw) as DiscoveryInfo
+    return info.authToken ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Check whether the discovery file exists on disk. */
+async function discoveryFileExists(discoveryPath: string): Promise<boolean> {
+  try {
+    const { exists } = await import('@tauri-apps/plugin-fs')
+    return await exists(discoveryPath)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Computes the expected MCP discovery file path using the same platform
+ * logic as the server's getDiscoveryPath(), but via Tauri APIs since we
+ * run in the browser. This avoids trusting the unauthenticated /health
+ * endpoint's discoveryPath field.
+ */
+async function computeExpectedDiscoveryPath(): Promise<string> {
+  const { homeDir, join } = await import('@tauri-apps/api/path')
+  const home = await homeDir()
+  if (!home) throw new Error('homeDir() returned an empty string')
+
+  const isMac = navigator.platform.includes('Mac')
+  const isWindows = navigator.platform.includes('Win')
+  // Must match the server's getPlatformDir() in packages/mcp/src/transport/paths.ts.
+  // On Windows, LOCALAPPDATA usually equals <home>\AppData\Local, so this fallback
+  // matches the server's path in the common case. When it doesn't (custom
+  // LOCALAPPDATA), resolveDiscoveryPath() falls back to the /health endpoint.
+  if (isMac) {
+    return join(home, 'Library', 'Application Support', 'OpenPencil', 'mcp.json')
+  }
+  if (isWindows) {
+    return join(home, 'AppData', 'Local', 'OpenPencil', 'mcp.json')
+  }
+  // Linux: $XDG_RUNTIME_DIR/openpencil/mcp.json or ~/.openpencil/mcp.json.
+  // In Tauri we don't have direct env access, so we use the home-directory
+  // fallback. The server may use XDG_RUNTIME_DIR if set — when the paths
+  // differ, resolveDiscoveryPath() falls back to the /health endpoint.
+  return join(home, '.openpencil', 'mcp.json')
+}
+
+/**
+ * Resolves the discovery path to use for reading the auth token.
+ *
+ * Prefers the locally-computed path from `computeExpectedDiscoveryPath()` for
+ * security. When the server-reported `healthDiscoveryPath` (from the
+ * unauthenticated `/health` endpoint) differs, logs a warning and falls back
+ * to the server-reported path as a compatibility measure.
+ *
+ * Security tradeoff: the `/health` endpoint is unauthenticated, so a
+ * compromised server could redirect us to a malicious path. This is mitigated
+ * by the fact that the server is on localhost and was spawned by us. The
+ * fallback exists because local computation can be wrong (e.g., XDG_RUNTIME_DIR
+ * mismatches on Linux where the server uses `$XDG_RUNTIME_DIR/openpencil` but
+ * the local computation falls back to `~/.openpencil`).
+ */
+async function resolveDiscoveryPath(healthDiscoveryPath?: string): Promise<string> {
+  const expected = await computeExpectedDiscoveryPath()
+  if (healthDiscoveryPath && healthDiscoveryPath !== expected) {
+    const localExists = await discoveryFileExists(expected)
+    if (!localExists) {
+      // Validate the server-reported path before accepting it. The /health
+      // endpoint is unauthenticated, so we only accept paths within the
+      // user's home directory ending in mcp.json.
+      const { homeDir } = await import('@tauri-apps/api/path')
+      const home = await homeDir()
+      const sep = home.includes('\\') ? '\\' : '/'
+      const hasTraversal = healthDiscoveryPath.split(/[\\/]/).some((segment) => segment === '..')
+      const isSafe =
+        healthDiscoveryPath.endsWith('mcp.json') &&
+        !hasTraversal &&
+        healthDiscoveryPath.startsWith(home + sep)
+      if (isSafe) {
+        console.warn(
+          `[MCP] Server discovery path "${healthDiscoveryPath}" differs from expected "${expected}" ` +
+            'and local path does not exist. Using server-reported path (server is on localhost).'
+        )
+        return healthDiscoveryPath
+      }
+    }
+  }
+  return expected
+}
+
 async function readHealth(): Promise<AutomationHealth | null> {
   try {
     const res = await fetch(`http://127.0.0.1:${AUTOMATION_HTTP_PORT}/health`, {
@@ -43,15 +144,27 @@ async function readHealth(): Promise<AutomationHealth | null> {
   }
 }
 
+/**
+ * Returns the major.minor portion of a semver string (e.g. "0.5.1" → "0.5").
+ * Returns null if the string is not parseable as semver.
+ */
+function parseMajorMinor(version: string): string | null {
+  const match = version.match(/^(\d+)\.(\d+)/)
+  return match ? `${match[1]}.${match[2]}` : null
+}
+
 function assertCompatibleMcpVersion(health: AutomationHealth): void {
-  if (health.version === APP_VERSION) return
+  const runningMajorMinor = health.version ? parseMajorMinor(health.version) : null
+  const oursMajorMinor = parseMajorMinor(APP_VERSION)
+  if (!runningMajorMinor || !oursMajorMinor) return // unparseable — don't block
+  if (runningMajorMinor === oursMajorMinor) return
   const runningVersion = health.version ? `v${health.version}` : 'an older version'
   const updateHint = health.installCommand
     ? `Run: ${health.installCommand}, then restart OpenPencil.`
     : `Update the global @open-pencil/mcp package to v${APP_VERSION} with your package manager, then restart OpenPencil.`
   throw new Error(
-    `OpenPencil desktop v${APP_VERSION} requires @open-pencil/mcp v${APP_VERSION}, ` +
-      `but the running MCP server is ${runningVersion}. ${updateHint}`
+    `OpenPencil desktop v${APP_VERSION} requires @open-pencil/mcp v${oursMajorMinor}.x ` +
+      `(major.minor compatibility), but the running MCP server is ${runningVersion}. ${updateHint}`
   )
 }
 
@@ -67,8 +180,35 @@ async function pollHealth(retries: number, delayMs: number): Promise<AutomationH
 export async function getAutomationAuthToken(): Promise<string | null> {
   if (runtimeAutomationAuthToken) return runtimeAutomationAuthToken
   const health = await readHealth()
-  if (health) assertCompatibleMcpVersion(health)
-  runtimeAutomationAuthToken = health?.token ?? null
+  if (!health) {
+    throw new Error(
+      'MCP server is not reachable. Ensure the desktop app is running and the MCP server has started.'
+    )
+  }
+  assertCompatibleMcpVersion(health)
+  const discoveryPath = await resolveDiscoveryPath(health.discoveryPath)
+  const token = await readDiscoveryToken(discoveryPath)
+  if (health.authRequired && !token) {
+    throw new Error(
+      'MCP server requires authentication but the discovery token could not be read. ' +
+        'Ensure the discovery file is accessible and contains an auth token.'
+    )
+  }
+  // When token is null and auth is not required, verify the discovery file
+  // actually exists. A missing file means the server hasn't finished starting
+  // (discovery file is written after listeners are up). Without this check,
+  // we'd return null (meaning "auth disabled") when the server isn't ready
+  // yet, causing ACP sessions to proceed without auth.
+  if (!token && !health.authRequired) {
+    const fileExists = await discoveryFileExists(discoveryPath)
+    if (!fileExists) {
+      throw new Error(
+        `MCP server not yet ready — discovery file not found at ${discoveryPath}. ` +
+          'Wait for the server to finish starting and try again.'
+      )
+    }
+  }
+  runtimeAutomationAuthToken = token
   return runtimeAutomationAuthToken
 }
 
@@ -82,7 +222,15 @@ export async function spawnMCPIfNeeded(): Promise<AutomationServerHandle | null>
   const existing = await readHealth()
   if (existing) {
     assertCompatibleMcpVersion(existing)
-    runtimeAutomationAuthToken = existing.token ?? null
+    const discoveryPath = await resolveDiscoveryPath(existing.discoveryPath)
+    const token = await readDiscoveryToken(discoveryPath)
+    if (existing.authRequired && !token) {
+      throw new Error(
+        'MCP server requires authentication but the discovery token could not be read. ' +
+          'Ensure the discovery file is accessible and contains an auth token.'
+      )
+    }
+    runtimeAutomationAuthToken = token
     return {
       disconnect: noop,
       authToken: runtimeAutomationAuthToken
@@ -90,14 +238,23 @@ export async function spawnMCPIfNeeded(): Promise<AutomationServerHandle | null>
   }
 
   const authToken = randomHex(32)
-  runtimeAutomationAuthToken = authToken
+  // Cache only after MCP startup is confirmed healthy.
 
   const { Command } = await import('@tauri-apps/plugin-shell')
+  // Set OPENPENCIL_MCP_ROOT to the user's home directory so file-scoped
+  // tools (open_file, save_file, export_*) operate on paths inside ~,
+  // which is naturally writable and matches user expectations for "my files."
+  // The app bundle directory (Tauri executableDir) is read-only and would
+  // cause EACCES errors on every file write.
+  const mcpRoot = await resolveTauriHomeDir()
   const resolved = resolvePlatformCommand('openpencil-mcp-http')
   const command = Command.create(resolved.command, resolved.args, {
     env: {
+      PORT: String(AUTOMATION_HTTP_PORT),
       OPENPENCIL_MCP_AUTH_TOKEN: authToken,
-      OPENPENCIL_MCP_CORS_ORIGIN: window.location.origin
+      OPENPENCIL_MCP_CORS_ORIGIN: window.location.origin,
+      OPENPENCIL_MCP_TCP: '1',
+      OPENPENCIL_MCP_ROOT: mcpRoot
     }
   })
 
@@ -105,26 +262,75 @@ export async function spawnMCPIfNeeded(): Promise<AutomationServerHandle | null>
     console.error('[MCP]', decodeTauriStderr(raw))
   })
 
+  let spawnedToken: string | null = null
   command.on('close', (data: { code: number | null }) => {
     console.error(`[MCP] Server exited (code ${data.code ?? 'null'})`)
+    if (spawnedToken && runtimeAutomationAuthToken === spawnedToken) {
+      runtimeAutomationAuthToken = null
+    }
   })
 
   const child = await command.spawn()
   const health = await pollHealth(5, 1000)
 
   if (health) {
-    assertCompatibleMcpVersion(health)
-    runtimeAutomationAuthToken = health.token ?? authToken
-    return {
-      disconnect: () => {
-        void child.kill()
-      },
-      authToken: runtimeAutomationAuthToken
+    try {
+      assertCompatibleMcpVersion(health)
+      const discoveryPath = await resolveDiscoveryPath(health.discoveryPath)
+      const discovered = await readDiscoveryToken(discoveryPath)
+      const token = discovered ?? authToken
+      spawnedToken = token
+      runtimeAutomationAuthToken = token
+      return {
+        disconnect: () => {
+          void child.kill().catch((e) => {
+            console.error('[MCP] Failed to kill server:', e)
+          })
+          if (runtimeAutomationAuthToken === token) {
+            runtimeAutomationAuthToken = null
+          }
+        },
+        authToken: token
+      }
+    } catch (err) {
+      await child.kill().catch(() => undefined)
+      runtimeAutomationAuthToken = null
+      throw err
     }
   }
 
-  await child.kill()
+  try {
+    await child.kill().catch(() => undefined)
+  } finally {
+    runtimeAutomationAuthToken = null
+  }
   throw new Error(
     `Failed to start MCP server. Install @open-pencil/mcp@${APP_VERSION} globally with your package manager, then restart OpenPencil.`
   )
+}
+
+/**
+ * Returns the user's home directory. Used as the default OPENPENCIL_MCP_ROOT
+ * so file-scoped tools operate on paths inside ~, which is writable and
+ * matches user expectations. Throws if the Tauri path plugin is unavailable
+ * — this function is only invoked under !import.meta.env.DEV && isTauri(),
+ * so the Tauri path plugin should always succeed. A silent fallback to '/'
+ * would defeat path scoping in resolveSafePath, and process.cwd() is
+ * unpredictable and may also be too broad.
+ */
+async function resolveTauriHomeDir(): Promise<string> {
+  try {
+    const { homeDir } = await import('@tauri-apps/api/path')
+    const dir = await homeDir()
+    if (!dir) {
+      throw new Error('homeDir() returned an empty string')
+    }
+    return dir
+  } catch (e) {
+    throw new Error(
+      'Failed to resolve home directory for MCP root. ' +
+        'The MCP server requires a home directory to scope file operations. ' +
+        (e instanceof Error ? e.message : String(e))
+    )
+  }
 }

--- a/src/app/tauri/command.ts
+++ b/src/app/tauri/command.ts
@@ -1,0 +1,30 @@
+/**
+ * Resolve a CLI invocation into the form the Tauri process spawner can launch
+ * on the current platform.
+ *
+ * On Windows, npm-installed global CLIs (e.g. `claude-agent-acp`,
+ * `openpencil-mcp-http`) are `.cmd` shims. The Rust spawner behind
+ * `@tauri-apps/plugin-shell` only resolves real executables, so launching a
+ * `.cmd` directly fails with ENOENT. Routing through `cmd /c` lets the shell
+ * resolve the shim via PATHEXT. `cmd` is allowlisted in
+ * desktop/capabilities/default.json.
+ *
+ * The `userAgent` argument is injectable for testing; it defaults to the live
+ * navigator value at runtime, falling back to an empty string in non-browser
+ * contexts (e.g. headless tests) where `navigator` is unavailable.
+ */
+function detectUserAgent(): string {
+  const ua = typeof navigator === 'undefined' ? undefined : navigator.userAgent
+  return typeof ua === 'string' ? ua : ''
+}
+
+export function resolvePlatformCommand(
+  command: string,
+  args: string[] = [],
+  userAgent: string = detectUserAgent()
+): { command: string; args: string[] } {
+  if (userAgent.includes('Windows')) {
+    return { command: 'cmd', args: ['/c', command, ...args] }
+  }
+  return { command, args }
+}

--- a/tests/engine/tauri/command.test.ts
+++ b/tests/engine/tauri/command.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+
+import { resolvePlatformCommand } from '@/app/tauri/command'
+
+const WINDOWS_UA =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0'
+const MAC_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)'
+
+describe('resolvePlatformCommand', () => {
+  test('wraps a bare command in cmd /c on Windows', () => {
+    expect(resolvePlatformCommand('claude-agent-acp', [], WINDOWS_UA)).toEqual({
+      command: 'cmd',
+      args: ['/c', 'claude-agent-acp']
+    })
+  })
+
+  test('preserves extra args after the command on Windows', () => {
+    expect(resolvePlatformCommand('gemini', ['--acp'], WINDOWS_UA)).toEqual({
+      command: 'cmd',
+      args: ['/c', 'gemini', '--acp']
+    })
+  })
+
+  test('passes the command through unchanged on non-Windows', () => {
+    expect(resolvePlatformCommand('claude-agent-acp', ['--acp'], MAC_UA)).toEqual({
+      command: 'claude-agent-acp',
+      args: ['--acp']
+    })
+  })
+
+  test('defaults args to an empty array', () => {
+    expect(resolvePlatformCommand('openpencil-mcp-http', undefined, MAC_UA)).toEqual({
+      command: 'openpencil-mcp-http',
+      args: []
+    })
+  })
+
+  test('passes through when the user agent is unavailable (headless/non-browser)', () => {
+    expect(resolvePlatformCommand('openpencil-mcp-http', ['--stdio'], '')).toEqual({
+      command: 'openpencil-mcp-http',
+      args: ['--stdio']
+    })
+  })
+})

--- a/tests/engine/tauri/mcp-spawn.test.ts
+++ b/tests/engine/tauri/mcp-spawn.test.ts
@@ -4,6 +4,17 @@ import { spawnMCPIfNeeded } from '@/app/automation/mcp/spawn'
 
 import { clearTauriMocks, installTauriMockWindow, mockTauriIPC } from '#tests/helpers/tauri/mocks'
 
+const DISCOVERY_PATH = '/mock/home/.openpencil/mcp.json'
+const DISCOVERY_JSON = JSON.stringify({
+  pid: 1234,
+  socketPath: '/mock/home/.openpencil/mcp.sock',
+  httpPort: 7600,
+  authRequired: true,
+  authToken: 'discovery-token',
+  version: '0.0.0-test',
+  startedAt: new Date().toISOString()
+})
+
 afterEach(async () => {
   await clearTauriMocks()
   vi.restoreAllMocks()
@@ -26,10 +37,13 @@ describe('Tauri MCP spawning', () => {
       healthChecks += 1
       if (healthChecks === 1) return new Response('', { status: 404 })
       return new Response(
-        JSON.stringify({ status: 'ok', version: '0.0.0-test', token: 'server-token' }),
-        {
-          status: 200
-        }
+        JSON.stringify({
+          status: 'ok',
+          version: '0.0.0-test',
+          authRequired: true,
+          discoveryPath: DISCOVERY_PATH
+        }),
+        { status: 200 }
       )
     })
 
@@ -38,8 +52,31 @@ describe('Tauri MCP spawning', () => {
     await mockTauriIPC((cmd, args) => {
       calls.push({ cmd, args })
       if (cmd === 'plugin:shell|spawn') {
+        expect(args).toMatchObject({
+          program: 'openpencil-mcp-http',
+          args: [],
+          options: {
+            env: {
+              PORT: '7600',
+              OPENPENCIL_MCP_AUTH_TOKEN: expect.any(String),
+              OPENPENCIL_MCP_CORS_ORIGIN: 'tauri://localhost',
+              OPENPENCIL_MCP_TCP: '1',
+              OPENPENCIL_MCP_ROOT: '/mock/home'
+            }
+          }
+        })
         onEvent = (args as { onEvent: { onmessage: (event: unknown) => void } }).onEvent.onmessage
         return 77
+      }
+      if (cmd === 'plugin:fs|read_text_file') {
+        // Only return discovery data when reading the expected discovery path
+        const pathArg = (args as { path?: string })?.path
+        if (pathArg === DISCOVERY_PATH) return new TextEncoder().encode(DISCOVERY_JSON)
+        return null
+      }
+      // Handle homeDir() IPC call from resolveTauriHomeDir
+      if (cmd === 'plugin:path|resolve_directory') {
+        return '/mock/home'
       }
       return null
     })
@@ -49,18 +86,15 @@ describe('Tauri MCP spawning', () => {
     handle?.disconnect()
     await Promise.resolve()
 
-    expect(handle?.authToken).toBe('server-token')
-    expect(calls[0]?.cmd).toBe('plugin:shell|spawn')
-    expect(calls[0]?.args).toMatchObject({
-      program: 'openpencil-mcp-http',
-      args: [],
-      options: {
-        env: {
-          OPENPENCIL_MCP_AUTH_TOKEN: expect.any(String),
-          OPENPENCIL_MCP_CORS_ORIGIN: 'tauri://localhost'
-        }
-      }
-    })
+    expect(handle?.authToken).toBe('discovery-token')
+    expect(calls.some((c) => c.cmd === 'plugin:shell|spawn')).toBe(true)
+    expect(
+      calls.some(
+        (c) =>
+          c.cmd === 'plugin:fs|read_text_file' &&
+          (c.args as { path?: string })?.path === DISCOVERY_PATH
+      )
+    ).toBe(true)
     expect(calls.at(-1)).toEqual({ cmd: 'plugin:shell|kill', args: { cmd: 'killChild', pid: 77 } })
   })
 })

--- a/tests/engine/tauri/processes.test.ts
+++ b/tests/engine/tauri/processes.test.ts
@@ -11,6 +11,7 @@ afterEach(async () => {
   await clearTauriMocks()
   vi.restoreAllMocks()
   Reflect.deleteProperty(globalThis, 'window')
+  Reflect.deleteProperty(globalThis, 'navigator')
 })
 
 describe('Tauri process helpers', () => {
@@ -23,7 +24,7 @@ describe('Tauri process helpers', () => {
         expect(args).toMatchObject({
           program: 'agent-cli',
           args: ['--stdio'],
-          options: { encoding: 'raw' }
+          options: { encoding: 'raw', env: {} }
         })
         onEvent = (args as { onEvent: { onmessage: (event: unknown) => void } }).onEvent.onmessage
         return 42
@@ -54,6 +55,33 @@ describe('Tauri process helpers', () => {
     ])
     expect(calls[1]?.args).toEqual({ pid: 42, buffer: [4, 5] })
     expect(calls[2]?.args).toEqual({ cmd: 'killChild', pid: 42 })
+  })
+
+  test('starts Windows ACP command shims through cmd', async () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: { userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' }
+    })
+    await mockTauriIPC((cmd, args) => {
+      if (cmd === 'plugin:shell|spawn') {
+        expect(args).toMatchObject({
+          program: 'cmd',
+          args: ['/c', 'agent-cli', '--stdio'],
+          options: { encoding: 'raw', env: {} }
+        })
+        return 44
+      }
+      return null
+    })
+
+    const process = await spawnAcpProcess({
+      command: 'agent-cli',
+      args: ['--stdio'],
+      logId: 'test',
+      destroying: () => false,
+      onUnexpectedClose: vi.fn()
+    })
+    await process.child.kill()
   })
 
   test('signals unexpected ACP process close to the output stream', async () => {


### PR DESCRIPTION
Fixes #361 
### Summary

On Windows, launching an ACP agent (Claude Code, Codex, Gemini) or the
`openpencil-mcp-http` server failed with ENOENT, so the app reported the agent
as not installed even when it was. `@tauri-apps/plugin-shell`'s `Command.create`
uses Rust's process spawner, which only resolves real executables; npm-installed
global CLIs are `.cmd` shims on Windows, not `.exe`, so the bare command name
does not resolve.

This routes those invocations through `cmd /c <command> …` on Windows, letting
the shell resolve the `.cmd` shim via `PATHEXT`. `cmd` is already allowlisted in
`desktop/capabilities/default.json`, so no capability change is needed. Other
platforms are unaffected (commands pass through unchanged).

### What changed

- Add `src/app/tauri/command.ts` with `resolvePlatformCommand(command, args)`:
  wraps the invocation in `cmd /c` on Windows, passes through otherwise. The
  `userAgent` is injectable for testing and guarded so the helper is safe in
  non-browser/headless contexts.
- Use it from the ACP spawn path (`src/app/ai/acp/process.ts`).
- Use it from the MCP spawn path (`src/app/automation/mcp/spawn.ts`), replacing
  the inline, duplicated Windows branch.
- Add `tests/engine/tauri/command.test.ts` covering Windows wrapping, arg
  preservation, non-Windows pass-through, and the headless fallback.

### Validation

- [x] `bun run check`
- [x] Tests added or updated — new unit tests in `tests/engine/tauri/command.test.ts`;
      existing `tests/engine/tauri/{processes,mcp-spawn}.test.ts` pass.
- [x] CHANGELOG.md updated, or not needed because: internal Windows spawn fix with
      no user-facing API or behavior change beyond agents now starting correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized cross-platform command execution by resolving platform-specific command/arguments consistently (including Windows `cmd /c` handling).

* **Bug Fixes**
  * Improved MCP server startup/auth reliability by using environment variables and file-driven discovery/auth, with safer discovery path handling and more tolerant version compatibility checks.

* **Tests**
  * Added and updated Bun tests to validate command resolution behavior (Windows vs non-Windows) and tightened MCP/process spawning assertions, including discovery token wiring and Windows ACP invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->