### PR TITLE
Add Requesty as an AI provider

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -174,6 +174,7 @@ export const ACP_AGENTS: ACPAgentDef[] = [
 
 export type AIProviderID =
   | 'openrouter'
+  | 'requesty'
   | 'anthropic'
   | 'openai'
   | 'google'
@@ -224,6 +225,20 @@ export const AI_PROVIDERS: AIProviderDef[] = [
       { id: 'qwen/qwen3.5-flash-02-23', name: 'Qwen 3.5 Flash', tag: 'Cheap' },
       { id: 'qwen/qwen3-coder:free', name: 'Qwen3 Coder', tag: 'Free' },
       { id: 'openai/gpt-oss-120b:free', name: 'GPT-OSS 120B', tag: 'Free' }
+    ]
+  },
+  {
+    id: 'requesty',
+    name: 'Requesty',
+    keyPlaceholder: 'rqsty-sk-…',
+    keyURL: 'https://app.requesty.ai/api-keys',
+    defaultModel: 'anthropic/claude-sonnet-4-5',
+    supportsCustomModel: true,
+    models: [
+      { id: 'anthropic/claude-sonnet-4-5', name: 'Claude Sonnet 4.5', tag: 'Best for design' },
+      { id: 'openai/gpt-4o', name: 'GPT-4o' },
+      { id: 'openai/gpt-4o-mini', name: 'GPT-4o Mini' },
+      { id: 'google/gemini-2.5-flash', name: 'Gemini 2.5 Flash' }
     ]
   },
   {

--- a/src/app/ai/chat/model.ts
+++ b/src/app/ai/chat/model.ts
@@ -24,6 +24,7 @@ export function resolveLanguageModelID(
 ) {
   const customModelID = config.customModelID.trim()
   if (config.providerID === 'openrouter') return customModelID || config.modelID
+  if (config.providerID === 'requesty') return customModelID || config.modelID
   if (config.providerID === 'openai-compatible' || config.providerID === 'anthropic-compatible') {
     return customModelID
   }
@@ -49,6 +50,18 @@ export function createLanguageModel(config: ModelConfig): LanguageModel {
         }
       })
       return openrouter(effectiveModelID)
+    }
+    case 'requesty': {
+      const requesty = createOpenAI({
+        apiKey: config.apiKey,
+        baseURL: 'https://router.requesty.ai/v1',
+        fetch,
+        headers: {
+          'X-Title': 'OpenPencil',
+          'HTTP-Referer': 'https://github.com/open-pencil/open-pencil'
+        }
+      })
+      return requesty.chat(effectiveModelID)
     }
     case 'anthropic': {
       const anthropic = createAnthropic({ apiKey: config.apiKey, fetch })

--- a/src/app/ai/chat/provider-models.ts
+++ b/src/app/ai/chat/provider-models.ts
@@ -16,13 +16,19 @@ type OpenRouterModelsResponse = {
 const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models'
 const OPENROUTER_MODELS_CACHE_KEY = 'openrouter/models'
 const OPENROUTER_MODELS_CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+const REQUESTY_MODELS_URL = 'https://router.requesty.ai/v1/models'
+const REQUESTY_MODELS_CACHE_KEY = 'requesty/models'
+const REQUESTY_MODELS_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 function curatedProviderModels(providerID: AIProviderID) {
   return AI_PROVIDERS.find((provider) => provider.id === providerID)?.models ?? []
 }
 
 const curatedOpenRouterModels = curatedProviderModels('openrouter')
+const curatedRequestyModels = curatedProviderModels('requesty')
 
 let modelsPromise: Promise<ModelOption[]> | null = null
+let requestyModelsPromise: Promise<ModelOption[]> | null = null
 
 function isToolCapableOpenRouterModel(model: OpenRouterModel) {
   return Array.isArray(model.supported_parameters) && model.supported_parameters.includes('tools')
@@ -65,10 +71,56 @@ async function listOpenRouterModels(fetcher: typeof fetch = fetch): Promise<Mode
   return modelsPromise
 }
 
+type RequestyModel = {
+  id?: unknown
+  name?: unknown
+}
+
+type RequestyModelsResponse = {
+  data?: RequestyModel[]
+}
+
+function normalizeRequestyModel(model: RequestyModel): ModelOption | null {
+  if (typeof model.id !== 'string' || !model.id) return null
+  return {
+    id: model.id,
+    name: typeof model.name === 'string' && model.name ? model.name : model.id
+  }
+}
+
+async function fetchRequestyModels(fetcher: typeof fetch): Promise<ModelOption[]> {
+  const response = await fetcher(REQUESTY_MODELS_URL)
+  if (!response.ok) throw new Error(`Requesty models request failed: ${response.status}`)
+  const json = (await response.json()) as RequestyModelsResponse
+  return json.data?.map(normalizeRequestyModel).filter((model) => model !== null) ?? []
+}
+
+async function listRequestyModels(fetcher: typeof fetch = fetch): Promise<ModelOption[]> {
+  requestyModelsPromise ??= (async () => {
+    const cached = await readCacheJson<ModelOption[]>(
+      REQUESTY_MODELS_CACHE_KEY,
+      REQUESTY_MODELS_CACHE_TTL_MS
+    )
+    if (cached?.length) return cached
+
+    try {
+      const models = await fetchRequestyModels(fetcher)
+      if (!models.length) return curatedRequestyModels
+      await writeCacheJson(REQUESTY_MODELS_CACHE_KEY, models)
+      return models
+    } catch {
+      return curatedRequestyModels
+    }
+  })()
+
+  return requestyModelsPromise
+}
+
 export async function listProviderModels(
   providerID: AIProviderID,
   fetcher: typeof fetch = fetch
 ): Promise<ModelOption[]> {
   if (providerID === 'openrouter') return listOpenRouterModels(fetcher)
+  if (providerID === 'requesty') return listRequestyModels(fetcher)
   return curatedProviderModels(providerID)
 }

--- a/src/app/ai/chat/transports.ts
+++ b/src/app/ai/chat/transports.ts
@@ -45,7 +45,8 @@ function supportsAnthropicCaching(providerID: AIProviderID, modelID: string): bo
   return (
     providerID === 'anthropic' ||
     providerID === 'anthropic-compatible' ||
-    (providerID === 'openrouter' && modelID.startsWith('anthropic/'))
+    (providerID === 'openrouter' && modelID.startsWith('anthropic/')) ||
+    (providerID === 'requesty' && modelID.startsWith('anthropic/'))
   )
 }
 

--- a/src/components/chat/ProviderSettings/CustomEndpointSection.vue
+++ b/src/components/chat/ProviderSettings/CustomEndpointSection.vue
@@ -11,7 +11,9 @@ import { useProviderSettingsContext } from '@/components/chat/ProviderSettings/c
 const ctx = useProviderSettingsContext()
 const { dialogs } = useI18n()
 const suggestedModels = ref<Array<{ id: string; name: string }>>([])
-const showModelSuggestions = computed(() => ctx.providerID === 'openrouter')
+const showModelSuggestions = computed(
+  () => ctx.providerID === 'openrouter' || ctx.providerID === 'requesty'
+)
 
 async function loadModelSuggestions() {
   if (!showModelSuggestions.value || suggestedModels.value.length) return

--- a/src/components/chat/ProviderSetup.vue
+++ b/src/components/chat/ProviderSetup.vue
@@ -38,6 +38,7 @@ const canTestConnection = computed(() => {
   if (
     providerDef.value.supportsCustomModel &&
     providerID.value !== 'openrouter' &&
+    providerID.value !== 'requesty' &&
     !customModelInput.value.trim()
   ) {
     return false
@@ -112,7 +113,7 @@ function save() {
 
       <!-- Optional custom model ID for providers that support arbitrary model IDs. -->
       <AppInput
-        v-if="providerDef.supportsCustomModel && providerID !== 'openrouter'"
+        v-if="providerDef.supportsCustomModel && providerID !== 'openrouter' && providerID !== 'requesty'"
         v-model="customModelInput"
         data-test-id="provider-custom-model"
         :placeholder="dialogs.modelIDPlaceholder"


### PR DESCRIPTION
Adds Requesty as an AI provider, mirroring the existing OpenRouter provider.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM router — base URL `https://router.requesty.ai/v1`, `GET /v1/models` (OpenAI shape) for live model discovery, `provider/model` naming, optional `HTTP-Referer`/`X-Title` headers.

Changes:
- `packages/core/src/constants.ts`: `'requesty'` in the `AIProviderID` union + a `requesty` entry in `AI_PROVIDERS` (mirrors OpenRouter; verified model ids; appended after OpenRouter so the default provider/model index is unchanged).
- `src/app/ai/chat/model.ts`: `requesty` in the model resolver + a `createLanguageModel` case using the OpenAI-compatible client with base URL `https://router.requesty.ai/v1`.
- `src/app/ai/chat/provider-models.ts`: live `/v1/models` listing + curated fallback, mirroring OpenRouter's.
- `src/app/ai/chat/transports.ts`: Requesty `anthropic/*` models get the same Anthropic cache-control as OpenRouter's.
- `src/components/chat/ProviderSetup.vue` + `ProviderSettings/CustomEndpointSection.vue`: Requesty behaves like OpenRouter (curated list, optional custom model). The provider dropdown is data-driven from `AI_PROVIDERS`, so no dropdown change was needed.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new AI provider option in the app.
  * Model suggestions now work for this provider, making it easier to pick a compatible model.

* **Bug Fixes**
  * Improved model loading and fallback behavior so available models are shown more reliably.
  * Enhanced compatibility for certain Anthropic-based models when used through the new provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->