### PR TITLE
fix(canvas): import dropped SVG files as vector nodes

### DIFF
--- a/packages/core/src/editor/bridges/clipboard.ts
+++ b/packages/core/src/editor/bridges/clipboard.ts
@@ -13,6 +13,7 @@ export function createClipboardBridge(clipboard: ClipboardActions, selection: Se
     deleteSelected: clipboard.deleteSelected,
     storeImage: clipboard.storeImage,
     placeImageFiles: clipboard.placeImageFiles,
+    placeSvgFiles: clipboard.placeSvgFiles,
     loadFontsForNodes: clipboard.loadFontsForNodes,
     copySelectionAsText: clipboard.copySelectionAsText,
     copySelectionAsSVG: clipboard.copySelectionAsSVG,

--- a/packages/core/src/editor/clipboard.ts
+++ b/packages/core/src/editor/clipboard.ts
@@ -17,6 +17,7 @@ import { replaceTargetsWithCreated, selectedReplacementTargets } from './clipboa
 import { resolvePasteTarget } from './clipboard/paste-target'
 import { createClipboardPlacementActions } from './clipboard/placement'
 import { collectSubtrees, restoreSubtree, snapshotSubtree } from './clipboard/subtree-history'
+import { createClipboardSvgActions } from './clipboard/svg'
 import type { EditorContext } from './types'
 
 type PasteOptions = {
@@ -225,6 +226,7 @@ export function createClipboardActions(ctx: EditorContext) {
   const exportActions = createClipboardExportActions(ctx)
   const fontActions = createClipboardFontActions(ctx)
   const imageActions = createClipboardImageActions(ctx)
+  const svgActions = createClipboardSvgActions(ctx)
   const placementActions = createClipboardPlacementActions(ctx)
 
   return {
@@ -237,6 +239,7 @@ export function createClipboardActions(ctx: EditorContext) {
     warnMissingImages,
     deleteSelected,
     ...imageActions,
+    ...svgActions,
     ...exportActions
   }
 }

--- a/packages/core/src/editor/clipboard/svg.ts
+++ b/packages/core/src/editor/clipboard/svg.ts
@@ -1,0 +1,58 @@
+import { resolvePasteTarget } from '#core/editor/clipboard/paste-target'
+import type { EditorContext } from '#core/editor/types'
+import { createSvgNodes } from '#core/tools/create/svg'
+
+import { deleteIds, recreateSnapshots } from './history'
+import { collectSubtrees } from './subtree-history'
+
+const SVG_GAP = 20
+
+export function createClipboardSvgActions(ctx: EditorContext) {
+  /** Import dropped/pasted SVG files as vector frames centered around (cx, cy). */
+  async function placeSvgFiles(files: File[], cx: number, cy: number) {
+    const parentId = resolvePasteTarget(ctx)
+    const prevSelection = new Set(ctx.state.selectedIds)
+
+    const frames = []
+    for (const file of files) {
+      const markup = await file.text()
+      const frame = createSvgNodes(ctx.graph, parentId, markup, {
+        name: file.name.replace(/\.svg$/i, '') || 'SVG'
+      })
+      if (frame) frames.push(frame)
+    }
+    if (!frames.length) return
+
+    let totalW = 0
+    for (const f of frames) totalW += f.width
+    totalW += SVG_GAP * (frames.length - 1)
+    const maxH = Math.max(...frames.map((f) => f.height))
+
+    let curX = cx - totalW / 2
+    const topY = cy - maxH / 2
+    for (const frame of frames) {
+      ctx.graph.updateNode(frame.id, { x: curX, y: topY })
+      curX += frame.width + SVG_GAP
+    }
+
+    const created = frames.map((f) => f.id)
+    const allNodes = collectSubtrees(ctx.graph, created)
+    const pageId = ctx.state.currentPageId
+    ctx.undo.push({
+      label: 'Import SVG',
+      forward: () => {
+        recreateSnapshots(ctx, allNodes, pageId)
+        ctx.setSelectedIds(new Set(created))
+      },
+      inverse: () => {
+        deleteIds(ctx, created)
+        ctx.setSelectedIds(prevSelection)
+      }
+    })
+
+    ctx.setSelectedIds(new Set(created))
+    ctx.requestRender()
+  }
+
+  return { placeSvgFiles }
+}

--- a/packages/core/src/editor/clipboard/svg.ts
+++ b/packages/core/src/editor/clipboard/svg.ts
@@ -1,5 +1,8 @@
+import type { SceneNode } from '@open-pencil/scene-graph'
+
 import { resolvePasteTarget } from '#core/editor/clipboard/paste-target'
 import type { EditorContext } from '#core/editor/types'
+import { computeAllLayouts } from '#core/layout'
 import { createSvgNodes } from '#core/tools/create/svg'
 
 import { deleteIds, recreateSnapshots } from './history'
@@ -13,7 +16,7 @@ export function createClipboardSvgActions(ctx: EditorContext) {
     const parentId = resolvePasteTarget(ctx)
     const prevSelection = new Set(ctx.state.selectedIds)
 
-    const frames = []
+    const frames: SceneNode[] = []
     for (const file of files) {
       const markup = await file.text()
       const frame = createSvgNodes(ctx.graph, parentId, markup, {
@@ -42,14 +45,17 @@ export function createClipboardSvgActions(ctx: EditorContext) {
       label: 'Import SVG',
       forward: () => {
         recreateSnapshots(ctx, allNodes, pageId)
+        computeAllLayouts(ctx.graph, pageId)
         ctx.setSelectedIds(new Set(created))
       },
       inverse: () => {
         deleteIds(ctx, created)
+        computeAllLayouts(ctx.graph, pageId)
         ctx.setSelectedIds(prevSelection)
       }
     })
 
+    computeAllLayouts(ctx.graph, pageId)
     ctx.setSelectedIds(new Set(created))
     ctx.requestRender()
   }

--- a/packages/core/src/tools/create/svg.ts
+++ b/packages/core/src/tools/create/svg.ts
@@ -1,3 +1,4 @@
+import type { SceneGraph } from '@open-pencil/scene-graph'
 import type { Rect } from '@open-pencil/scene-graph/primitives'
 
 import { parseColor } from '#core/color'
@@ -32,7 +33,7 @@ function parseSvgSize(svg: string): { width: number; height: number } {
 }
 
 function createVectorFromPath(
-  figma: Parameters<Parameters<typeof defineTool>[0]['execute']>[0],
+  graph: SceneGraph,
   path: IconPathInfo,
   width: number,
   height: number,
@@ -40,7 +41,7 @@ function createVectorFromPath(
   defaultColor: string
 ) {
   const vectorNetwork = parseSVGPath(path.d, path.fillRule)
-  const vector = figma.graph.createNode('VECTOR', parentId, {
+  const vector = graph.createNode('VECTOR', parentId, {
     name: 'path',
     width,
     height,
@@ -52,27 +53,63 @@ function createVectorFromPath(
   if (path.fill && path.fill !== 'none') {
     const fillColor =
       path.fill === 'currentColor' ? parseColor(defaultColor) : parseColor(path.fill)
-    figma.graph.updateNode(vector.id, {
+    graph.updateNode(vector.id, {
       fills: [{ type: 'SOLID', color: fillColor, opacity: 1, visible: true }]
     })
   } else if (path.fill === null && !path.stroke) {
     const fillColor = parseColor(defaultColor)
-    figma.graph.updateNode(vector.id, {
+    graph.updateNode(vector.id, {
       fills: [{ type: 'SOLID', color: fillColor, opacity: 1, visible: true }]
     })
   } else {
-    figma.graph.updateNode(vector.id, { fills: [] })
+    graph.updateNode(vector.id, { fills: [] })
   }
 
   if (path.stroke && path.stroke !== 'none') {
     const strokeColor =
       path.stroke === 'currentColor' ? parseColor(defaultColor) : parseColor(path.stroke)
-    figma.graph.updateNode(vector.id, {
+    graph.updateNode(vector.id, {
       strokes: [createPathStroke(strokeColor, path.strokeWidth, path.strokeCap, path.strokeJoin)]
     })
   }
 
   return vector
+}
+
+export interface CreateSvgNodesOptions {
+  name?: string
+  color?: string
+  x?: number
+  y?: number
+}
+
+/** Parse SVG markup into a frame of vector nodes. Returns the frame, or null
+ *  when the markup contains no supported elements. */
+export function createSvgNodes(
+  graph: SceneGraph,
+  parentId: string,
+  svg: string,
+  options: CreateSvgNodesOptions = {}
+) {
+  const paths = extractPaths(svg)
+  if (paths.length === 0) return null
+
+  const { width, height } = parseSvgSize(svg)
+  const defaultColor = options.color ?? '#000000'
+
+  const frame = graph.createNode('FRAME', parentId, {
+    name: options.name ?? 'SVG',
+    width,
+    height,
+    fills: []
+  })
+  if (options.x !== undefined) frame.x = options.x
+  if (options.y !== undefined) frame.y = options.y
+
+  for (const path of paths) {
+    createVectorFromPath(graph, path, width, height, frame.id, defaultColor)
+  }
+  return frame
 }
 
 export const importSvg = defineTool({
@@ -99,26 +136,13 @@ export const importSvg = defineTool({
     const svg = args.svg
     if (!svg || typeof svg !== 'string') return { error: 'svg parameter is required' }
 
-    const paths = extractPaths(svg)
-    if (paths.length === 0) return { error: 'No supported SVG elements found in the markup' }
-
-    const { width, height } = parseSvgSize(svg)
-    const defaultColor = args.color ?? '#000000'
-    const parentId = args.parent_id ?? figma.currentPage.id
-
-    const frame = figma.graph.createNode('FRAME', parentId, {
-      name: args.name ?? 'SVG',
-      width,
-      height,
-      fills: []
+    const frame = createSvgNodes(figma.graph, args.parent_id ?? figma.currentPage.id, svg, {
+      name: args.name,
+      color: args.color,
+      x: args.x,
+      y: args.y
     })
-
-    if (args.x !== undefined) frame.x = args.x
-    if (args.y !== undefined) frame.y = args.y
-
-    for (const path of paths) {
-      createVectorFromPath(figma, path, width, height, frame.id, defaultColor)
-    }
+    if (!frame) return { error: 'No supported SVG elements found in the markup' }
 
     return { id: frame.id, name: frame.name, type: frame.type }
   }

--- a/packages/core/src/tools/create/svg.ts
+++ b/packages/core/src/tools/create/svg.ts
@@ -7,6 +7,7 @@ import { extractPaths } from '#core/icons/svg'
 import type { IconPathInfo } from '#core/icons/types'
 import { parseSVGPath } from '#core/io/formats/svg/parse-path'
 import { defineTool } from '#core/tools/schema'
+import { computeAccurateBounds } from '#core/vector'
 
 function parseSvgViewBox(svg: string): Rect | null {
   const match = svg.match(/viewBox="([^"]+)"/)
@@ -67,20 +68,24 @@ function createVectorFromPath(
   parentId: string,
   defaultColor: string
 ) {
-  const vectorNetwork = fitNetworkToNode(
-    parseSVGPath(path.d, path.fillRule),
-    viewBox,
-    width,
-    height
-  )
+  const network = fitNetworkToNode(parseSVGPath(path.d, path.fillRule), viewBox, width, height)
+
+  // Size each vector to its own path bounds — full-canvas vectors would all
+  // overlap, making selection outlines, hit-testing, and node editing useless.
+  const bounds = computeAccurateBounds(network)
+  const vectorNetwork = {
+    vertices: network.vertices.map((v) => ({ ...v, x: v.x - bounds.x, y: v.y - bounds.y })),
+    segments: network.segments,
+    regions: network.regions
+  }
   const vector = graph.createNode('VECTOR', parentId, {
     name: 'path',
-    width,
-    height,
+    width: Math.max(bounds.width, 0.01),
+    height: Math.max(bounds.height, 0.01),
     vectorNetwork
   })
-  vector.x = 0
-  vector.y = 0
+  vector.x = bounds.x
+  vector.y = bounds.y
 
   if (path.fill && path.fill !== 'none') {
     const fillColor =

--- a/packages/core/src/tools/create/svg.ts
+++ b/packages/core/src/tools/create/svg.ts
@@ -32,15 +32,47 @@ function parseSvgSize(svg: string): { width: number; height: number } {
   return { width: 24, height: 24 }
 }
 
+/** Map a parsed network from viewBox units into node-space pixels. */
+function fitNetworkToNode(
+  network: ReturnType<typeof parseSVGPath>,
+  viewBox: Rect | null,
+  width: number,
+  height: number
+) {
+  if (!viewBox || viewBox.width <= 0 || viewBox.height <= 0) return network
+  const sx = width / viewBox.width
+  const sy = height / viewBox.height
+  if (sx === 1 && sy === 1 && viewBox.x === 0 && viewBox.y === 0) return network
+  return {
+    vertices: network.vertices.map((v) => ({
+      ...v,
+      x: (v.x - viewBox.x) * sx,
+      y: (v.y - viewBox.y) * sy
+    })),
+    segments: network.segments.map((seg) => ({
+      ...seg,
+      tangentStart: { x: seg.tangentStart.x * sx, y: seg.tangentStart.y * sy },
+      tangentEnd: { x: seg.tangentEnd.x * sx, y: seg.tangentEnd.y * sy }
+    })),
+    regions: network.regions
+  }
+}
+
 function createVectorFromPath(
   graph: SceneGraph,
   path: IconPathInfo,
+  viewBox: Rect | null,
   width: number,
   height: number,
   parentId: string,
   defaultColor: string
 ) {
-  const vectorNetwork = parseSVGPath(path.d, path.fillRule)
+  const vectorNetwork = fitNetworkToNode(
+    parseSVGPath(path.d, path.fillRule),
+    viewBox,
+    width,
+    height
+  )
   const vector = graph.createNode('VECTOR', parentId, {
     name: 'path',
     width,
@@ -83,8 +115,9 @@ export interface CreateSvgNodesOptions {
   y?: number
 }
 
-/** Parse SVG markup into a frame of vector nodes. Returns the frame, or null
- *  when the markup contains no supported elements. */
+/** Parse SVG markup into a group of vector nodes (group resize scales the
+ *  vectors). Returns the group root, or null when the markup contains no
+ *  supported elements. */
 export function createSvgNodes(
   graph: SceneGraph,
   parentId: string,
@@ -95,21 +128,22 @@ export function createSvgNodes(
   if (paths.length === 0) return null
 
   const { width, height } = parseSvgSize(svg)
+  const viewBox = parseSvgViewBox(svg)
   const defaultColor = options.color ?? '#000000'
 
-  const frame = graph.createNode('FRAME', parentId, {
+  const root = graph.createNode('GROUP', parentId, {
     name: options.name ?? 'SVG',
     width,
     height,
     fills: []
   })
-  if (options.x !== undefined) frame.x = options.x
-  if (options.y !== undefined) frame.y = options.y
+  if (options.x !== undefined) root.x = options.x
+  if (options.y !== undefined) root.y = options.y
 
   for (const path of paths) {
-    createVectorFromPath(graph, path, width, height, frame.id, defaultColor)
+    createVectorFromPath(graph, path, viewBox, width, height, root.id, defaultColor)
   }
-  return frame
+  return root
 }
 
 export const importSvg = defineTool({

--- a/packages/vue/src/canvas/drop/use.ts
+++ b/packages/vue/src/canvas/drop/use.ts
@@ -4,6 +4,11 @@ import { ref, type Ref } from 'vue'
 import type { Editor } from '@open-pencil/core/editor'
 
 const ACCEPTED_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/avif'])
+const SVG_TYPE = 'image/svg+xml'
+
+function isSvgFile(file: { type: string; name?: string }): boolean {
+  return file.type === SVG_TYPE || !!file.name?.toLowerCase().endsWith('.svg')
+}
 
 export function useCanvasDrop(canvasRef: Ref<HTMLCanvasElement | null>, editor: Editor) {
   const isDraggingOver = ref(false)
@@ -29,8 +34,9 @@ export function useCanvasDrop(canvasRef: Ref<HTMLCanvasElement | null>, editor: 
     e.preventDefault()
     isDraggingOver.value = false
 
-    const files = filterImageFiles(e.dataTransfer?.files ?? null)
-    if (!files.length) return
+    const images = filterImageFiles(e.dataTransfer?.files ?? null)
+    const svgs = filterSvgFiles(e.dataTransfer?.files ?? null)
+    if (!images.length && !svgs.length) return
 
     const canvas = canvasRef.value
     if (!canvas) return
@@ -40,7 +46,8 @@ export function useCanvasDrop(canvasRef: Ref<HTMLCanvasElement | null>, editor: 
     const sy = e.clientY - rect.top
     const { x: cx, y: cy } = editor.screenToCanvas(sx, sy)
 
-    void editor.placeImageFiles(files, cx, cy)
+    if (images.length) void editor.placeImageFiles(images, cx, cy)
+    if (svgs.length) void editor.placeSvgFiles(svgs, cx, cy)
   })
 
   return { isDraggingOver }
@@ -49,7 +56,8 @@ export function useCanvasDrop(canvasRef: Ref<HTMLCanvasElement | null>, editor: 
 function hasImageFiles(e: DragEvent): boolean {
   if (!e.dataTransfer?.types.includes('Files')) return false
   for (const item of e.dataTransfer.items) {
-    if (item.kind === 'file' && ACCEPTED_TYPES.has(item.type)) return true
+    if (item.kind !== 'file') continue
+    if (ACCEPTED_TYPES.has(item.type) || item.type === SVG_TYPE) return true
   }
   return false
 }
@@ -59,6 +67,15 @@ function filterImageFiles(files: FileList | null): File[] {
   const result: File[] = []
   for (const file of files) {
     if (ACCEPTED_TYPES.has(file.type)) result.push(file)
+  }
+  return result
+}
+
+function filterSvgFiles(files: FileList | null): File[] {
+  if (!files) return []
+  const result: File[] = []
+  for (const file of files) {
+    if (isSvgFile(file)) result.push(file)
   }
   return result
 }

--- a/tests/engine/editor/svg-drop-import.test.ts
+++ b/tests/engine/editor/svg-drop-import.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+
+import { SceneGraph } from '@open-pencil/scene-graph'
+
+import { createSvgNodes } from '#core/tools/create/svg'
+
+import { expectDefined } from '#tests/helpers/assert'
+
+const STAR_SVG = `<svg viewBox="0 0 24 24" width="48" height="48">
+  <path d="M12 2 L15 9 L22 9 L16 14 L18 21 L12 17 L6 21 L8 14 L2 9 L9 9 Z" fill="#ff6600"/>
+  <path d="M0 0 H24 V24 H0 Z" fill="none" stroke="#333333" stroke-width="2"/>
+</svg>`
+
+describe('SVG drop import', () => {
+  test('createSvgNodes builds a frame of vectors sized from the markup', () => {
+    const graph = new SceneGraph()
+    const page = expectDefined(graph.getPages()[0])
+
+    const frame = expectDefined(
+      createSvgNodes(graph, page.id, STAR_SVG, { name: 'star' }),
+      'imported frame'
+    )
+
+    expect(frame.type).toBe('FRAME')
+    expect(frame.name).toBe('star')
+    expect(frame.width).toBe(48)
+    expect(frame.height).toBe(48)
+    expect(frame.childIds).toHaveLength(2)
+
+    const star = expectDefined(graph.getNode(frame.childIds[0]))
+    expect(star.type).toBe('VECTOR')
+    expect(star.fills[0]?.color.r).toBeCloseTo(1, 2)
+    expect(star.fills[0]?.color.g).toBeCloseTo(0.4, 2)
+
+    const border = expectDefined(graph.getNode(frame.childIds[1]))
+    expect(border.fills).toHaveLength(0)
+    expect(border.strokes[0]?.weight).toBe(2)
+  })
+
+  test('createSvgNodes returns null for markup without supported elements', () => {
+    const graph = new SceneGraph()
+    const page = expectDefined(graph.getPages()[0])
+    expect(createSvgNodes(graph, page.id, '<svg><text>hi</text></svg>')).toBeNull()
+  })
+})

--- a/tests/engine/editor/svg-drop-import.test.ts
+++ b/tests/engine/editor/svg-drop-import.test.ts
@@ -12,7 +12,7 @@ const STAR_SVG = `<svg viewBox="0 0 24 24" width="48" height="48">
 </svg>`
 
 describe('SVG drop import', () => {
-  test('createSvgNodes builds a frame of vectors sized from the markup', () => {
+  test('createSvgNodes builds a group of vectors sized from the markup', () => {
     const graph = new SceneGraph()
     const page = expectDefined(graph.getPages()[0])
 
@@ -21,7 +21,7 @@ describe('SVG drop import', () => {
       'imported frame'
     )
 
-    expect(frame.type).toBe('FRAME')
+    expect(frame.type).toBe('GROUP')
     expect(frame.name).toBe('star')
     expect(frame.width).toBe(48)
     expect(frame.height).toBe(48)
@@ -31,6 +31,10 @@ describe('SVG drop import', () => {
     expect(star.type).toBe('VECTOR')
     expect(star.fills[0]?.color.r).toBeCloseTo(1, 2)
     expect(star.fills[0]?.color.g).toBeCloseTo(0.4, 2)
+    // viewBox is 24 units but the node is 48px — coordinates map to node space
+    const network = expectDefined(star.vectorNetwork, 'vectorNetwork')
+    expect(network.vertices[0]?.x).toBeCloseTo(24, 4) // 12 in viewBox units
+    expect(network.vertices[0]?.y).toBeCloseTo(4, 4) // 2 in viewBox units
 
     const border = expectDefined(graph.getNode(frame.childIds[1]))
     expect(border.fills).toHaveLength(0)

--- a/tests/engine/editor/svg-drop-import.test.ts
+++ b/tests/engine/editor/svg-drop-import.test.ts
@@ -31,10 +31,15 @@ describe('SVG drop import', () => {
     expect(star.type).toBe('VECTOR')
     expect(star.fills[0]?.color.r).toBeCloseTo(1, 2)
     expect(star.fills[0]?.color.g).toBeCloseTo(0.4, 2)
-    // viewBox is 24 units but the node is 48px — coordinates map to node space
+    // viewBox is 24 units but the node is 48px — coordinates map to node space,
+    // and each vector hugs its own path bounds (star spans x 2..22, y 2..21).
+    expect(star.x).toBeCloseTo(4, 4)
+    expect(star.y).toBeCloseTo(4, 4)
+    expect(star.width).toBeCloseTo(40, 4)
+    expect(star.height).toBeCloseTo(38, 4)
     const network = expectDefined(star.vectorNetwork, 'vectorNetwork')
-    expect(network.vertices[0]?.x).toBeCloseTo(24, 4) // 12 in viewBox units
-    expect(network.vertices[0]?.y).toBeCloseTo(4, 4) // 2 in viewBox units
+    expect(network.vertices[0]?.x).toBeCloseTo(20, 4) // (12 − 2) × 2 in node space
+    expect(network.vertices[0]?.y).toBeCloseTo(0, 4)
 
     const border = expectDefined(graph.getNode(frame.childIds[1]))
     expect(border.fills).toHaveLength(0)


### PR DESCRIPTION
## Summary

Dragging an SVG file onto the canvas navigated the browser to the file (opened it in a new tab) instead of importing it. The canvas drop handler only accepted raster image types, so the `dragover` was never claimed for SVGs and the browser's default drag behavior won.

SVG drops now import as editable vectors: a frame of VECTOR nodes at the drop position, parsed by the same code path as the existing `import_svg` tool, selected after import, and undoable as "Import SVG".

## What changed

- `packages/core/src/tools/create/svg.ts` — extracted `createSvgNodes(graph, parentId, svg, options)` from the `import_svg` tool so the parser is callable outside the tool adapter; the tool now delegates to it
- `packages/core/src/editor/clipboard/svg.ts` — new `placeSvgFiles(files, cx, cy)` clipboard action mirroring `placeImageFiles`: row layout around the drop point, paste-target parent, subtree undo via the paste helpers
- `packages/vue/src/canvas/drop/use.ts` — the canvas drop accepts `image/svg+xml` (with a `.svg` filename fallback for drags that lose the MIME type) alongside rasters and routes each kind to its handler

## Validation

- [x] `bun test tests/engine/editor/svg-drop-import.test.ts` — frame sizing from viewBox/width/height, per-path fills and strokes, null on unsupported markup
- [x] `bun test tests/engine/tools/vectorize.test.ts` (neighbouring SVG consumers unaffected)
- [x] Typecheck + lint clean
- [x] Manual: dropping `.svg` imports vectors at the cursor; dropping `.png` still places an image; undo removes the imported frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dropping SVG files onto the canvas, converting them into editable vector frames positioned at the drop location.
  * Added SVG clipboard placement actions to insert SVG content.
* **Bug Fixes**
  * Improved SVG import to correctly map `viewBox` into node space and preserve per-path fills, strokes, and sizing.
* **Tests**
  * Added automated coverage for SVG node creation, including styling/geometry validation and `null` when no supported SVG elements are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->