### PR TITLE
fix(clipboard): paste image between two files

### DIFF
--- a/packages/core/src/editor/clipboard.ts
+++ b/packages/core/src/editor/clipboard.ts
@@ -1,4 +1,4 @@
-import type { SceneNode } from '@open-pencil/scene-graph'
+import { computeImageHash, type SceneNode } from '@open-pencil/scene-graph'
 import type { Vector } from '@open-pencil/scene-graph/primitives'
 
 import {
@@ -66,18 +66,39 @@ export function createClipboardActions(ctx: EditorContext) {
     }
   }
 
-  function pushPasteUndo(created: string[], prevSelection: Set<string>) {
+  function pushPasteUndo(created: string[], prevSelection: Set<string>, imageIds?: string[]) {
     const allNodes = collectSubtrees(ctx.graph, created)
     const pageId = ctx.state.currentPageId
+    let imageMap: Map<string, Uint8Array<ArrayBufferLike>> | undefined
     ctx.undo.push({
       label: 'Paste',
       forward: () => {
         recreateSnapshots(ctx, allNodes, pageId)
         computeAllLayouts(ctx.graph, pageId)
+        if (imageIds?.length && imageMap) {
+          for (const id of imageIds) {
+            const image = imageMap?.get(id)
+            if (image) {
+              ctx.graph.images.set(id, image)
+            }
+          }
+        }
+        imageMap = undefined
         ctx.setSelectedIds(new Set(created))
       },
       inverse: () => {
         deleteIds(ctx, created)
+        imageMap = new Map()
+        if (imageIds?.length) {
+          for (const id of [...imageIds].reverse()) {
+            const image = ctx.graph.images.get(id)
+            if (image) {
+              imageMap.set(id, image)
+            }
+            ctx.graph.images.delete(id)
+          }
+        }
+
         computeAllLayouts(ctx.graph, pageId)
         ctx.setSelectedIds(prevSelection)
       }
@@ -92,11 +113,22 @@ export function createClipboardActions(ctx: EditorContext) {
     }
 
     const figma = await parseFigmaClipboard(html)
+
+    const imageIds: string[] = []
     if (figma) {
       const prevSelection = new Set(ctx.state.selectedIds)
       const replacementTargets = options.replaceSelection ? selectedReplacementTargets(ctx) : []
       const pasteTarget = replacementTargets[0]?.parentId ?? resolvePasteTarget(ctx)
       const created = importClipboardNodes(figma.nodes, ctx.graph, pasteTarget, 0, 0, figma.blobs)
+
+      if (figma.blobs) {
+        figma.blobs.forEach((it) => {
+          const hash = computeImageHash(it)
+          ctx.graph.images.set(hash, it)
+          imageIds.push(hash)
+        })
+      }
+
       if (created.length > 0) {
         if (replacementTargets.length > 0) {
           replaceTargetsWithCreated(
@@ -118,7 +150,7 @@ export function createClipboardActions(ctx: EditorContext) {
         computeAllLayouts(ctx.graph, ctx.state.currentPageId)
         ctx.setSelectedIds(new Set(created))
 
-        pushPasteUndo(created, prevSelection)
+        pushPasteUndo(created, prevSelection, imageIds)
         void fontActions.loadFontsForNodes(created)
         warnMissingImages(created)
         ctx.requestRender()

--- a/packages/core/src/kiwi/fig/node-change/export-node.ts
+++ b/packages/core/src/kiwi/fig/node-change/export-node.ts
@@ -618,6 +618,17 @@ function applyNodeVisualProps(
         `fills/${index}/color`
       )
     )
+    node.fills.forEach((it) => {
+      if (it.type === 'IMAGE' && it?.imageHash) {
+        const hash = it?.imageHash
+
+        const find = context.graph.images.get(hash)
+
+        if (find) {
+          context.blobs.push(find)
+        }
+      }
+    })
   }
 
   context.serializeCornerRadii(node, nc)


### PR DESCRIPTION
Summary
Fixes a clipboard paste issue where copying from different source files (especially unfinished Figma assets) into Open Pencil fails to produce an image.

This change improves cross-source paste handling by accounting for cases where Figma does not place a direct image stream in the clipboard.
When copying between Figma files, data transfer may rely on Figma’s internal object storage mechanism instead of standard clipboard image data, which caused Open Pencil paste to fail.

What changed
Improved paste logic for cross-file clipboard content.
Added handling/fallback for clipboard payloads that do not contain a direct image stream.
Fixed a scenario where unfinished or in-progress Figma content could not be pasted into Open Pencil.
Added clearer detection for Figma-originated clipboard data patterns.

### Validation

- [x] `bun run check`
- [ ] Tests added or updated, or not needed because: explain here
- [ ] CHANGELOG.md updated, or not needed because: explain here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added undo and redo support for images pasted from Figma, ensuring pasted image content is restored correctly.
  * Exported nodes with image fills now include their associated image content.
* **Bug Fixes**
  * Improved clipboard history handling so undoing and redoing image pastes no longer loses image data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->