### PR TITLE
fix(acp): launch Windows command shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Match Figma auto-layout reflow after deleting children, hiding optional instance slots, or syncing component changes.
 - Make group and boolean-operation children scale with their parent during resize.
 - Restore desktop copy, cut, and paste when browser clipboard events are unavailable.
+- Start globally installed ACP agents correctly on Windows instead of reporting them as unavailable (#361).
 - Keep duplicated layers independent instead of sharing mutable fills, strokes, bindings, overrides, or vector data, and remove stale bindings when paints are deleted.
 - Preserve Hangul IME composition while editing text.
 - Share public app links from the desktop collaboration panel and send the current document to newly joined collaborators.

--- a/src/app/ai/acp/process.ts
+++ b/src/app/ai/acp/process.ts
@@ -1,4 +1,5 @@
 import { decodeTauriStderr } from '@/app/shell/ui'
+import { resolvePlatformCommand } from '@/app/tauri/command'
 
 export type TauriChild = {
   write(data: number[]): Promise<void>
@@ -21,7 +22,11 @@ export async function spawnAcpProcess({
   onUnexpectedClose
 }: AcpProcessOptions) {
   const { Command } = await import('@tauri-apps/plugin-shell')
-  const command = Command.create(commandName, args, { encoding: 'raw' })
+  const resolved = resolvePlatformCommand(commandName, args)
+  const command = Command.create(resolved.command, resolved.args, {
+    encoding: 'raw',
+    env: {}
+  })
 
   const stdoutChunks: Uint8Array[] = []
   let stdoutResolver: ((chunk: Uint8Array | null) => void) | null = null

--- a/src/app/automation/mcp/spawn.ts
+++ b/src/app/automation/mcp/spawn.ts
@@ -5,6 +5,7 @@ import { randomHex } from '@open-pencil/core/random'
 import type { DiscoveryInfo } from '@open-pencil/mcp/discovery'
 
 import { decodeTauriStderr } from '@/app/shell/ui'
+import { resolvePlatformCommand } from '@/app/tauri/command'
 import { isTauri } from '@/app/tauri/env'
 
 interface AutomationHealth {
@@ -240,32 +241,22 @@ export async function spawnMCPIfNeeded(): Promise<AutomationServerHandle | null>
   // Cache only after MCP startup is confirmed healthy.
 
   const { Command } = await import('@tauri-apps/plugin-shell')
-  const isWindows = navigator.platform.includes('Win')
   // Set OPENPENCIL_MCP_ROOT to the user's home directory so file-scoped
   // tools (open_file, save_file, export_*) operate on paths inside ~,
   // which is naturally writable and matches user expectations for "my files."
   // The app bundle directory (Tauri executableDir) is read-only and would
   // cause EACCES errors on every file write.
   const mcpRoot = await resolveTauriHomeDir()
-  const command = isWindows
-    ? Command.create('cmd', ['/c', 'openpencil-mcp-http'], {
-        env: {
-          PORT: String(AUTOMATION_HTTP_PORT),
-          OPENPENCIL_MCP_AUTH_TOKEN: authToken,
-          OPENPENCIL_MCP_CORS_ORIGIN: window.location.origin,
-          OPENPENCIL_MCP_TCP: '1',
-          OPENPENCIL_MCP_ROOT: mcpRoot
-        }
-      })
-    : Command.create('openpencil-mcp-http', [], {
-        env: {
-          PORT: String(AUTOMATION_HTTP_PORT),
-          OPENPENCIL_MCP_AUTH_TOKEN: authToken,
-          OPENPENCIL_MCP_CORS_ORIGIN: window.location.origin,
-          OPENPENCIL_MCP_TCP: '1',
-          OPENPENCIL_MCP_ROOT: mcpRoot
-        }
-      })
+  const resolved = resolvePlatformCommand('openpencil-mcp-http')
+  const command = Command.create(resolved.command, resolved.args, {
+    env: {
+      PORT: String(AUTOMATION_HTTP_PORT),
+      OPENPENCIL_MCP_AUTH_TOKEN: authToken,
+      OPENPENCIL_MCP_CORS_ORIGIN: window.location.origin,
+      OPENPENCIL_MCP_TCP: '1',
+      OPENPENCIL_MCP_ROOT: mcpRoot
+    }
+  })
 
   command.stderr.on('data', (raw: Uint8Array | number[] | string) => {
     console.error('[MCP]', decodeTauriStderr(raw))

--- a/src/app/tauri/command.ts
+++ b/src/app/tauri/command.ts
@@ -1,0 +1,30 @@
+/**
+ * Resolve a CLI invocation into the form the Tauri process spawner can launch
+ * on the current platform.
+ *
+ * On Windows, npm-installed global CLIs (e.g. `claude-agent-acp`,
+ * `openpencil-mcp-http`) are `.cmd` shims. The Rust spawner behind
+ * `@tauri-apps/plugin-shell` only resolves real executables, so launching a
+ * `.cmd` directly fails with ENOENT. Routing through `cmd /c` lets the shell
+ * resolve the shim via PATHEXT. `cmd` is allowlisted in
+ * desktop/capabilities/default.json.
+ *
+ * The `userAgent` argument is injectable for testing; it defaults to the live
+ * navigator value at runtime, falling back to an empty string in non-browser
+ * contexts (e.g. headless tests) where `navigator` is unavailable.
+ */
+function detectUserAgent(): string {
+  const ua = typeof navigator === 'undefined' ? undefined : navigator.userAgent
+  return typeof ua === 'string' ? ua : ''
+}
+
+export function resolvePlatformCommand(
+  command: string,
+  args: string[] = [],
+  userAgent: string = detectUserAgent()
+): { command: string; args: string[] } {
+  if (userAgent.includes('Windows')) {
+    return { command: 'cmd', args: ['/c', command, ...args] }
+  }
+  return { command, args }
+}

--- a/tests/engine/tauri/command.test.ts
+++ b/tests/engine/tauri/command.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+
+import { resolvePlatformCommand } from '@/app/tauri/command'
+
+const WINDOWS_UA =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0'
+const MAC_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)'
+
+describe('resolvePlatformCommand', () => {
+  test('wraps a bare command in cmd /c on Windows', () => {
+    expect(resolvePlatformCommand('claude-agent-acp', [], WINDOWS_UA)).toEqual({
+      command: 'cmd',
+      args: ['/c', 'claude-agent-acp']
+    })
+  })
+
+  test('preserves extra args after the command on Windows', () => {
+    expect(resolvePlatformCommand('gemini', ['--acp'], WINDOWS_UA)).toEqual({
+      command: 'cmd',
+      args: ['/c', 'gemini', '--acp']
+    })
+  })
+
+  test('passes the command through unchanged on non-Windows', () => {
+    expect(resolvePlatformCommand('claude-agent-acp', ['--acp'], MAC_UA)).toEqual({
+      command: 'claude-agent-acp',
+      args: ['--acp']
+    })
+  })
+
+  test('defaults args to an empty array', () => {
+    expect(resolvePlatformCommand('openpencil-mcp-http', undefined, MAC_UA)).toEqual({
+      command: 'openpencil-mcp-http',
+      args: []
+    })
+  })
+
+  test('passes through when the user agent is unavailable (headless/non-browser)', () => {
+    expect(resolvePlatformCommand('openpencil-mcp-http', ['--stdio'], '')).toEqual({
+      command: 'openpencil-mcp-http',
+      args: ['--stdio']
+    })
+  })
+})

--- a/tests/engine/tauri/mcp-spawn.test.ts
+++ b/tests/engine/tauri/mcp-spawn.test.ts
@@ -52,6 +52,19 @@ describe('Tauri MCP spawning', () => {
     await mockTauriIPC((cmd, args) => {
       calls.push({ cmd, args })
       if (cmd === 'plugin:shell|spawn') {
+        expect(args).toMatchObject({
+          program: 'openpencil-mcp-http',
+          args: [],
+          options: {
+            env: {
+              PORT: '7600',
+              OPENPENCIL_MCP_AUTH_TOKEN: expect.any(String),
+              OPENPENCIL_MCP_CORS_ORIGIN: 'tauri://localhost',
+              OPENPENCIL_MCP_TCP: '1',
+              OPENPENCIL_MCP_ROOT: '/mock/home'
+            }
+          }
+        })
         onEvent = (args as { onEvent: { onmessage: (event: unknown) => void } }).onEvent.onmessage
         return 77
       }

--- a/tests/engine/tauri/processes.test.ts
+++ b/tests/engine/tauri/processes.test.ts
@@ -11,6 +11,7 @@ afterEach(async () => {
   await clearTauriMocks()
   vi.restoreAllMocks()
   Reflect.deleteProperty(globalThis, 'window')
+  Reflect.deleteProperty(globalThis, 'navigator')
 })
 
 describe('Tauri process helpers', () => {
@@ -23,7 +24,7 @@ describe('Tauri process helpers', () => {
         expect(args).toMatchObject({
           program: 'agent-cli',
           args: ['--stdio'],
-          options: { encoding: 'raw' }
+          options: { encoding: 'raw', env: {} }
         })
         onEvent = (args as { onEvent: { onmessage: (event: unknown) => void } }).onEvent.onmessage
         return 42
@@ -54,6 +55,33 @@ describe('Tauri process helpers', () => {
     ])
     expect(calls[1]?.args).toEqual({ pid: 42, buffer: [4, 5] })
     expect(calls[2]?.args).toEqual({ cmd: 'killChild', pid: 42 })
+  })
+
+  test('starts Windows ACP command shims through cmd', async () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: { userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' }
+    })
+    await mockTauriIPC((cmd, args) => {
+      if (cmd === 'plugin:shell|spawn') {
+        expect(args).toMatchObject({
+          program: 'cmd',
+          args: ['/c', 'agent-cli', '--stdio'],
+          options: { encoding: 'raw', env: {} }
+        })
+        return 44
+      }
+      return null
+    })
+
+    const process = await spawnAcpProcess({
+      command: 'agent-cli',
+      args: ['--stdio'],
+      logId: 'test',
+      destroying: () => false,
+      onUnexpectedClose: vi.fn()
+    })
+    await process.child.kill()
   })
 
   test('signals unexpected ACP process close to the output stream', async () => {


### PR DESCRIPTION
## Summary

- Launch npm-installed ACP agents through `cmd /c` on Windows
- Reuse the resolver for MCP without dropping current transport settings
- Preserve the inherited ACP environment so Windows can resolve global shims
- Add focused command, ACP process, and MCP environment coverage

Supersedes #362 while preserving Damián Briones’s contribution.

Closes #361.

## Validation

- `bun run check` passed through lint, type, architecture, package, and duplication checks; the final audit step is currently blocked by a malformed compressed registry response
- 12 focused Tauri tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed globally installed ACP agents failing to start on Windows.
  * Improved Windows compatibility for MCP server and ACP process startup.
  * Preserved required startup settings, including environment configuration and command arguments.
* **Documentation**
  * Added an unreleased changelog entry describing the Windows startup fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->