### PR TITLE
fix: avoid SVG export stack overflow for large images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Export SVGs with large embedded image fills without overflowing the JavaScript call stack.
 - Save auto-layout frames that stretch their children to `.fig` without failing. (#427)
 - Reduce large `.fig` page-switch work to the active page and coalesce Layers tree rebuilds. (#420)
 - Center text glyphs within explicit line-height leading in CanvasKit paragraph rendering.

--- a/packages/core/src/io/base64.ts
+++ b/packages/core/src/io/base64.ts
@@ -4,6 +4,9 @@ export function uint8ArrayToBase64(bytes: Uint8Array): string {
   if (typeof Buffer !== 'undefined') {
     return Buffer.from(bytes).toString('base64')
   }
+  if (typeof btoa !== 'function') {
+    throw new TypeError('Base64 encoding is unavailable in this environment')
+  }
 
   let binary = ''
   for (let index = 0; index < bytes.length; index += BASE64_CHUNK_SIZE) {

--- a/packages/core/src/io/base64.ts
+++ b/packages/core/src/io/base64.ts
@@ -1,0 +1,14 @@
+const BASE64_CHUNK_SIZE = 0x8000
+
+export function uint8ArrayToBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64')
+  }
+
+  let binary = ''
+  for (let index = 0; index < bytes.length; index += BASE64_CHUNK_SIZE) {
+    const chunk = bytes.subarray(index, index + BASE64_CHUNK_SIZE)
+    binary += String.fromCharCode(...chunk)
+  }
+  return btoa(binary)
+}

--- a/packages/core/src/io/formats/svg/defs.ts
+++ b/packages/core/src/io/formats/svg/defs.ts
@@ -4,6 +4,7 @@ import type { Color } from '@open-pencil/scene-graph/primitives'
 import { colorToHex } from '#core/color'
 import { colorToDisplayCss, getDefaultRenderColorSpace } from '#core/color/management'
 import type { RenderColorSpace } from '#core/color/management'
+import { uint8ArrayToBase64 } from '#core/io/base64'
 
 import { svg, type SVGNode } from './node'
 import { round } from './paths'
@@ -109,7 +110,7 @@ function createImagePattern(
   if (!data) return null
 
   const id = nextDefId(ctx, 'img')
-  const base64 = btoa(String.fromCharCode(...data))
+  const base64 = uint8ArrayToBase64(data)
   const mime = detectImageMime(data)
 
   return {

--- a/packages/core/src/tools/vector/export.ts
+++ b/packages/core/src/tools/vector/export.ts
@@ -1,19 +1,6 @@
+import { uint8ArrayToBase64 } from '#core/io/base64'
 import type { RasterExportFormat } from '#core/io/formats/raster'
 import { defineTool } from '#core/tools/schema'
-
-const CHUNK_SIZE = 0x8000
-
-function uint8ArrayToBase64(bytes: Uint8Array): string {
-  if (typeof Buffer !== 'undefined') {
-    return Buffer.from(bytes).toString('base64')
-  }
-  let binary = ''
-  for (let index = 0; index < bytes.length; index += CHUNK_SIZE) {
-    const chunk = bytes.subarray(index, index + CHUNK_SIZE)
-    binary += String.fromCharCode(...chunk)
-  }
-  return btoa(binary)
-}
 
 export const exportSvg = defineTool({
   name: 'export_svg',

--- a/tests/engine/io/svg/export/image-fill.test.ts
+++ b/tests/engine/io/svg/export/image-fill.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'bun:test'
+
+import { exportSVGOrThrow, makeGraph, pageId } from './helpers'
+
+test('embeds large image fills without overflowing the call stack', () => {
+  const graph = makeGraph()
+  const imageHash = 'large-png'
+  const imageBytes = new Uint8Array(2_700_000)
+  imageBytes.set([0x89, 0x50, 0x4e, 0x47])
+  imageBytes.fill(0xa5, 4)
+  graph.images.set(imageHash, imageBytes)
+
+  const node = graph.createNode('RECTANGLE', pageId(graph), {
+    width: 100,
+    height: 100,
+    fills: [
+      {
+        type: 'IMAGE',
+        imageHash,
+        imageScaleMode: 'FILL',
+        color: { r: 0, g: 0, b: 0, a: 0 },
+        opacity: 1,
+        visible: true
+      }
+    ]
+  })
+
+  const result = exportSVGOrThrow(graph, [node.id])
+  const encoded = Buffer.from(imageBytes).toString('base64')
+  expect(result).toContain(`href="data:image/png;base64,${encoded}"`)
+})

--- a/tests/engine/io/svg/export/image-fill.test.ts
+++ b/tests/engine/io/svg/export/image-fill.test.ts
@@ -1,6 +1,31 @@
 import { expect, test } from 'bun:test'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { exportSVGOrThrow, makeGraph, pageId } from './helpers'
+
+const base64ModuleUrl = pathToFileURL(
+  resolve(import.meta.dir, '../../../../../packages/core/src/io/base64.ts')
+).href
+
+async function runWithoutBuffer(body: string) {
+  const process = Bun.spawn(
+    [
+      'bun',
+      '-e',
+      `globalThis.Buffer = undefined
+const { uint8ArrayToBase64 } = await import(${JSON.stringify(base64ModuleUrl)})
+${body}`
+    ],
+    { stdout: 'pipe', stderr: 'pipe' }
+  )
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited
+  ])
+  return { stdout, stderr, exitCode }
+}
 
 test('embeds large image fills without overflowing the call stack', () => {
   const graph = makeGraph()
@@ -28,4 +53,31 @@ test('embeds large image fills without overflowing the call stack', () => {
   const result = exportSVGOrThrow(graph, [node.id])
   const encoded = Buffer.from(imageBytes).toString('base64')
   expect(result).toContain(`href="data:image/png;base64,${encoded}"`)
+})
+
+test('chunks large payloads when Buffer is unavailable', async () => {
+  const size = 100_000
+  const bytes = Uint8Array.from({ length: size }, (_, index) => index % 251)
+  const result = await runWithoutBuffer(`
+const bytes = Uint8Array.from({ length: ${size} }, (_, index) => index % 251)
+process.stdout.write(uint8ArrayToBase64(bytes))`)
+
+  expect(result.exitCode).toBe(0)
+  expect(result.stderr).toBe('')
+  expect(result.stdout).toBe(Buffer.from(bytes).toString('base64'))
+})
+
+test('reports an unsupported environment without Buffer or btoa', async () => {
+  const result = await runWithoutBuffer(`
+globalThis.btoa = undefined
+try {
+  uint8ArrayToBase64(new Uint8Array([1, 2, 3]))
+} catch (error) {
+  process.stderr.write(error instanceof Error ? error.message : String(error))
+  process.exit(7)
+}`)
+
+  expect(result.exitCode).toBe(7)
+  expect(result.stdout).toBe('')
+  expect(result.stderr).toBe('Base64 encoding is unavailable in this environment')
 })


### PR DESCRIPTION
### Summary

Prevent SVG exports with large embedded image fills from throwing `Maximum call stack size exceeded`. The previous implementation spread every image byte into `String.fromCharCode`, which exceeds the JavaScript argument limit for multi-megabyte images.

### What changed

- Add a shared byte-to-base64 helper that uses `Buffer` when available and bounded chunks in browser runtimes.
- Use the helper for SVG image fills and the existing raster/PDF tool responses.
- Add a regression test with a 2.7 MB image fill, matching the size that reproduced the failure.
- Document the fix in the changelog.

### Validation

- [ ] `bun run check` — build, lint, type, Vue, i18n, package, and dependency checks passed through `check:deps`; `bun audit` returned HTTP 404. The remaining secret, monorepo, architecture, type-shape, tool, and duplication checks were run separately and passed.
- [x] `bun test tests/engine/io/svg/export/render.test.ts tests/engine/io/svg/export/image-fill.test.ts` — 35 passed, 0 failed.
- [x] Real CLI reproduction: exported a frame containing a 2,701,712-byte image fill in 22.07 seconds without a stack overflow; `xmllint --noout` accepted the 10.47 MB SVG.
- [ ] `bun run test:unit` — 2,237 passed; tests requiring Git LFS `.fig` fixtures failed because this environment only had pointer files, plus one unrelated MCP lifecycle race.
- [ ] `bun run test` — Playwright Chromium is not installed in this environment, so the browser suite could not start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SVG exports with large embedded images that could previously trigger a JavaScript call stack overflow.
  * Improved reliability of image embedding in SVG, PDF, and raster exports, including better handling when browser/Node encoding APIs are restricted.
* **Tests**
  * Added coverage for exporting SVGs with large image fills and for base64 encoding behavior across constrained environments (including clearer failure when encoding isn’t available).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->