### PR TITLE
perf(fig): index override convergence candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Match regional browser languages to supported locales without selecting a secondary language. (#417)
 - Save auto-layout frames that stretch their children to `.fig` without failing. (#427)
-- Reduce large `.fig` page-switch work to the active page and coalesce Layers tree rebuilds. (#420)
+- Reduce large `.fig` page-switch work to the active page, reuse fixed-point propagation indexes, and coalesce Layers tree rebuilds. (#420)
 - Center text glyphs within explicit line-height leading in CanvasKit paragraph rendering.
 
 ### Added

--- a/packages/fig/src/instance-overrides/index.ts
+++ b/packages/fig/src/instance-overrides/index.ts
@@ -85,10 +85,35 @@ function buildKiwiGeometryNodes(
   return result
 }
 
-function propagateResolvedFills(graph: SceneGraph, protectedNodes: Set<string>): void {
+function componentLinkedNodes(graph: SceneGraph): SceneNode[] {
+  const nodes: SceneNode[] = []
+  for (const node of graph.getAllNodes()) if (node.componentId) nodes.push(node)
+  return nodes
+}
+
+function instancePlacementPairs(
+  graph: SceneGraph
+): Array<{ sourceChildId: string; childId: string }> {
+  const pairs: Array<{ sourceChildId: string; childId: string }> = []
+  for (const node of graph.getAllNodes()) {
+    if (node.type !== 'INSTANCE' || !node.componentId) continue
+    const source = graph.getNode(node.componentId)
+    if (!source || source.childIds.length !== node.childIds.length) continue
+    for (let index = 0; index < node.childIds.length; index++) {
+      pairs.push({ sourceChildId: source.childIds[index], childId: node.childIds[index] })
+    }
+  }
+  return pairs
+}
+
+function propagateResolvedFills(
+  graph: SceneGraph,
+  protectedNodes: Set<string>,
+  candidates = componentLinkedNodes(graph)
+): void {
   for (let pass = 0; pass < 10; pass++) {
     let changed = false
-    for (const node of graph.getAllNodes()) {
+    for (const node of candidates) {
       if (!node.componentId) continue
       const source = graph.getNode(node.componentId)
       if (!source || isEqual(source.fills, node.fills)) continue
@@ -100,32 +125,30 @@ function propagateResolvedFills(graph: SceneGraph, protectedNodes: Set<string>):
   }
 }
 
-function propagateResolvedChildPlacementClones(graph: SceneGraph): void {
+function propagateResolvedChildPlacementClones(
+  graph: SceneGraph,
+  pairs = instancePlacementPairs(graph)
+): void {
   for (let pass = 0; pass < 10; pass++) {
     let changed = false
-    for (const node of graph.getAllNodes()) {
-      if (node.type !== 'INSTANCE' || !node.componentId) continue
-      const source = graph.getNode(node.componentId)
-      if (!source || source.childIds.length !== node.childIds.length) continue
-      for (let i = 0; i < node.childIds.length; i++) {
-        const sourceChild = graph.getNode(source.childIds[i])
-        const child = graph.getNode(node.childIds[i])
-        if (!sourceChild || !child) continue
-        if (
-          sourceChild.overrideKey &&
-          child.overrideKey &&
-          sourceChild.overrideKey !== child.overrideKey
-        ) {
-          continue
-        }
-        const updates: Partial<SceneNode> = {}
-        if (!sourceChild.visible && child.visible) updates.visible = false
-        if (sourceChild.x !== child.x) updates.x = sourceChild.x
-        if (sourceChild.y !== child.y) updates.y = sourceChild.y
-        if (Object.keys(updates).length === 0) continue
-        graph.updateNode(child.id, updates)
-        changed = true
+    for (const pair of pairs) {
+      const sourceChild = graph.getNode(pair.sourceChildId)
+      const child = graph.getNode(pair.childId)
+      if (!sourceChild || !child) continue
+      if (
+        sourceChild.overrideKey &&
+        child.overrideKey &&
+        sourceChild.overrideKey !== child.overrideKey
+      ) {
+        continue
       }
+      const updates: Partial<SceneNode> = {}
+      if (!sourceChild.visible && child.visible) updates.visible = false
+      if (sourceChild.x !== child.x) updates.x = sourceChild.x
+      if (sourceChild.y !== child.y) updates.y = sourceChild.y
+      if (Object.keys(updates).length === 0) continue
+      graph.updateNode(child.id, updates)
+      changed = true
     }
     if (!changed) return
   }


### PR DESCRIPTION
## Summary

- Build the global component-linked node list once before resolved fill convergence
- Build corresponding instance/source child pairs once before placement convergence
- Preserve the existing graph order, global scope, and fixed-point behavior

## Performance

Fresh Chromium processes were used for each baseline/indexed sample.

- `gold-preview.fig` median revisit: 780.5 ms → 770.7 ms (about 1.3%)
- `material3.fig` Tooltips median revisit: 279.8 ms → 267.2 ms (about 4.5%)

The optimization is intentionally small. It avoids repeated candidate discovery without changing Figma-compatible propagation semantics.

## Validation

- `bun run check`
- `bun test tests/engine/io/fig/import/instance-regressions.test.ts packages/fig/tests/instance-overrides.test.ts tests/engine/io/fig/import/lazy-pages.test.ts`
- 15 targeted tests pass, including nested visibility, fill, text, and placement overrides


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved page-switching performance in `.fig` files by reducing unnecessary processing and optimizing layer updates.
  * Improved the performance of instance overrides, including fill propagation and child placement handling.
* **Documentation**
  * Updated the unreleased changelog with additional details about the page-switching performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->