### PR TITLE
fix(canvas): keep canvas alive when toggling the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Keep the canvas rendering when hiding or showing the UI: the editor no longer remounts the canvas between layouts, and the retained scene backing stays within the GPU texture-size limit on wide HiDPI viewports.
 - Match regional browser languages to supported locales without selecting a secondary language. (#417)
 - Save auto-layout frames that stretch their children to `.fig` without failing. (#427)
 - Reduce large `.fig` page-switch work to the active page, reuse fixed-point propagation indexes, and coalesce Layers tree rebuilds. (#420)

--- a/packages/core/src/canvas/renderer.ts
+++ b/packages/core/src/canvas/renderer.ts
@@ -62,6 +62,19 @@ export interface PendingFontNode {
 
 import type { RenderOverlays, RulerTheme } from './renderer/types'
 
+/** Conservative floor mandated by the WebGL2 spec when the real limit is unknown. */
+const DEFAULT_MAX_TEXTURE_SIZE = 2048
+
+function readMaxTextureSize(gl: WebGL2RenderingContext | null): number {
+  if (!gl) return DEFAULT_MAX_TEXTURE_SIZE
+  try {
+    const size: unknown = gl.getParameter(gl.MAX_TEXTURE_SIZE)
+    return typeof size === 'number' && size > 0 ? size : DEFAULT_MAX_TEXTURE_SIZE
+  } catch {
+    return DEFAULT_MAX_TEXTURE_SIZE
+  }
+}
+
 export class SkiaRenderer {
   ck: CanvasKit
   surface: Surface
@@ -173,6 +186,8 @@ export class SkiaRenderer {
   panY = 0
   zoom = 1
   dpr = 1
+  /** GPU limit for a single texture dimension, in device pixels. */
+  maxTextureSize = DEFAULT_MAX_TEXTURE_SIZE
   viewportWidth = 0
   viewportHeight = 0
   showRulers = true
@@ -412,6 +427,7 @@ export class SkiaRenderer {
   constructor(ck: CanvasKit, surface: Surface, gl?: WebGL2RenderingContext | null) {
     this.ck = ck
     this.surface = surface
+    this.maxTextureSize = readMaxTextureSize(gl ?? null)
     this.profiler = new RenderProfiler(ck, gl ?? null)
     initializeRendererPaints(this)
   }

--- a/packages/core/src/canvas/renderer/retained-backing.ts
+++ b/packages/core/src/canvas/renderer/retained-backing.ts
@@ -153,11 +153,24 @@ function drawSceneBacking(
   return true
 }
 
+function maxSceneBackingPixels(r: SkiaRenderer): number {
+  return Math.max(1, r.maxTextureSize)
+}
+
 function sceneBackingGeometry(r: SkiaRenderer) {
+  // The backing texture is SCENE_BACKING_SCALE times the viewport in each axis,
+  // then multiplied again by dpr in createSceneBackingSurface. On a wide
+  // viewport with a HiDPI display that product overshoots the GPU's maximum
+  // texture dimension (commonly 16384), which makes the allocation fail. Cap
+  // the margin so the final pixel size always stays inside the limit — a
+  // smaller backing only costs extra re-records while panning.
+  const maxBackingPx = maxSceneBackingPixels(r)
+  const maxWidth = Math.max(1, Math.floor(maxBackingPx / r.dpr))
+  const maxHeight = Math.max(1, Math.floor(maxBackingPx / r.dpr))
   const marginX = r.viewportWidth * ((SCENE_BACKING_SCALE - 1) / 2)
   const marginY = r.viewportHeight * ((SCENE_BACKING_SCALE - 1) / 2)
-  const width = Math.max(1, Math.ceil(r.viewportWidth + marginX * 2))
-  const height = Math.max(1, Math.ceil(r.viewportHeight + marginY * 2))
+  const width = clamp(Math.ceil(r.viewportWidth + marginX * 2), 1, maxWidth)
+  const height = clamp(Math.ceil(r.viewportHeight + marginY * 2), 1, maxHeight)
   const backingPanX = r.panX + marginX
   const backingPanY = r.panY + marginY
   return {
@@ -175,13 +188,21 @@ function sceneBackingGeometry(r: SkiaRenderer) {
 }
 
 function createSceneBackingSurface(r: SkiaRenderer, width: number, height: number): Surface | null {
-  return r.surface.makeSurface({
-    width: Math.ceil(width * r.dpr),
-    height: Math.ceil(height * r.dpr),
-    colorType: r.ck.ColorType.RGBA_8888,
-    alphaType: r.ck.AlphaType.Premul,
-    colorSpace: r.ck.ColorSpace.SRGB
-  })
+  try {
+    // CanvasKit throws (rather than returning null) when the backing store
+    // cannot be allocated, so the null-check at the call sites is not enough
+    // on its own. Falling back to null just skips the retained backing for
+    // this frame; the scene still renders directly to the on-screen surface.
+    return r.surface.makeSurface({
+      width: Math.ceil(width * r.dpr),
+      height: Math.ceil(height * r.dpr),
+      colorType: r.ck.ColorType.RGBA_8888,
+      alphaType: r.ck.AlphaType.Premul,
+      colorSpace: r.ck.ColorSpace.SRGB
+    })
+  } catch {
+    return null
+  }
 }
 
 function ensureSubtreePictureCacheScope(

--- a/src/views/EditorView.vue
+++ b/src/views/EditorView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, provide, ref } from 'vue'
+import { computed, onMounted, onUnmounted, provide, ref } from 'vue'
 import { useEventListener, useUrlSearchParams } from '@vueuse/core'
 import { useRoute } from 'vue-router'
 import { useHead } from '@unhead/vue'
@@ -59,6 +59,15 @@ useEventListener(
   { passive: false }
 )
 
+// The canvas is mounted once and teleported into the slot exposed by the
+// active layout, so switching layouts never destroys the WebGL surface.
+const desktopCanvasSlot = ref<HTMLElement | null>(null)
+const fallbackCanvasSlot = ref<HTMLElement | null>(null)
+const showDesktopChrome = computed(() => !isMobile.value && showChrome && store.state.showUI)
+const canvasSlot = computed(() =>
+  showDesktopChrome.value ? desktopCanvasSlot.value : fallbackCanvasSlot.value
+)
+
 const automationCleanup = ref<(() => void) | null>(null)
 const mcpCleanup = ref<(() => void) | null>(null)
 const fileAssociationCleanup = ref<(() => void) | null>(null)
@@ -116,9 +125,16 @@ onUnmounted(() => {
     <SafariBanner />
     <TabBar />
 
-    <!-- Desktop layout -->
+    <!--
+      The canvas host is intentionally rendered exactly once, outside of any
+      v-if branch. Toggling `showUI` (or crossing the mobile breakpoint) only
+      swaps the surrounding chrome — it must never unmount `EditorCanvas`,
+      because a remount destroys the WebGL surface and the Skia renderer and
+      leaves the freshly mounted <canvas> at its 300x150 default until the
+      async CanvasKit re-init completes.
+    -->
     <SplitterGroup
-      v-if="!isMobile && showChrome && store.state.showUI"
+      v-show="showDesktopChrome"
       :key="activeTab?.id"
       direction="horizontal"
       class="flex-1 overflow-hidden"
@@ -140,10 +156,7 @@ onUnmounted(() => {
         <div class="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2" />
       </SplitterResizeHandle>
       <SplitterPanel id="canvas" :default-size="initialEditorLayout[1]" :min-size="30" class="flex">
-        <div class="relative flex min-w-0 flex-1">
-          <EditorCanvas />
-          <Toolbar />
-        </div>
+        <div ref="desktopCanvasSlot" class="relative flex min-w-0 flex-1" />
       </SplitterPanel>
       <SplitterResizeHandle class="group relative z-10 -mx-1 w-2 cursor-col-resize">
         <div class="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2" />
@@ -164,58 +177,41 @@ onUnmounted(() => {
       </SplitterPanel>
     </SplitterGroup>
 
-    <!-- Mobile layout -->
-    <div
-      v-else-if="isMobile && showChrome && store.state.showUI"
-      :key="'mobile-' + activeTab?.id"
-      class="flex flex-1 overflow-hidden"
-    >
-      <div class="relative flex min-w-0 flex-1">
-        <EditorCanvas />
-        <MobileHud />
-        <Toolbar />
-      </div>
-      <MobileDrawer />
+    <!-- Mobile / collapsed / bare layouts all reuse the same canvas host -->
+    <div v-show="!showDesktopChrome" class="flex flex-1 overflow-hidden">
+      <div ref="fallbackCanvasSlot" class="relative flex min-w-0 flex-1" />
+      <MobileDrawer v-if="isMobile && showChrome && store.state.showUI" />
     </div>
 
-    <!-- Collapsed UI (showUI=false) -->
-    <div
-      v-else-if="showChrome"
-      :key="'collapsed-' + activeTab?.id"
-      class="flex flex-1 overflow-hidden"
-    >
-      <div class="relative flex min-w-0 flex-1">
-        <EditorCanvas />
-        <div
-          v-if="!isMobile"
-          class="absolute top-7 left-7 z-10 flex items-center gap-2 rounded-lg border border-border bg-panel px-2 py-1 shadow-sm"
+    <!--
+      The single canvas instance. It is teleported into whichever slot the
+      active layout exposes; Teleport moves the existing DOM node instead of
+      recreating it, so the WebGL context survives every layout change.
+    -->
+    <Teleport v-if="canvasSlot" :to="canvasSlot">
+      <EditorCanvas />
+      <MobileHud v-if="isMobile && showChrome && store.state.showUI" />
+      <Toolbar v-if="showChrome && store.state.showUI" />
+      <div
+        v-if="showChrome && !store.state.showUI && !isMobile"
+        class="absolute top-7 left-7 z-10 flex items-center gap-2 rounded-lg border border-border bg-panel px-2 py-1 shadow-sm"
+      >
+        <img src="/favicon-32.png" class="size-4" alt="OpenPencil" />
+        <span data-test-id="editor-document-name" class="text-xs text-surface">{{
+          store.state.documentName
+        }}</span>
+        <Tip
+          :label="dialogs.showUI({ shortcut: formatShortcut(appMenuShortcut('toggle-ui')) ?? '' })"
         >
-          <img src="/favicon-32.png" class="size-4" alt="OpenPencil" />
-          <span data-test-id="editor-document-name" class="text-xs text-surface">{{
-            store.state.documentName
-          }}</span>
-          <Tip
-            :label="
-              dialogs.showUI({ shortcut: formatShortcut(appMenuShortcut('toggle-ui')) ?? '' })
-            "
+          <button
+            data-test-id="editor-show-ui"
+            class="ml-1 flex size-6 cursor-pointer items-center justify-center rounded text-muted transition-colors hover:bg-hover hover:text-surface"
+            @click="store.state.showUI = true"
           >
-            <button
-              data-test-id="editor-show-ui"
-              class="ml-1 flex size-6 cursor-pointer items-center justify-center rounded text-muted transition-colors hover:bg-hover hover:text-surface"
-              @click="store.state.showUI = true"
-            >
-              <icon-lucide-sidebar class="size-3.5" />
-            </button>
-          </Tip>
-        </div>
+            <icon-lucide-sidebar class="size-3.5" />
+          </button>
+        </Tip>
       </div>
-    </div>
-
-    <!-- Bare canvas (no chrome, e.g. ?no-chrome) -->
-    <div v-else :key="'bare-' + activeTab?.id" class="flex flex-1 overflow-hidden">
-      <div class="relative flex min-w-0 flex-1">
-        <EditorCanvas />
-      </div>
-    </div>
+    </Teleport>
   </div>
 </template>

--- a/tests/engine/render/canvas/retained-backing.test.ts
+++ b/tests/engine/render/canvas/retained-backing.test.ts
@@ -1,13 +1,13 @@
 import { expect, mock, test } from 'bun:test'
 
-import type { Canvas, Image as CKImage, Surface } from 'canvaskit-wasm'
+import type { Canvas, Image as CKImage, ImageInfo, Surface } from 'canvaskit-wasm'
 
 import type { SceneGraph } from '@open-pencil/scene-graph'
 
 import type { SkiaRenderer } from '#core/canvas/renderer'
 import { renderSceneBacking } from '#core/canvas/renderer/retained-backing'
 
-function createRenderer(surfaceFactory: () => Surface | null) {
+function createRenderer(surfaceFactory: (info: ImageInfo) => Surface | null) {
   const renderer: Partial<SkiaRenderer> = {
     ck: {
       AlphaType: { Premul: 'Premul' },
@@ -33,6 +33,7 @@ function createRenderer(surfaceFactory: () => Surface | null) {
     panY: 0,
     zoom: 1,
     dpr: 1,
+    maxTextureSize: 16384,
     viewportWidth: 100,
     viewportHeight: 100,
     pageColor: { r: 1, g: 1, b: 1 },
@@ -147,6 +148,62 @@ test('retained scene backing allows same-zoom previews while panning', () => {
 
   expect(renderSceneBacking(r, canvas, graph, 1)).toBe(true)
   expect(canvas.drawImageRectOptions).toHaveBeenCalled()
+})
+
+test('retained scene backing keeps the offscreen surface within the GPU texture limit', () => {
+  // Regression: a wide viewport on a HiDPI display asked for a backing texture
+  // larger than MAX_TEXTURE_SIZE, so the allocation failed and the canvas went
+  // blank. Reproduces the reported case: 2998x1490 CSS px at dpr 2, where the
+  // unclamped 3x margin would request ceil(2998*3)*2 = 17988 px of width.
+  const requested: Array<{ width: number; height: number }> = []
+  const r = createRenderer((info) => {
+    requested.push({ width: info.width, height: info.height })
+    return null
+  })
+  r.dpr = 2
+  r.maxTextureSize = 16384
+  r.viewportWidth = 2998
+  r.viewportHeight = 1490
+
+  renderSceneBacking(r, createCanvas(), createGraph(), 1)
+
+  expect(requested).not.toHaveLength(0)
+  for (const size of requested) {
+    expect(size.width).toBeLessThanOrEqual(r.maxTextureSize)
+    expect(size.height).toBeLessThanOrEqual(r.maxTextureSize)
+  }
+})
+
+test('retained scene backing does not shrink the margin when it already fits', () => {
+  const requested: Array<{ width: number; height: number }> = []
+  const r = createRenderer((info) => {
+    requested.push({ width: info.width, height: info.height })
+    return null
+  })
+  r.dpr = 2
+  r.maxTextureSize = 16384
+  r.viewportWidth = 1919
+  r.viewportHeight = 1490
+
+  renderSceneBacking(r, createCanvas(), createGraph(), 1)
+
+  // 1919 * 3 * 2 = 11514, comfortably inside the limit, so the full
+  // SCENE_BACKING_SCALE margin must be preserved.
+  expect(requested[0]).toEqual({ width: 11514, height: 8940 })
+})
+
+test('retained scene backing survives CanvasKit throwing instead of returning null', () => {
+  // CanvasKit raises "Cannot set properties of null" rather than returning null
+  // when it cannot allocate; the null-guard alone did not stop that from
+  // escaping as an uncaught TypeError.
+  const r = createRenderer(() => {
+    throw new TypeError("Cannot set properties of null (setting 'be')")
+  })
+  const canvas = createCanvas()
+
+  expect(() => renderSceneBacking(r, canvas, createGraph(), 1)).not.toThrow()
+  expect(r.sceneBacking).toBeNull()
+  expect(canvas.drawImageRectOptions).not.toHaveBeenCalled()
 })
 
 test('retained scene backing invalidates stale position-preview metadata', () => {


### PR DESCRIPTION
Fixes #432

### Summary

Hiding the UI (**Toggle UI** / `MOD+\`) blanked the canvas and raised an uncaught `TypeError: Cannot set properties of null (setting 'be')` from CanvasKit. Two independent causes were involved — fixing either one alone still left the bug reproducible, so both are addressed here.

### What changed

**1. The canvas is no longer remounted when the layout changes.**

`EditorView.vue` wrote `<EditorCanvas />` once inside each of four `v-if` / `v-else-if` / `v-else` layout branches. Toggling `showUI` swapped branches, and Vue destroyed the entire subtree — taking the WebGL surface and the Skia renderer with it. Reuse was impossible because the branch roots differ (`SplitterGroup` vs `<div>`) and each branch had a distinct `:key` prefix.

The canvas is now mounted exactly once, outside every branch, and `<Teleport>`ed into whichever slot the active layout exposes. Teleport moves the existing DOM node rather than recreating it, so the GL context survives. The layout branches themselves became `v-show` so both teleport targets stay in the DOM.

Verified by tagging the `<canvas>` nodes and toggling: the *same* node objects survive (`sameNodes: true`), `data-ready` stays set, and the backbuffer resizes (3838 → 5996 → 3838) instead of collapsing to the `300×150` default.

**2. The retained scene backing is clamped to the GPU texture limit.**

`sceneBackingGeometry` multiplied the viewport by `SCENE_BACKING_SCALE` (3) and `createSceneBackingSurface` multiplied again by `dpr`, unbounded. At 2998×1490 CSS px with `dpr` 2 that requests a **17988 px** wide texture against a `MAX_TEXTURE_SIZE` of **16384**, so the allocation fails. With the panels open the same math yields 11514 px and stays under the limit — which is why the bug only appeared once the panels closed and the viewport widened.

The backing is now clamped so the final pixel size stays within `MAX_TEXTURE_SIZE`, read once from the GL context in the `SkiaRenderer` constructor (falling back to the WebGL2-mandated floor of 2048 when unavailable). A smaller backing only costs extra re-records while panning; `worldWidth`/`worldHeight` derive from the clamped values, so the existing coverage checks stay consistent.

Separately, `createSceneBackingSurface` now catches. It was already typed `Surface | null` with an `if (!surface) return` guard at the call site, but CanvasKit *throws* rather than returning `null`, so that guard never ran.

### AI assistance

Models: Claude Opus 5

### Validation

- [ ] `bun run check`
- [x] Tests added or updated, or not needed because: explain here
- [x] CHANGELOG.md updated, or not needed because: explain here

**On `bun run check`** — it does not pass end-to-end in my environment, for reasons unrelated to this change:

- `check:secrets` fails because neither `gitleaks` nor `go` is installed locally. This change introduces no credentials.
- 78 engine tests fail on this machine **and fail identically on unmodified `master`**: the `.fig` fixtures under `tests/fixtures/` are unfetched git-LFS pointer files, so `unzipSync` rejects them. None of the failures reference the code touched here.

Everything else passes: `lint` (0 errors), `tsgo --noEmit`, `check:vue`, `check:arch`, `check:monorepo`, `check:i18n`, `check:packages`, `test:type-shapes`, `test:dupes`.

**Tests** — three regression tests added to `tests/engine/render/canvas/retained-backing.test.ts`:

- the backing stays within `MAX_TEXTURE_SIZE` at the reported 2998×1490 @ dpr 2 geometry;
- the margin is *not* shrunk when it already fits (asserts the exact `11514×8940` request, so the clamp cannot silently over-trim);
- `renderSceneBacking` does not propagate a throwing `makeSurface`.

I confirmed these fail without the fix — reverting the clamp makes the first test fail with `Received: 17988`, matching the value measured in the browser.

**Manual verification** — reproduced and confirmed fixed in the running app: drew a rectangle, toggled the UI three times, and checked the console after each. Zero errors, rendering intact, panels/layers/selection preserved, and tab switching still behaves correctly.
