### PR TITLE
feat(ai): add Atlas Cloud provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Added
 
+- Connect Atlas Cloud as a direct OpenAI-compatible AI provider with curated and custom models.
 - Export selections, pages and documents as editable PowerPoint (`.pptx`) files from the File menu, CLI and SDK: text, rectangles, ellipses and lines stay native editable elements, while gradients, masks, blends, vectors and icons fall back to embedded images.
 - Figma-style Assets panel browsing with component thumbnails, grid/list views, page grouping, context actions, and drag-to-canvas insertion.
 - Import HTML, CSS, Tailwind, and JSX as editable documents from the app, CLI, and SDK, and export standalone browser-ready HTML with compiled CSS and optional external assets.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -178,6 +178,7 @@ export type AIProviderID =
   | 'openai'
   | 'google'
   | 'deepseek'
+  | 'atlascloud'
   | 'openai-compatible'
   | 'zai'
   | 'minimax'
@@ -270,6 +271,21 @@ export const AI_PROVIDERS: AIProviderDef[] = [
     models: [
       { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', tag: 'Fast' },
       { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', tag: 'Reasoning' }
+    ]
+  },
+  {
+    id: 'atlascloud',
+    name: 'Atlas Cloud',
+    keyPlaceholder: 'API key',
+    keyURL: 'https://www.atlascloud.ai/console/api-keys',
+    defaultModel: 'deepseek-ai/deepseek-v4-pro',
+    supportsCustomModel: true,
+    models: [
+      {
+        id: 'deepseek-ai/deepseek-v4-pro',
+        name: 'DeepSeek V4 Pro',
+        tag: 'Reasoning'
+      }
     ]
   },
   {

--- a/src/app/ai/chat/model.ts
+++ b/src/app/ai/chat/model.ts
@@ -12,6 +12,7 @@ export function resolveLanguageModelID(
 ): string {
   if (
     config.providerID === 'openrouter' ||
+    config.providerID === 'atlascloud' ||
     config.providerID === 'openai-compatible' ||
     config.providerID === 'anthropic-compatible'
   ) {

--- a/src/app/ai/providers/registry.ts
+++ b/src/app/ai/providers/registry.ts
@@ -40,6 +40,10 @@ const MODEL_PROVIDER_ADAPTERS = {
       return createDeepSeek({ apiKey: config.apiKey, fetch: runtime.fetch })(config.modelID)
     }
   },
+  atlascloud: createOpenAICompatibleAdapter({
+    baseURL: 'https://api.atlascloud.ai/v1',
+    mode: 'chat'
+  }),
   zai: createAnthropicCompatibleAdapter({ baseURL: 'https://api.z.ai/api/anthropic' }),
   minimax: createOpenAICompatibleAdapter({ baseURL: 'https://api.minimax.io/v1', mode: 'chat' }),
   'openai-compatible': createOpenAICompatibleAdapter({

--- a/tests/engine/app/ai/atlascloud-provider.test.ts
+++ b/tests/engine/app/ai/atlascloud-provider.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test'
+
+import { AI_PROVIDERS } from '@open-pencil/core/constants'
+
+import { resolveLanguageModelID } from '@/app/ai/chat/model'
+import { modelProviderAdapter } from '@/app/ai/providers/registry'
+
+describe('Atlas Cloud provider', () => {
+  test('registers the default and custom model configuration', () => {
+    const provider = AI_PROVIDERS.find((candidate) => candidate.id === 'atlascloud')
+    expect(provider).toMatchObject({
+      defaultModel: 'deepseek-ai/deepseek-v4-pro',
+      supportsCustomModel: true
+    })
+    if (!provider) throw new Error('Atlas Cloud provider is not registered')
+
+    expect(
+      resolveLanguageModelID({
+        providerID: 'atlascloud',
+        modelID: provider.defaultModel,
+        customModelID: '  qwen/qwen3-coder  '
+      })
+    ).toBe('qwen/qwen3-coder')
+  })
+
+  test('creates a chat-completions model', () => {
+    const model = modelProviderAdapter('atlascloud').create(
+      {
+        providerID: 'atlascloud',
+        apiKey: 'test-key',
+        modelID: 'deepseek-ai/deepseek-v4-pro',
+        customModelID: '',
+        customBaseURL: '',
+        customAPIType: 'completions'
+      },
+      {}
+    )
+    expect(model.modelId).toBe('deepseek-ai/deepseek-v4-pro')
+  })
+})


### PR DESCRIPTION
### Summary

Add Atlas Cloud as a direct AI provider so model profiles can use its OpenAI-compatible chat completions endpoint without entering a custom base URL.

### What changed

- Registered Atlas Cloud with a curated default model and custom model ID support.
- Routed Atlas Cloud through the existing OpenAI-compatible chat adapter at `https://api.atlascloud.ai/v1`.
- Added focused tests for provider metadata, custom model resolution, and chat model creation.
- Updated the Unreleased changelog.

### AI assistance

Models: OpenAI Codex (GPT-5)

### Validation

- [ ] `bun run check` (not run: the full repository archive could not be fetched in this environment)
- [x] Repository `oxfmt` and custom `oxlint` passed on all changed TypeScript files
- [x] `bun test tests/engine/app/ai/atlascloud-provider.test.ts` (2 passed)
- [x] Live `generateText` request through the Atlas Cloud adapter completed successfully
- [x] `CHANGELOG.md` updated

No README, published documentation, or locale files were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Atlas Cloud as an OpenAI-compatible AI provider.
  * Added the default DeepSeek reasoning model.
  * Added support for custom model IDs.

* **Documentation**
  * Updated the changelog with Atlas Cloud availability.

* **Tests**
  * Added coverage for provider registration, default models, custom models, and model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->