### PR TITLE
fix(ai): opt into Anthropic direct browser access

### DIFF
--- a/src/app/ai/providers/compatible.ts
+++ b/src/app/ai/providers/compatible.ts
@@ -1,7 +1,13 @@
 import { createAnthropic } from '@ai-sdk/anthropic'
 import { createOpenAI } from '@ai-sdk/openai'
 
+import { IS_TAURI } from '@open-pencil/core/constants'
+
 import type { ModelConfig, ModelProviderAdapter } from '@/app/ai/providers/types'
+
+// Anthropic omits CORS headers unless the caller opts in, so browser requests fail with an
+// opaque "failed to fetch". The desktop build goes through tauriFetch and is not subject to CORS.
+const BROWSER_ACCESS_HEADERS = { 'anthropic-dangerous-direct-browser-access': 'true' }
 
 export type CompatibleEndpoint = string | ((config: ModelConfig) => string)
 
@@ -48,7 +54,8 @@ export function createAnthropicCompatibleAdapter(
       const provider = createAnthropic({
         apiKey: config.apiKey,
         baseURL: resolveEndpoint(options.baseURL, config),
-        fetch: runtime.fetch
+        fetch: runtime.fetch,
+        headers: IS_TAURI ? undefined : BROWSER_ACCESS_HEADERS
       })
       return provider(config.customModelID.trim() || config.modelID)
     }

--- a/tests/engine/app/ai/model.test.ts
+++ b/tests/engine/app/ai/model.test.ts
@@ -4,7 +4,9 @@ import { AI_PROVIDERS } from '@open-pencil/core/constants'
 
 import { resolveLanguageModelID } from '@/app/ai/chat/model'
 import { normalizeOpenRouterModel } from '@/app/ai/chat/provider-models'
+import { createAnthropicCompatibleAdapter } from '@/app/ai/providers/compatible'
 import { modelProviderAdapter } from '@/app/ai/providers/registry'
+import type { ModelConfig } from '@/app/ai/providers/types'
 
 describe('resolveLanguageModelID', () => {
   test('uses the selected OpenRouter model when no custom model is configured', () => {
@@ -35,6 +37,41 @@ describe('model provider registry', () => {
     }
     expect(() => modelProviderAdapter('acp:claude-code')).toThrow(
       'ACP providers do not use direct API models'
+    )
+  })
+})
+
+describe('anthropic compatible adapter', () => {
+  const config: ModelConfig = {
+    providerID: 'anthropic',
+    apiKey: 'test-key',
+    modelID: 'claude-sonnet-4.6',
+    customModelID: '',
+    customBaseURL: '',
+    customAPIType: 'completions'
+  }
+
+  async function capturedHeaders(): Promise<Record<string, string>> {
+    let captured: Record<string, string> = {}
+    const fetchSpy: typeof fetch = async (_input, init) => {
+      captured = Object.fromEntries(new Headers(init?.headers).entries())
+      throw new Error('stop')
+    }
+
+    const model = createAnthropicCompatibleAdapter().create(config, { fetch: fetchSpy })
+    await model
+      .doGenerate({ prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }] })
+      .catch(() => undefined)
+
+    return captured
+  }
+
+  test('opts into direct browser access so Anthropic returns CORS headers', async () => {
+    // Anthropic omits Access-Control-Allow-Origin unless this header is sent, which makes the
+    // web build fail with an opaque network error. See #436.
+    expect(await capturedHeaders()).toHaveProperty(
+      'anthropic-dangerous-direct-browser-access',
+      'true'
     )
   })
 })


### PR DESCRIPTION
### Summary

Fixes #436. The `anthropic` provider could not work in the web build.

Anthropic does support direct browser calls, but gates them behind an explicit opt-in header. Without it they omit `Access-Control-Allow-Origin` entirely, so the browser discards the response and `fetch` rejects with a generic failure — which OpenPencil surfaces as *"Could not reach this endpoint from the browser"*, indistinguishable from a wrong API key.

`@ai-sdk/anthropic@3.0.74` sends only `x-api-key` and `anthropic-version`; the string `dangerous-direct-browser-access` does not appear anywhere in the package. `createAnthropicCompatibleAdapter` didn't add it either, so nothing in the stack sent it.

Verified against the live API:

```console
$ curl -sD - -o /dev/null -X POST https://api.anthropic.com/v1/messages \
    -H "Origin: https://openpencil.dev" -H "content-type: application/json" -d '{}'
HTTP/2 401
(no access-control-allow-origin)

$ curl -sD - -o /dev/null -X POST https://api.anthropic.com/v1/messages \
    -H "Origin: https://openpencil.dev" -H "content-type: application/json" \
    -H "anthropic-dangerous-direct-browser-access: true" -d '{}'
HTTP/2 401
access-control-allow-origin: *
access-control-expose-headers: *
```

### What changed

- `createAnthropicCompatibleAdapter` now sends `anthropic-dangerous-direct-browser-access: true`, gated on `!IS_TAURI`. The desktop build routes through `tauriFetch` and isn't subject to CORS, so it has no reason to advertise browser access.
- Add a test that drives the adapter with a fake `fetch` and asserts the header reaches the request. Confirmed it fails without the source change (`Unable to find property`) and passes with it — it isn't a tautological test.

### Scope note for reviewers

The header applies to every provider built on this adapter — `anthropic`, `zai`, and user-configured `anthropic-compatible` endpoints — not just direct Anthropic.

A custom header widens the CORS preflight, so a strict endpoint could in principle reject a request that previously succeeded. I checked the two endpoints we ship, and both reflect it back:

```console
# Access-Control-Request-Headers: …,anthropic-dangerous-direct-browser-access
api.z.ai        → 200, access-control-allow-headers: …, anthropic-dangerous-direct-browser-access
api.anthropic.com → 200, access-control-allow-headers: …,anthropic-dangerous-direct-browser-access
```

A third-party `anthropic-compatible` proxy with a strict allow-list is the residual risk. If you'd prefer to narrow it, the alternative is to send the header only when `options.baseURL` is undefined (direct Anthropic). Happy to change it — I went with the broader scope because the header is Anthropic's own mechanism and an Anthropic-compatible endpoint should tolerate it.

Worth noting the header name is Anthropic's wording, not ours: it signals the user's API key lives in browser storage. That's already true of every other provider we support in the web build, and OpenPencil encrypts credentials at rest, but it's a deliberate choice rather than an implicit one.

### AI assistance

Models: Claude Opus 5

### Validation

- [x] `bunx tsgo --noEmit` — clean. `oxlint` on the changed file — 0 warnings, 0 errors. `oxfmt` applied to both files.
- [x] Tests added or updated: `tests/engine/app/ai/model.test.ts` — 6 pass / 0 fail. Verified the new test fails when the source change is reverted.
- [ ] CHANGELOG.md updated, or not needed because: bug fix to previously non-functional behaviour; happy to add an entry if you'd like one.

Full `bun run check` not run locally — `check:secrets` requires `gitleaks` or `go`, neither of which is installed in my environment (it fails on clean `master` too). Ran the type, lint, format, and test stages that this change touches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Anthropic-compatible AI access across browser and desktop app environments.
  * Browser requests now include the required access header, while desktop requests omit it when unnecessary.

* **Tests**
  * Added coverage to verify the correct request headers are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->