### PR TITLE
fix(design-jsx): stop reporting SVG attributes as unsupported props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Stop warning AI agents that supported inline SVG attributes were ignored. (#445)
 - Help AI agents discover every shape supported by `create_shape`. (#448)
 - Keep `fill="none"` and `stroke="none"` SVG paths transparent when rendering inline artwork. (#446)
 - Match regional browser languages to supported locales without selecting a secondary language. (#417)

--- a/packages/core/src/design-jsx/render.ts
+++ b/packages/core/src/design-jsx/render.ts
@@ -140,12 +140,19 @@ function unsupportedPropWarnings(tree: TreeNode): string[] {
   return warnings
 }
 
+const SVG_ROOT_PROPS = new Set([...SUPPORTED_PROPS, 'viewBox', 'body'])
+
 function collectUnsupportedPropWarnings(tree: TreeNode, warnings: string[]): void {
+  const supportedProps = tree.type === 'svg' ? SVG_ROOT_PROPS : SUPPORTED_PROPS
   for (const key of Object.keys(tree.props)) {
-    if (!SUPPORTED_PROPS.has(key)) {
+    if (!supportedProps.has(key)) {
       warnings.push(`Unsupported prop "${key}" on <${tree.type}> is ignored.`)
     }
   }
+
+  // SVG descendants are parsed as markup by renderSvgNode, not as Design JSX nodes.
+  if (tree.type === 'svg') return
+
   for (const child of tree.children) {
     if (isTreeNode(child)) collectUnsupportedPropWarnings(child, warnings)
   }

--- a/tests/engine/tools/create.test.ts
+++ b/tests/engine/tools/create.test.ts
@@ -85,6 +85,20 @@ describe('render', () => {
     expect(result.warnings).toEqual(['Unsupported prop "mt" on <frame> is ignored.'])
   })
 
+  test('accepts SVG markup attributes without hiding invalid root props', async () => {
+    const { figma } = setupToolTest()
+    const render = getTool('render')
+    const valid = (await render.execute(figma, {
+      jsx: '<svg name="Boat" viewBox="0 0 640 700" size={600}><path d="M380 40 L380 560" stroke="#021A3B" stroke-width="6" fill="none" /></svg>'
+    })) as ToolResult
+    const invalid = (await render.execute(figma, {
+      jsx: '<svg viewBox="0 0 1 1" mt={8}><path d="M0 0 L1 1" /></svg>'
+    })) as ToolResult
+
+    expect(valid.warnings).toBeUndefined()
+    expect(invalid.warnings).toEqual(['Unsupported prop "mt" on <svg> is ignored.'])
+  })
+
   test('get_node exposes text style fields', async () => {
     const { figma } = setupToolTest()
     const render = getTool('render')


### PR DESCRIPTION
## Problem

`collectUnsupportedPropWarnings` checks every prop on every element against a single flat `SUPPORTED_PROPS` set, which only contains design-JSX props (`w`, `h`, `bg`, `gap`, …). SVG attributes are never in that set, so rendering

```jsx
<svg viewBox="0 0 640 700" size={600}>
  <path d="M380 40 L380 560" stroke="#021A3B" stroke-width="6" fill="none" />
</svg>
```

returns:

```
Unsupported prop "viewBox" on <svg> is ignored.
Unsupported prop "d" on <path> is ignored.
Unsupported prop "stroke-width" on <path> is ignored.
```

All three are false. `renderSvgNode` reads `viewBox` (`renderer.ts:289`), `d` and `stroke-width` (`renderer.ts:274-278`). The same call produces a node with real geometry and a scaled stroke.

## Why it matters

The warnings are returned to the caller, and an AI agent using the `render` tool takes them at face value. Asked to draw an outline drawing, one rendered correct geometry on its first attempt, read `Unsupported prop`, concluded `<svg>` was unsupported, deleted the node, and fell back to hand-building vector networks through `eval` — which produced nothing on canvas.

## Fix

Stop descending into `<svg>`. Everything inside it is SVG markup parsed by the SVG renderer, not design props. The `<svg>` element's own props are still validated against the design set plus `viewBox`/`size`/`body`/`color`.

## Test

`does not warn about SVG attributes inside <svg>` in `tests/engine/tools/create.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline SVG handling so valid attributes no longer generate unsupported-property warnings.
  * Continued validation of unexpected properties on the root SVG element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->