### PR TITLE
fix(icons): honour fill="none" and stroke="none"

### DIFF
--- a/packages/core/src/icons/render.ts
+++ b/packages/core/src/icons/render.ts
@@ -33,7 +33,10 @@ export function createIconFromPaths(
     vector.x = 0
     vector.y = 0
 
-    if (path.fill) {
+    // `fill="none"` is a non-empty string, so a truthiness check treats it as a
+    // colour and parseColor() falls back to black — outline drawings came out
+    // as solid black blobs.
+    if (path.fill && path.fill !== 'none') {
       const fillColor = path.fill === 'currentColor' ? color : parseColor(path.fill)
       graph.updateNode(vector.id, {
         fills: [{ type: 'SOLID', color: fillColor, opacity: 1, visible: true }]
@@ -42,7 +45,7 @@ export function createIconFromPaths(
       graph.updateNode(vector.id, { fills: [] })
     }
 
-    if (path.stroke) {
+    if (path.stroke && path.stroke !== 'none') {
       const strokeColor = path.stroke === 'currentColor' ? color : parseColor(path.stroke)
       graph.updateNode(vector.id, {
         strokes: [createPathStroke(strokeColor, path.strokeWidth, path.strokeCap, path.strokeJoin)]

--- a/tests/engine/icons/render.test.ts
+++ b/tests/engine/icons/render.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test'
+
+import { SceneGraph } from '@open-pencil/scene-graph'
+
+import { createIconFromPaths } from '#core/icons/render'
+import type { IconData, IconPath } from '#core/icons/types'
+
+import { expectDefined } from '#tests/helpers/assert'
+
+const BLACK = { r: 0, g: 0, b: 0, a: 1 }
+
+function iconPath(overrides: Partial<IconPath>): IconPath {
+  return {
+    vectorNetwork: {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 }
+      ],
+      segments: [{ start: 0, end: 1, tangentStart: { x: 0, y: 0 }, tangentEnd: { x: 0, y: 0 } }],
+      regions: []
+    },
+    fill: null,
+    stroke: null,
+    strokeWidth: 1,
+    strokeCap: 'butt',
+    strokeJoin: 'miter',
+    ...overrides
+  }
+}
+
+function renderIcon(paths: IconPath[]) {
+  const graph = new SceneGraph()
+  const page = graph.createNode('CANVAS', graph.rootId, { name: 'Page 1' })
+  const icon: IconData = { prefix: 'test', name: 'test', width: 24, height: 24, paths }
+  const frame = createIconFromPaths(graph, icon, 'Test', 24, BLACK, page.id)
+  return frame.childIds.map((id) => expectDefined(graph.getNode(id), 'path node'))
+}
+
+describe('createIconFromPaths', () => {
+  test('treats fill="none" as no fill', () => {
+    // "none" is a non-empty string, so a truthiness check sent it to
+    // parseColor(), which falls back to black on unparseable input — every
+    // outline drawing came out as a solid black blob.
+    const [node] = renderIcon([iconPath({ fill: 'none', stroke: '#021A3B', strokeWidth: 6 })])
+    expect(node.fills).toEqual([])
+    expect(node.strokes.length).toBe(1)
+  })
+
+  test('treats stroke="none" as no stroke', () => {
+    const [node] = renderIcon([iconPath({ fill: '#FF0000', stroke: 'none' })])
+    expect(node.strokes).toEqual([])
+    expect(node.fills.length).toBe(1)
+  })
+
+  test('still paints a real fill colour', () => {
+    const [node] = renderIcon([iconPath({ fill: '#FF0000' })])
+    expect(node.fills.length).toBe(1)
+    expect(node.fills[0].color.r).toBeCloseTo(1)
+  })
+})


### PR DESCRIPTION
## Problem

`createIconFromPaths` gates painting on truthiness:

```ts
if (path.fill) {
  const fillColor = path.fill === 'currentColor' ? color : parseColor(path.fill)
```

`"none"` is a non-empty string, so it takes the paint branch. `parseColor("none")` does not parse and falls back to black, so `fill="none"` produces an opaque black fill.

Inline `<svg>` in design JSX runs through this same pipeline — `renderSvgNode` builds an `IconData` and calls `createIconFromPaths` — so every outline drawing comes back as solid black shapes sitting on top of their own strokes:

```jsonc
// node rendered from <path stroke="#021A3B" stroke-width="6" fill="none" />
{ "strokes": [{ "color": navy, "weight": 5.14 }],
  "fills":   [{ "type": "SOLID", "color": { "r": 0, "g": 0, "b": 0, "a": 1 } }] }
```

The vectorize path already gets this right — `svg/to-vectors.ts` guards with `path.fill !== 'none'` in both `resolveFill` and `resolveStrokes`. This just brings the icon path in line.

## Why it matters

`describe` then summarises the node by its fill, reporting `#000000`. An agent drawing a sailboat outline read that back, concluded its stroke props had not applied, patched fills by hand through `eval`, second-guessed the result and deleted it.

## Fix

Skip the paint when the value is `"none"`, for both fill and stroke.

## Test

`tests/engine/icons/render.test.ts` — new file, three cases. Fails on master (2 of 3), passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon rendering by correctly ignoring `none` fill and stroke values.
  * Preserved valid fill and stroke colors for accurate icon appearance.

* **Tests**
  * Added coverage for icons with absent and valid fill or stroke colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->