### PR TITLE
fix(tools): report stroke colour and weight in describe summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Show stroke colors and weights in AI visual descriptions. (#447)
 - Stop warning AI agents that supported inline SVG attributes were ignored. (#445)
 - Help AI agents discover every shape supported by `create_shape`. (#448)
 - Keep `fill="none"` and `stroke="none"` SVG paths transparent when rendering inline artwork. (#446)

--- a/packages/core/src/tools/describe/summaries.ts
+++ b/packages/core/src/tools/describe/summaries.ts
@@ -16,6 +16,13 @@ function findSolidFillIndex(node: SceneNode): number {
   return node.fills.findIndex((candidate) => candidate.type === 'SOLID' && candidate.visible)
 }
 
+function strokeSummary(node: SceneNode): string | null {
+  const stroke = node.strokes.find((candidate) => candidate.visible)
+  if (!stroke) return null
+  const weight = Math.round(stroke.weight * 100) / 100
+  return `${colorToHex(stroke.color)} ${weight}px stroke`
+}
+
 export function describeVisual(node: SceneNode, graph?: SceneGraph): string {
   const parts: string[] = []
   const fillIndex = findSolidFillIndex(node)
@@ -23,7 +30,8 @@ export function describeVisual(node: SceneNode, graph?: SceneGraph): string {
     const fill = node.fills[fillIndex]
     parts.push(`${colorToHex(fill.color)}${boundFillSuffix(node, fillIndex, graph)} fill`)
   }
-  if (node.strokes.length > 0 && node.strokes[0]?.visible) parts.push('bordered')
+  const stroke = strokeSummary(node)
+  if (stroke) parts.push(stroke)
   if (node.cornerRadius > 0) parts.push('rounded')
   if (node.clipsContent) parts.push('clipped')
   for (const effect of node.effects) {
@@ -83,6 +91,8 @@ export function summarizeContainer(node: SceneNode, graph?: SceneGraph): string 
     const fill = node.fills[fillIndex]
     parts.push(`${colorToHex(fill.color)}${boundFillSuffix(node, fillIndex, graph)}`)
   }
+  const stroke = strokeSummary(node)
+  if (stroke) parts.push(stroke)
   if (node.cornerRadius > 0) parts.push('rounded')
   const layout = describeLayout(node)
   if (layout) parts.push(layout)

--- a/tests/engine/tools/describe.test.ts
+++ b/tests/engine/tools/describe.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { Color, Stroke } from '@open-pencil/scene-graph'
+
+import { expectDefined } from '#tests/helpers/assert'
+import { getTool, setupToolTest, type ToolResult } from '#tests/helpers/tools'
+
+const NAVY: Color = { r: 2 / 255, g: 26 / 255, b: 59 / 255, a: 1 }
+
+const HIDDEN_STROKE: Stroke = {
+  color: { r: 1, g: 0, b: 0, a: 1 },
+  weight: 4,
+  opacity: 1,
+  visible: false,
+  align: 'CENTER',
+  cap: 'NONE',
+  join: 'MITER'
+}
+
+const VISIBLE_STROKE: Stroke = {
+  color: NAVY,
+  weight: 10.126,
+  opacity: 1,
+  visible: true,
+  align: 'CENTER',
+  cap: 'NONE',
+  join: 'MITER'
+}
+
+interface ChildSummary {
+  summary: string
+}
+
+function setupStrokedChild() {
+  const { figma, graph } = setupToolTest()
+  const frame = figma.createFrame()
+  frame.name = 'Outline'
+  frame.resize(200, 200)
+
+  const outline = figma.createRectangle()
+  outline.resize(100, 4)
+  frame.appendChild(outline)
+  graph.updateNode(outline.id, {
+    fills: [],
+    strokes: [HIDDEN_STROKE, VISIBLE_STROKE]
+  })
+
+  return { figma, frameId: frame.id, outlineId: outline.id }
+}
+
+describe('describe stroke summaries', () => {
+  test('reports the first visible stroke in a child summary', () => {
+    const { figma, frameId } = setupStrokedChild()
+    const result = getTool('describe').execute(figma, { id: frameId }) as ToolResult
+    const children = result.children as ChildSummary[]
+    const summary = expectDefined(children[0], 'stroked child summary').summary
+
+    expect(summary).toContain('#021A3B 10.13px stroke')
+  })
+
+  test('reports the first visible stroke in the node visual summary', () => {
+    const { figma, outlineId } = setupStrokedChild()
+    const result = getTool('describe').execute(figma, { id: outlineId }) as ToolResult
+
+    expect(result.visual).toContain('#021A3B 10.13px stroke')
+  })
+})


### PR DESCRIPTION
## Problem

`describeVisual` collapses any stroke to the bare word `bordered`, and `summarizeContainer` omits strokes entirely.

For a filled rectangle that is fine — the fill carries the appearance. For an outline drawing the stroke *is* the appearance, so ten correctly stroked paths summarise as:

```
900×900, #000000      ← the fill, which shouldn't even be there
1000×1000             ← once fills are correct: nothing at all
```

A correctly stroked path is indistinguishable from an empty node.

## Why it matters

`describe` is how an agent verifies its own work. Asked to draw a sailboat outline, one rendered ten correct stroked paths, read the summaries back, could not see any stroke, concluded the render had failed, and deleted it — then ran out of steps.

With the fix the same run reads:

```
1000×1000, #021A3B 10.91px stroke
```

and proceeds to positioning instead of starting over.

## Fix

Report colour and weight in both builders, via a shared `strokeSummary` helper.

## Test

`tests/engine/tools/describe.test.ts` — new file. Both cases fail on master, pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual descriptions now report the first visible stroke’s color and rounded weight in pixels.
  * Stroke details are included in both child and container visual summaries.

* **Bug Fixes**
  * Hidden strokes are excluded, improving the accuracy of reported border styling.

* **Documentation**
  * Added a changelog entry describing the enhanced stroke information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->