### PR TITLE
fix(tools): name every supported node type in the create_shape description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Help AI agents discover every shape supported by `create_shape`. (#448)
 - Keep `fill="none"` and `stroke="none"` SVG paths transparent when rendering inline artwork. (#446)
 - Match regional browser languages to supported locales without selecting a secondary language. (#417)
 - Save auto-layout frames that stretch their children to `.fig` without failing. (#427)

--- a/packages/core/src/tools/create/basic.ts
+++ b/packages/core/src/tools/create/basic.ts
@@ -5,7 +5,7 @@ export const createShape = defineTool({
   name: 'create_shape',
   mutates: true,
   description:
-    'Create a shape on the canvas. Use FRAME for containers/cards, RECTANGLE for solid blocks, ELLIPSE for circles, TEXT for labels, SECTION for page sections.',
+    'Create a shape on the canvas. Use FRAME for containers/cards, RECTANGLE for solid blocks, ELLIPSE for circles, TEXT for labels, LINE for rules and dividers, STAR for starbursts and badges, POLYGON for triangles and regular polygons, and SECTION for page sections. Use create_vector with an SVG path for arbitrary shapes.',
   params: {
     type: {
       type: 'string',

--- a/tests/engine/tools/create.test.ts
+++ b/tests/engine/tools/create.test.ts
@@ -28,6 +28,14 @@ describe('create_shape', () => {
     expect(node.height).toBe(400)
   })
 
+  test('names every supported node type in the tool description', () => {
+    const tool = getTool('create_shape')
+    const supportedTypes = tool.params.type.enum ?? []
+
+    expect(supportedTypes.length).toBeGreaterThan(0)
+    expect(supportedTypes.filter((type) => !tool.description.includes(type))).toEqual([])
+  })
+
   test('creates nested inside parent', () => {
     const { figma } = setupToolTest()
     const tool = getTool('create_shape')


### PR DESCRIPTION
## Problem

`create_shape` accepts eight node types:

```ts
enum: ['FRAME', 'RECTANGLE', 'ELLIPSE', 'TEXT', 'LINE', 'STAR', 'POLYGON', 'SECTION']
```

but the description only named four of them. `STAR`, `POLYGON`, `LINE` and `SECTION` were supported and unmentioned.

A model choosing a tool reads the prose, not the enum. Asked for a star, agents concluded stars were impossible and hand-rasterised one out of rectangles instead of passing `type: "STAR"`.

## Fix

Name all eight, each with the case it is for, and point at `create_vector` for anything outside the set.

## Test

`every supported node type is named in the description` — asserts the enum and the prose cannot drift apart again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded shape-creation guidance for lines, stars, and polygons.
  * Clarified that custom or unsupported shapes can be created with SVG paths.

* **Tests**
  * Added coverage confirming that all supported shape types appear in the shape-creation tool description.

* **Changelog**
  * Documented improved discoverability of supported shapes for AI-assisted creation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->