### PR TITLE
ci: move Git LFS to provider-neutral gateway

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,2 +1,2 @@
 [lfs]
-	url = https://c163e722363f1cc881b9e0d1b8834b85:0c5c80a008ef8a9e5f215e438698ac52dcc9473760667eb3c539932c7a745281@git-lfs-s3-proxy.pages.dev/ca633c52af8f8351ed72fb5d12b423f0.r2.cloudflarestorage.com/open-pencil-lfs
+	url = https://lfs.openpencil.dev

--- a/packages/core/src/design-jsx/renderer.ts
+++ b/packages/core/src/design-jsx/renderer.ts
@@ -253,7 +253,10 @@ async function renderSvgNode(
   const props = tree.props
   const explicitW = typeof props.w === 'number' ? props.w : 0
   const explicitH = typeof props.h === 'number' ? props.h : 0
-  const size = explicitW > 0 || explicitH > 0 ? Math.max(explicitW, explicitH) : ((props.size as number | undefined) ?? 24)
+  const size =
+    explicitW > 0 || explicitH > 0
+      ? Math.max(explicitW, explicitH)
+      : ((props.size as number | undefined) ?? 24)
   const colorHex = (props.color as string | undefined) ?? '#000000'
   const parsedColor = parseColor(colorHex)
 
@@ -278,13 +281,18 @@ async function renderSvgNode(
           strokeWidth: Number(child.props['stroke-width'] ?? child.props.strokeWidth ?? 1),
           strokeCap: (child.props['stroke-linecap'] as string | undefined) ?? 'butt',
           strokeJoin: (child.props['stroke-linejoin'] as string | undefined) ?? 'miter',
-          fillRule: (child.props['fill-rule'] as string | undefined) === 'evenodd' ? 'EVENODD' as const : 'NONZERO' as const
+          fillRule:
+            (child.props['fill-rule'] as string | undefined) === 'evenodd'
+              ? ('EVENODD' as const)
+              : ('NONZERO' as const)
         }
       })
       .filter((p): p is NonNullable<typeof p> => p !== null)
   }
   if (pathInfos.length === 0) {
-    throw new Error('<svg> requires SVG markup as children, a body prop, or <path d="..."> children')
+    throw new Error(
+      '<svg> requires SVG markup as children, a body prop, or <path d="..."> children'
+    )
   }
 
   const vb = parseViewBox(props.viewBox as string | undefined)
@@ -303,7 +311,10 @@ async function renderSvgNode(
 
 function parseViewBox(viewBox: string | undefined): { w: number; h: number } {
   if (!viewBox) return { w: 0, h: 0 }
-  const parts = viewBox.trim().split(/[\s,]+/).map(Number)
+  const parts = viewBox
+    .trim()
+    .split(/[\s,]+/)
+    .map(Number)
   const w = parts[2] ?? 0
   const h = parts[3] ?? 0
   return { w, h }


### PR DESCRIPTION
## Summary

- Replace the credential-bearing Cloudflare R2 LFS URL with `https://lfs.openpencil.dev`
- Keep S3 provider configuration and storage credentials behind the OpenPencil LFS gateway
- Restore fresh clones after the former R2 backend began returning `403 NotEntitled`

Fixes #457.

## Validation

- Fetched every LFS object referenced by current `master` through the public gateway
- Verified each downloaded SHA-256 against its LFS OID
- Ran `git lfs fsck --objects`
- Cloned the branch without local object sharing, ran `git lfs pull`, and verified all current fixtures

## Infrastructure

The gateway implementation lives at https://github.com/open-pencil/git-lfs-s3-proxy and sends object transfers directly to the configured S3-compatible provider through short-lived presigned URLs. Public downloads require no credentials; uploads use a separate uncommitted token.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Git LFS service endpoint for improved configuration and security.

* **Style**
  * Improved code formatting for SVG rendering and viewBox parsing without changing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->