### PR TITLE
ci: update GitHub Actions to Node 24

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -25,7 +25,7 @@ runs:
 
     - uses: oven-sh/setup-bun@v2
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v6
       with:
         path: ~/.bun/install/cache
         key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-bun
 
@@ -22,7 +22,7 @@ jobs:
 
       - run: bun run build
 
-      - uses: cloudflare/wrangler-action@v3
+      - uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -125,9 +125,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-bun
         with:
@@ -39,7 +39,7 @@ jobs:
         group: [app, dom, editor, fig, render, scene, vue]
     name: Unit tests (${{ matrix.group }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-bun
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,73 @@
+name: Deploy preview
+
+on:
+  workflow_run:
+    workflows: [Preview]
+    types: [completed]
+
+concurrency:
+  group: deploy-preview-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.pull_requests[0].number != null
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
+      pull-requests: write
+    environment:
+      name: preview
+      url: ${{ steps.deploy.outputs.deployment-url }}
+    steps:
+      - name: Download validated preview artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: preview-dist
+          path: dist
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Deploy preview
+        uses: cloudflare/wrangler-action@v4
+        id: deploy
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: npm
+          command: pages deploy dist --project-name=openpencil-app --branch=pr-${{ github.event.workflow_run.pull_requests[0].number }}
+
+      - name: Comment preview URL
+        uses: actions/github-script@v9
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.deployment-url }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        with:
+          script: |
+            const url = process.env.PREVIEW_URL;
+            const issue_number = Number(process.env.PR_NUMBER);
+            if (!url || !Number.isInteger(issue_number)) {
+              core.setFailed('Preview deployment metadata is incomplete');
+              return;
+            }
+            const marker = '<!-- preview-deploy -->';
+            const body = `${marker}\n🔗 Preview: ${url}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo, issue_number
+            });
+            const existing = comments.find(comment => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo, comment_id: existing.id, body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number, body
+              });
+            }

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,13 +13,13 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-bun
 
       - run: bun run --filter @open-pencil/docs build
 
-      - uses: cloudflare/wrangler-action@v3
+      - uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-bun
         with:

--- a/.github/workflows/pr-review-guidance.yml
+++ b/.github/workflows/pr-review-guidance.yml
@@ -20,13 +20,13 @@ jobs:
       pull-requests: read
     steps:
       - name: Check out trusted workflow scripts
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,7 +23,7 @@ jobs:
       name: preview
       url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -34,7 +34,7 @@ jobs:
 
       - run: bun run build
 
-      - uses: cloudflare/wrangler-action@v3
+      - uses: cloudflare/wrangler-action@v4
         id: deploy
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -42,7 +42,7 @@ jobs:
           command: pages deploy dist --project-name=openpencil-app --branch=${{ github.event.pull_request.head.ref }}
 
       - name: Comment preview URL
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const url = '${{ steps.deploy.outputs.deployment-url }}';

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,7 +1,7 @@
 name: Preview
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [master]
     paths-ignore:
       - 'packages/docs/**'
@@ -12,21 +12,14 @@ concurrency:
   group: preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   preview:
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      deployments: write
-      pull-requests: write
-    environment:
-      name: preview
-      url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: ./.github/actions/setup-bun
 
@@ -35,30 +28,10 @@ jobs:
 
       - run: bun run build
 
-      - uses: cloudflare/wrangler-action@v4
-        id: deploy
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v7
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=openpencil-app --branch=${{ github.event.pull_request.head.ref }}
-
-      - name: Comment preview URL
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const url = '${{ steps.deploy.outputs.deployment-url }}';
-            const marker = '<!-- preview-deploy -->';
-            const body = `${marker}\n🔗 Preview: ${url}`;
-            const { data: comments } = await github.rest.issues.listComments({
-              ...context.repo, issue_number: context.issue.number
-            });
-            const existing = comments.find(c => c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                ...context.repo, comment_id: existing.id, body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                ...context.repo, issue_number: context.issue.number, body
-              });
-            }
+          name: preview-dist
+          path: dist
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### Summary

Update GitHub Actions dependencies to Node.js 24-compatible releases and stop privileged preview jobs from trying to execute code from fork pull requests.

### What changed

- Upgrade checkout, cache, setup-node, github-script, and Wrangler actions to current Node.js 24-compatible majors.
- Refresh the SHA-pinned checkout and setup-node actions used by trusted PR review guidance.
- Build PR previews without secrets, upload the validated static artifact, and deploy only same-repository artifacts from a separate trusted workflow.

### AI assistance

Models: OpenAI ChatGPT

### Validation

- [x] `bun run check`
- [x] `bun run format:check`
- [x] Tests not needed because this only updates workflow action versions and preview orchestration; all workflow YAML files were parsed locally.
- [x] CHANGELOG.md not needed because this is CI-only maintenance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated preview deployments for eligible pull requests, including deployment links in pull request comments.
  * Preview builds are now validated and passed securely between build and deployment stages.

* **Bug Fixes**
  * Preview workflows now use read-only access and run only for pull requests from the same repository, improving security.

* **Chores**
  * Updated automated build, test, deployment, documentation, caching, and publishing workflows for improved reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->