### PR TITLE
fix(fig): scale target-aspect instance subtrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,9 @@
 
 ### Fixed
 
-- Match Figma auto-layout spacing, padding, min/max constraints, scalar variable bindings, CanvasKit-shaped generated text, imported text bounds, and nested instance geometry more closely.
-- Match Figma Plugin API vector path and network editing, including bounds, transforms, winding rules, region fills, validation, and handle mirroring. (#444)
+- Scale proportion-constrained `.fig` instance geometry through fixed wrapper layers so imported logos and icons retain their intended size.
+- Match Figma auto-layout spacing, padding, min/max constraints, scalar variable bindings, imported text bounds, and nested instance geometry more closely.
+- Match Figma Plugin API vector path and network editing, including bounds, winding rules, region fills, validation, and handle mirroring. (#444)
 - Let AI and MCP tools create arbitrary vectors from SVG path data, validating input without leaving blank layers behind. (#440)
 - Improve AI design accuracy by exposing every supported shape, including visible stroke colors and weights in visual descriptions, and accepting supported inline SVG attributes without false warnings. (#445, #447, #448)
 - Restore Anthropic AI connections in the web app instead of failing with a browser endpoint error. (#438)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@
 ### Fixed
 
 - Scale proportion-constrained `.fig` instance geometry through fixed wrapper layers so imported logos and icons retain their intended size.
-- Match Figma auto-layout spacing, padding, min/max constraints, scalar variable bindings, imported text bounds, and nested instance geometry more closely.
-- Match Figma Plugin API vector path and network editing, including bounds, winding rules, region fills, validation, and handle mirroring. (#444)
+- Match Figma auto-layout spacing, padding, min/max constraints, scalar variable bindings, CanvasKit-shaped generated text, imported text bounds, and nested instance geometry more closely.
+- Match Figma Plugin API vector path and network editing, including bounds, transforms, winding rules, region fills, validation, and handle mirroring. (#444)
 - Let AI and MCP tools create arbitrary vectors from SVG path data, validating input without leaving blank layers behind. (#440)
 - Improve AI design accuracy by exposing every supported shape, including visible stroke colors and weights in visual descriptions, and accepting supported inline SVG attributes without false warnings. (#445, #447, #448)
 - Restore Anthropic AI connections in the web app instead of failing with a browser endpoint error. (#438)

--- a/packages/fig/src/instance-overrides/constraints.ts
+++ b/packages/fig/src/instance-overrides/constraints.ts
@@ -10,9 +10,14 @@ import { overrideCandidates } from './utils'
 
 const MAX_CLONE_CHAIN_DEPTH = 10
 
+interface ScaleDescendantAxes {
+  horizontal: boolean
+  vertical: boolean
+}
+
 interface InstanceScale {
   basis: SceneNode
-  scaleEntireSubtree: boolean
+  scaleThroughFixedWrappers: boolean
   sx: number
   sy: number
   useCurrentChildAsSource: boolean
@@ -52,7 +57,7 @@ export function applyConstraintScaling(ctx: OverrideContext): void {
       ctx.geometryOverrideNodes,
       scale.useCurrentChildAsSource,
       strokeScale,
-      scale.scaleEntireSubtree
+      scale.scaleThroughFixedWrappers
     )
   }
 
@@ -68,13 +73,13 @@ function resolveInstanceScale(
   const resolvedBasis = resolveScaleBasis(graph, instance, component)
   if (!targetAspectRatio && !resolvedBasis) return null
   const basis = resolvedBasis ?? component
-  const scaleEntireSubtree = targetAspectRatio !== null
+  const scaleThroughFixedWrappers = targetAspectRatio !== null
   return {
     basis,
-    scaleEntireSubtree,
-    sx: instance.width / (targetAspectRatio?.width ?? basis.width),
-    sy: instance.height / (targetAspectRatio?.height ?? basis.height),
-    useCurrentChildAsSource: scaleEntireSubtree || basis !== component
+    scaleThroughFixedWrappers,
+    sx: instance.width / basis.width,
+    sy: instance.height / basis.height,
+    useCurrentChildAsSource: basis !== component
   }
 }
 
@@ -268,6 +273,40 @@ function scaledGeometryUpdates(
   return updates
 }
 
+function scaleDescendantAxes(
+  graph: SceneGraph,
+  node: SceneNode,
+  cache: Map<string, ScaleDescendantAxes>
+): ScaleDescendantAxes {
+  const cached = cache.get(node.id)
+  if (cached) return cached
+  const result: ScaleDescendantAxes = { horizontal: false, vertical: false }
+  for (const child of graph.getChildren(node.id)) {
+    const nested = scaleDescendantAxes(graph, child, cache)
+    result.horizontal ||= child.horizontalConstraint === 'SCALE' || nested.horizontal
+    result.vertical ||= child.verticalConstraint === 'SCALE' || nested.vertical
+    if (result.horizontal && result.vertical) break
+  }
+  cache.set(node.id, result)
+  return result
+}
+
+function childScaleAxes(
+  graph: SceneGraph,
+  child: SceneNode,
+  scaleThroughFixedWrappers: boolean,
+  cache: Map<string, ScaleDescendantAxes>
+): ScaleDescendantAxes {
+  const descendantAxes = scaleDescendantAxes(graph, child, cache)
+  return {
+    horizontal:
+      child.horizontalConstraint === 'SCALE' ||
+      (scaleThroughFixedWrappers && descendantAxes.horizontal),
+    vertical:
+      child.verticalConstraint === 'SCALE' || (scaleThroughFixedWrappers && descendantAxes.vertical)
+  }
+}
+
 function scaleChildren(
   graph: SceneGraph,
   instance: SceneNode,
@@ -278,7 +317,8 @@ function scaleChildren(
   geometryOverrideNodes: Set<string>,
   useCurrentChildAsSource = false,
   strokeScale?: number,
-  scaleEntireSubtree = false
+  scaleThroughFixedWrappers = false,
+  descendantScaleCache = new Map<string, ScaleDescendantAxes>()
 ): void {
   const len = Math.min(instance.childIds.length, comp.childIds.length)
   for (let i = 0; i < len; i++) {
@@ -286,8 +326,9 @@ function scaleChildren(
     const compChild = graph.getNode(comp.childIds[i])
     if (!child || !compChild) continue
 
-    const hScale = scaleEntireSubtree || child.horizontalConstraint === 'SCALE'
-    const vScale = scaleEntireSubtree || child.verticalConstraint === 'SCALE'
+    const scaleAxes = childScaleAxes(graph, child, scaleThroughFixedWrappers, descendantScaleCache)
+    const hScale = scaleAxes.horizontal
+    const vScale = scaleAxes.vertical
     if (!hScale && !vScale) continue
 
     const updates: Partial<SceneNode> = {}
@@ -321,7 +362,8 @@ function scaleChildren(
         geometryOverrideNodes,
         useCurrentChildAsSource,
         strokeScale,
-        scaleEntireSubtree
+        scaleThroughFixedWrappers,
+        descendantScaleCache
       )
     }
   }

--- a/packages/fig/src/instance-overrides/constraints.ts
+++ b/packages/fig/src/instance-overrides/constraints.ts
@@ -2,12 +2,21 @@ import type { SceneGraph, SceneNode, VectorNetwork } from '@open-pencil/scene-gr
 import { copyGeometryPaths, scaleGeometryPaths } from '@open-pencil/scene-graph/copy'
 import { constrainedChildRect } from '@open-pencil/scene-graph/resize'
 
+import { readEffectiveFigmaRawField } from '../source-metadata'
 import { isFieldProtected } from './patches'
 import { buildClonesMap } from './sync'
 import type { OverrideContext } from './types'
 import { overrideCandidates } from './utils'
 
 const MAX_CLONE_CHAIN_DEPTH = 10
+
+interface InstanceScale {
+  basis: SceneNode
+  scaleEntireSubtree: boolean
+  sx: number
+  sy: number
+  useCurrentChildAsSource: boolean
+}
 
 /**
  * Apply SCALE constraint resizing to children of instances whose size
@@ -22,14 +31,13 @@ export function applyConstraintScaling(ctx: OverrideContext): void {
     if (node.type !== 'INSTANCE' || !node.componentId) continue
     const comp = graph.getNode(node.componentId)
     if (!comp || comp.width <= 0 || comp.height <= 0) continue
-    const basis = resolveScaleBasis(graph, node, comp)
-    if (!basis) continue
+    const scale = resolveInstanceScale(graph, node, comp)
+    if (!scale) continue
 
-    positionPinnedAbsoluteChildren(ctx, node, basis)
+    positionPinnedAbsoluteChildren(ctx, node, scale.basis)
     if (node.layoutMode !== 'NONE') continue
 
-    const sx = node.width / basis.width
-    const sy = node.height / basis.height
+    const { sx, sy } = scale
     if (Math.abs(sx - 1) < 0.001 && Math.abs(sy - 1) < 0.001) continue
 
     const figmaId = ctx.nodeIdToGuid.get(node.id)
@@ -42,12 +50,51 @@ export function applyConstraintScaling(ctx: OverrideContext): void {
       sy,
       scaled,
       ctx.geometryOverrideNodes,
-      basis !== comp,
-      strokeScale
+      scale.useCurrentChildAsSource,
+      strokeScale,
+      scale.scaleEntireSubtree
     )
   }
 
   if (scaled.size > 0) propagateScaling(ctx, scaled)
+}
+
+function resolveInstanceScale(
+  graph: SceneGraph,
+  instance: SceneNode,
+  component: SceneNode
+): InstanceScale | null {
+  const targetAspectRatio = resolveTargetAspectRatio(instance)
+  const resolvedBasis = resolveScaleBasis(graph, instance, component)
+  if (!targetAspectRatio && !resolvedBasis) return null
+  const basis = resolvedBasis ?? component
+  const scaleEntireSubtree = targetAspectRatio !== null
+  return {
+    basis,
+    scaleEntireSubtree,
+    sx: instance.width / (targetAspectRatio?.width ?? basis.width),
+    sy: instance.height / (targetAspectRatio?.height ?? basis.height),
+    useCurrentChildAsSource: scaleEntireSubtree || basis !== component
+  }
+}
+
+function resolveTargetAspectRatio(instance: SceneNode): { width: number; height: number } | null {
+  const rawTarget = readEffectiveFigmaRawField(instance, 'targetAspectRatio')
+  if (!rawTarget || typeof rawTarget !== 'object' || !('value' in rawTarget)) return null
+  const value = rawTarget.value
+  if (!value || typeof value !== 'object' || !('x' in value) || !('y' in value)) return null
+  const { x, y } = value
+  if (
+    typeof x !== 'number' ||
+    typeof y !== 'number' ||
+    !Number.isFinite(x) ||
+    !Number.isFinite(y) ||
+    x <= 0 ||
+    y <= 0
+  ) {
+    return null
+  }
+  return { width: x, height: y }
 }
 
 function isCloneOfSource(graph: SceneGraph, child: SceneNode, sourceId: string): boolean {
@@ -230,7 +277,8 @@ function scaleChildren(
   scaled: Set<string>,
   geometryOverrideNodes: Set<string>,
   useCurrentChildAsSource = false,
-  strokeScale?: number
+  strokeScale?: number,
+  scaleEntireSubtree = false
 ): void {
   const len = Math.min(instance.childIds.length, comp.childIds.length)
   for (let i = 0; i < len; i++) {
@@ -238,8 +286,8 @@ function scaleChildren(
     const compChild = graph.getNode(comp.childIds[i])
     if (!child || !compChild) continue
 
-    const hScale = child.horizontalConstraint === 'SCALE'
-    const vScale = child.verticalConstraint === 'SCALE'
+    const hScale = scaleEntireSubtree || child.horizontalConstraint === 'SCALE'
+    const vScale = scaleEntireSubtree || child.verticalConstraint === 'SCALE'
     if (!hScale && !vScale) continue
 
     const updates: Partial<SceneNode> = {}
@@ -272,7 +320,8 @@ function scaleChildren(
         scaled,
         geometryOverrideNodes,
         useCurrentChildAsSource,
-        strokeScale
+        strokeScale,
+        scaleEntireSubtree
       )
     }
   }

--- a/packages/fig/tests/instance-overrides.test.ts
+++ b/packages/fig/tests/instance-overrides.test.ts
@@ -156,6 +156,34 @@ describe('@open-pencil/fig instance interpretation', () => {
     expect(placeholder).toMatchObject({ x: 16, y: 10, text: 'Placeholder' })
   })
 
+  test('scales target-aspect instance geometry through fixed wrappers', () => {
+    const graph = new SceneGraph()
+    const pageId = graph.getPages()[0].id
+    const component = graph.createNode('COMPONENT', pageId, { width: 310, height: 62 })
+    const wrapper = graph.createNode('FRAME', component.id, { width: 310, height: 61.214 })
+    graph.createNode('VECTOR', wrapper.id, {
+      width: 56.392,
+      height: 61.214,
+      horizontalConstraint: 'SCALE',
+      verticalConstraint: 'SCALE'
+    })
+    const instance = graph.createNode('INSTANCE', pageId, {
+      width: 100,
+      height: 20,
+      componentId: component.id
+    })
+    instance.source.fig.rawNodeFields.targetAspectRatio = { value: { x: 310, y: 62 } }
+
+    populateAndApplyOverrides(graph, new Map(), new Map())
+
+    const scaledWrapper = graph.getChildren(instance.id)[0]
+    const scaledShape = graph.getChildren(scaledWrapper.id)[0]
+    expect(scaledWrapper.width).toBeCloseTo(100)
+    expect(scaledWrapper.height).toBeCloseTo((61.214 * 20) / 62)
+    expect(scaledShape.width).toBeCloseTo((56.392 * 100) / 310)
+    expect(scaledShape.height).toBeCloseTo((61.214 * 20) / 62)
+  })
+
   test('limits lazy population to required global propagation scans', () => {
     const graph = new SceneGraph()
     const activePage = graph.getPages()[0]

--- a/packages/fig/tests/instance-overrides.test.ts
+++ b/packages/fig/tests/instance-overrides.test.ts
@@ -161,7 +161,15 @@ describe('@open-pencil/fig instance interpretation', () => {
     const pageId = graph.getPages()[0].id
     const component = graph.createNode('COMPONENT', pageId, { width: 310, height: 62 })
     const wrapper = graph.createNode('FRAME', component.id, { width: 310, height: 61.214 })
-    graph.createNode('VECTOR', wrapper.id, {
+    const inset = graph.createNode('RECTANGLE', wrapper.id, {
+      x: 250,
+      y: 10,
+      width: 20,
+      height: 20,
+      horizontalConstraint: 'MAX',
+      verticalConstraint: 'MIN'
+    })
+    const vector = graph.createNode('VECTOR', wrapper.id, {
       width: 56.392,
       height: 61.214,
       horizontalConstraint: 'SCALE',
@@ -177,11 +185,48 @@ describe('@open-pencil/fig instance interpretation', () => {
     populateAndApplyOverrides(graph, new Map(), new Map())
 
     const scaledWrapper = graph.getChildren(instance.id)[0]
-    const scaledShape = graph.getChildren(scaledWrapper.id)[0]
+    const scaledShape = graph.getChildren(scaledWrapper.id)[1]
+    const preservedInset = graph.getChildren(scaledWrapper.id)[0]
     expect(scaledWrapper.width).toBeCloseTo(100)
     expect(scaledWrapper.height).toBeCloseTo((61.214 * 20) / 62)
-    expect(scaledShape.width).toBeCloseTo((56.392 * 100) / 310)
-    expect(scaledShape.height).toBeCloseTo((61.214 * 20) / 62)
+    expect(preservedInset).toMatchObject({
+      x: inset.x,
+      y: inset.y,
+      width: inset.width,
+      height: inset.height
+    })
+    expect(scaledShape.width).toBeCloseTo((vector.width * 100) / 310)
+    expect(scaledShape.height).toBeCloseTo((vector.height * 20) / 62)
+  })
+
+  test('uses target-aspect metadata only to reach scale-constrained descendants', () => {
+    const graph = new SceneGraph()
+    const pageId = graph.getPages()[0].id
+    const component = graph.createNode('COMPONENT', pageId, { width: 24, height: 24 })
+    const vector = graph.createNode('VECTOR', component.id, {
+      x: 9,
+      y: 3,
+      width: 6,
+      height: 6,
+      horizontalConstraint: 'SCALE',
+      verticalConstraint: 'SCALE'
+    })
+    const instance = graph.createNode('INSTANCE', pageId, {
+      width: 14,
+      height: 14,
+      componentId: component.id
+    })
+    instance.source.fig.rawNodeFields.targetAspectRatio = { value: { x: 32, y: 32 } }
+
+    populateAndApplyOverrides(graph, new Map(), new Map())
+
+    const scaledVector = graph.getChildren(instance.id)[0]
+    expect(scaledVector).toMatchObject({
+      x: (vector.x * 14) / 24,
+      y: (vector.y * 14) / 24,
+      width: (vector.width * 14) / 24,
+      height: (vector.height * 14) / 24
+    })
   })
 
   test('limits lazy population to required global propagation scans', () => {


### PR DESCRIPTION
## Summary

- Use preserved Figma `targetAspectRatio` metadata to continue scaling through fixed wrapper layers.
- Scale only branches that lead to descendants with explicit `SCALE` constraints.
- Preserve fixed, pinned, centered, and unrelated siblings inside the same subtree.
- Add regression coverage modeled on a 310×62 vector logo instantiated at 100×20 and ordinary resized icons.
- Document the import-fidelity fix in the Unreleased changelog.

## Root cause

Constraint scaling stopped at a fixed wrapper frame, so scale-constrained vector paths nested below it retained the component's original geometry and rendered oversized or clipped.

The initial fix used `targetAspectRatio` as permission to scale the entire populated subtree. Real-file validation showed that was too broad: Preline contains 1,297 target-aspect instances, and whole-subtree scaling changed 537 vector nodes, including icons that were already correct.

The adapted implementation uses target-aspect metadata only to allow traversal through fixed wrappers. Each branch is cached and traversed only when it contains an explicit horizontal or vertical `SCALE` descendant. The component remains the geometry basis, preventing ordinary resized icons from being scaled twice.

## Impact

Proportion-constrained `.fig` instances such as logos retain their intended size when vector geometry is nested under fixed wrapper layers, without changing unrelated target-aspect icons or fixed sibling geometry.

## Validation

- `bun run check`
- `bun --cwd packages/fig test` — 33 passed
- Shadcn fixture — no affected geometry
- Preline fixture — 0 geometry changes across 427,980 nodes
- Duplication detection — 0 clones

## Attribution

Zack Chapple authored the original target-aspect scaling contribution. The maintainer adaptation narrows its traversal semantics against current `master` and adds real-file regression coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the intended sizing and proportions of imported logos and icons.
  - Improved scaling for proportion-constrained graphics, including nested elements, vector content, and fixed-size wrappers.
  - Preserved inset and constraint geometry when resizing graphics to a target aspect ratio.
  - Applied scaling consistently to descendants with scale constraints.
  - Ignored invalid or missing sizing metadata to prevent incorrect geometry changes.

- **Documentation**
  - Added an Unreleased changelog entry describing the sizing improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->