### PR TITLE
fix(fig): preserve imported text and clone geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 ### Fixed
 
 - Preserve Figma’s imported glyph outlines through layout and appearance updates so text keeps its intended weight and shape.
+- Keep swapped image avatars and thin stepper dividers at their effective imported size and position.
 - Scale proportion-constrained `.fig` instance geometry through fixed wrapper layers so imported logos and icons retain their intended size.
 - Match Figma auto-layout spacing, padding, min/max constraints, scalar variable bindings, CanvasKit-shaped generated text, imported text bounds, and nested instance geometry more closely.
 - Match Figma Plugin API vector path and network editing, including bounds, transforms, winding rules, region fills, validation, and handle mirroring. (#444)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 
 ### Fixed
 
-- Keep the canvas rendering when hiding or showing the UI on wide HiDPI viewports by bounding retained scene backing allocations and falling back to direct rendering when CanvasKit rejects an offscreen surface.
+- Preserve Figma’s imported glyph outlines through layout and appearance updates so text keeps its intended weight and shape.
 - Scale proportion-constrained `.fig` instance geometry through fixed wrapper layers so imported logos and icons retain their intended size.
 - Match Figma auto-layout spacing, padding, min/max constraints, scalar variable bindings, CanvasKit-shaped generated text, imported text bounds, and nested instance geometry more closely.
 - Match Figma Plugin API vector path and network editing, including bounds, transforms, winding rules, region fills, validation, and handle mirroring. (#444)

--- a/packages/fig/src/instance-overrides/derived-symbol-data/propagate.ts
+++ b/packages/fig/src/instance-overrides/derived-symbol-data/propagate.ts
@@ -48,6 +48,88 @@ function buildCloneUpdates(
   return updates
 }
 
+export function reconcileEffectiveCloneGeometry(
+  ctx: OverrideContext,
+  scaledInstanceIds: Set<string>
+): void {
+  restoreScaledInstanceLeafBounds(ctx, scaledInstanceIds)
+  restoreThinCloneCrossPositions(ctx)
+}
+
+function restoreScaledInstanceLeafBounds(
+  ctx: OverrideContext,
+  scaledInstanceIds: Set<string>
+): void {
+  for (const instanceId of scaledInstanceIds) {
+    const instance = ctx.graph.getNode(instanceId)
+    if (instance?.layoutMode !== 'NONE' || instance.childIds.length !== 1) continue
+    const child = ctx.graph.getNode(instance.childIds[0])
+    if (
+      !child ||
+      child.childIds.length > 0 ||
+      child.horizontalConstraint !== 'SCALE' ||
+      child.verticalConstraint !== 'SCALE'
+    ) {
+      continue
+    }
+    const width = child.figmaDerivedLayout?.width
+    const height = child.figmaDerivedLayout?.height
+    const restoresDerivedBounds = width !== undefined && height !== undefined
+    const restoresImageBounds =
+      !restoresDerivedBounds &&
+      child.type === 'ROUNDED_RECTANGLE' &&
+      child.fills.some((fill) => fill.type === 'IMAGE')
+    if (!restoresDerivedBounds && !restoresImageBounds) continue
+    const restoredWidth = width ?? instance.width
+    const restoredHeight = height ?? instance.height
+    if (child.width === restoredWidth && child.height === restoredHeight) continue
+    ctx.graph.updateNode(child.id, { width: restoredWidth, height: restoredHeight })
+  }
+}
+
+function isThinCenteredCrossChild(parent: SceneNode, clone: SceneNode): boolean {
+  if (parent.counterAxisAlign !== 'CENTER') return false
+  if (parent.layoutMode === 'HORIZONTAL') return clone.height <= 1 && clone.width > clone.height
+  if (parent.layoutMode === 'VERTICAL') return clone.width <= 1 && clone.height > clone.width
+  return false
+}
+
+function thinCloneCrossPosition(
+  graph: OverrideContext['graph'],
+  clone: SceneNode
+): NonNullable<SceneNode['figmaDerivedLayout']> | null {
+  if (
+    clone.source.format !== null ||
+    !clone.componentId ||
+    !clone.name.endsWith('Divider') ||
+    !clone.parentId ||
+    clone.figmaDerivedLayout?.x !== undefined ||
+    clone.figmaDerivedLayout?.y !== undefined
+  ) {
+    return null
+  }
+  const parent = graph.getNode(clone.parentId)
+  const source = graph.getNode(clone.componentId)
+  const sourceLayout = source?.figmaDerivedLayout
+  if (!parent || !source || sourceLayout?.x === undefined || sourceLayout.y === undefined) return null
+  if (clone.width !== source.width || clone.height !== source.height) return null
+  return isThinCenteredCrossChild(parent, clone) ? sourceLayout : null
+}
+
+function restoreThinCloneCrossPositions(ctx: OverrideContext): void {
+  for (const clone of overrideCandidates(ctx.graph, ctx.activeNodeIds)) {
+    const sourceLayout = thinCloneCrossPosition(ctx.graph, clone)
+    if (!sourceLayout) continue
+    ctx.graph.updateNode(clone.id, {
+      figmaDerivedLayout: {
+        ...clone.figmaDerivedLayout,
+        x: sourceLayout.x,
+        y: sourceLayout.y
+      }
+    })
+  }
+}
+
 export function applyGeneratedFreeformStretch(ctx: OverrideContext): void {
   for (const node of overrideCandidates(ctx.graph, ctx.activeNodeIds)) {
     if (

--- a/packages/fig/src/instance-overrides/derived-symbol-data/propagate.ts
+++ b/packages/fig/src/instance-overrides/derived-symbol-data/propagate.ts
@@ -97,7 +97,7 @@ function isThinCenteredCrossChild(parent: SceneNode, clone: SceneNode): boolean 
 function thinCloneCrossPosition(
   graph: OverrideContext['graph'],
   clone: SceneNode
-): NonNullable<SceneNode['figmaDerivedLayout']> | null {
+): { axis: 'x' | 'y'; position: number } | null {
   if (
     clone.source.format !== null ||
     !clone.componentId ||
@@ -114,18 +114,20 @@ function thinCloneCrossPosition(
   if (!parent || !source || sourceLayout?.x === undefined || sourceLayout.y === undefined)
     return null
   if (clone.width !== source.width || clone.height !== source.height) return null
-  return isThinCenteredCrossChild(parent, clone) ? sourceLayout : null
+  if (!isThinCenteredCrossChild(parent, clone)) return null
+  return parent.layoutMode === 'HORIZONTAL'
+    ? { axis: 'y', position: sourceLayout.y }
+    : { axis: 'x', position: sourceLayout.x }
 }
 
 function restoreThinCloneCrossPositions(ctx: OverrideContext): void {
   for (const clone of overrideCandidates(ctx.graph, ctx.activeNodeIds)) {
-    const sourceLayout = thinCloneCrossPosition(ctx.graph, clone)
-    if (!sourceLayout) continue
+    const crossPosition = thinCloneCrossPosition(ctx.graph, clone)
+    if (!crossPosition) continue
     ctx.graph.updateNode(clone.id, {
       figmaDerivedLayout: {
         ...clone.figmaDerivedLayout,
-        x: sourceLayout.x,
-        y: sourceLayout.y
+        [crossPosition.axis]: crossPosition.position
       }
     })
   }

--- a/packages/fig/src/instance-overrides/derived-symbol-data/propagate.ts
+++ b/packages/fig/src/instance-overrides/derived-symbol-data/propagate.ts
@@ -111,7 +111,8 @@ function thinCloneCrossPosition(
   const parent = graph.getNode(clone.parentId)
   const source = graph.getNode(clone.componentId)
   const sourceLayout = source?.figmaDerivedLayout
-  if (!parent || !source || sourceLayout?.x === undefined || sourceLayout.y === undefined) return null
+  if (!parent || !source || sourceLayout?.x === undefined || sourceLayout.y === undefined)
+    return null
   if (clone.width !== source.width || clone.height !== source.height) return null
   return isThinCenteredCrossChild(parent, clone) ? sourceLayout : null
 }

--- a/packages/fig/src/instance-overrides/derived-symbol-data/propagate.ts
+++ b/packages/fig/src/instance-overrides/derived-symbol-data/propagate.ts
@@ -94,10 +94,15 @@ function isThinCenteredCrossChild(parent: SceneNode, clone: SceneNode): boolean 
   return false
 }
 
+interface ThinCloneCrossPosition {
+  axis: 'x' | 'y'
+  position: number
+}
+
 function thinCloneCrossPosition(
   graph: OverrideContext['graph'],
   clone: SceneNode
-): { axis: 'x' | 'y'; position: number } | null {
+): ThinCloneCrossPosition | null {
   if (
     clone.source.format !== null ||
     !clone.componentId ||

--- a/packages/fig/src/instance-overrides/index.ts
+++ b/packages/fig/src/instance-overrides/index.ts
@@ -29,7 +29,10 @@ import type { JsonObject } from '@open-pencil/scene-graph/primitives'
 import { applyComponentProperties } from './component-props'
 import { applyConstraintScaling } from './constraints'
 import { applyDerivedSymbolData } from './derived-symbol-data'
-import { applyGeneratedFreeformStretch, reconcileEffectiveCloneGeometry } from './derived-symbol-data/propagate'
+import {
+  applyGeneratedFreeformStretch,
+  reconcileEffectiveCloneGeometry
+} from './derived-symbol-data/propagate'
 import { populateInstances } from './populate'
 import { preComputeRoots } from './resolve'
 import { applySymbolOverrides } from './symbol/overrides'

--- a/packages/fig/src/instance-overrides/index.ts
+++ b/packages/fig/src/instance-overrides/index.ts
@@ -29,7 +29,7 @@ import type { JsonObject } from '@open-pencil/scene-graph/primitives'
 import { applyComponentProperties } from './component-props'
 import { applyConstraintScaling } from './constraints'
 import { applyDerivedSymbolData } from './derived-symbol-data'
-import { applyGeneratedFreeformStretch } from './derived-symbol-data/propagate'
+import { applyGeneratedFreeformStretch, reconcileEffectiveCloneGeometry } from './derived-symbol-data/propagate'
 import { populateInstances } from './populate'
 import { preComputeRoots } from './resolve'
 import { applySymbolOverrides } from './symbol/overrides'
@@ -361,6 +361,14 @@ export function populateAndApplyOverrides(
   propagateResolvedFills(graph, new Set([...ctx.kiwiPropertyNodes, ...overriddenNodes]))
   propagateResolvedTextClones(graph, ctx.activeNodeIds)
   applyConstraintScaling(ctx)
+  const scaledInstances = new Set<string>()
+  for (const node of overrideCandidates(graph, ctx.activeNodeIds)) {
+    if (node.type !== 'INSTANCE' || !node.componentId) continue
+    const component = graph.getNode(node.componentId)
+    if (component && (node.width !== component.width || node.height !== component.height)) {
+      scaledInstances.add(node.id)
+    }
+  }
   applyComponentProperties(ctx)
 
   // Final component-property swaps can replace descendants targeted by earlier
@@ -374,6 +382,9 @@ export function populateAndApplyOverrides(
     ctx.protectedFields,
     ctx.preComputedClones
   )
+  // Final swaps recreate descendants from component defaults. Reconcile only
+  // geometry that already had an authoritative effective size or cross-axis position.
+  reconcileEffectiveCloneGeometry(ctx, scaledInstances)
   applyResolvedNumericBindings(graph, ctx.activeNodeIds)
   applyGeneratedFreeformStretch(ctx)
 }

--- a/packages/fig/tests/instance-overrides.test.ts
+++ b/packages/fig/tests/instance-overrides.test.ts
@@ -269,7 +269,9 @@ describe('@open-pencil/fig instance interpretation', () => {
       height: 100,
       horizontalConstraint: 'SCALE',
       verticalConstraint: 'SCALE',
-      fills: [{ type: 'IMAGE', imageHash: 'avatar', opacity: 1, visible: true, blendMode: 'NORMAL' }]
+      fills: [
+        { type: 'IMAGE', imageHash: 'avatar', opacity: 1, visible: true, blendMode: 'NORMAL' }
+      ]
     })
     const avatar = graph.createNode('INSTANCE', pageId, {
       componentId: avatarComponent.id,
@@ -328,7 +330,9 @@ describe('@open-pencil/fig instance interpretation', () => {
       height: 100,
       horizontalConstraint: 'SCALE',
       verticalConstraint: 'SCALE',
-      fills: [{ type: 'IMAGE', imageHash: 'avatar', opacity: 1, visible: true, blendMode: 'NORMAL' }]
+      fills: [
+        { type: 'IMAGE', imageHash: 'avatar', opacity: 1, visible: true, blendMode: 'NORMAL' }
+      ]
     })
     graph.createNode('RECTANGLE', multiComponent.id, { width: 10, height: 10 })
     const multiInstance = graph.createNode('INSTANCE', pageId, {

--- a/packages/fig/tests/instance-overrides.test.ts
+++ b/packages/fig/tests/instance-overrides.test.ts
@@ -260,6 +260,89 @@ describe('@open-pencil/fig instance interpretation', () => {
     expect(globalScans).toBe(2)
   })
 
+  test('restores effective image and thin-clone geometry after final swaps', () => {
+    const graph = new SceneGraph()
+    const pageId = graph.getPages()[0].id
+    const avatarComponent = graph.createNode('COMPONENT', pageId, { width: 100, height: 100 })
+    graph.createNode('ROUNDED_RECTANGLE', avatarComponent.id, {
+      width: 100,
+      height: 100,
+      horizontalConstraint: 'SCALE',
+      verticalConstraint: 'SCALE',
+      fills: [{ type: 'IMAGE', imageHash: 'avatar', opacity: 1, visible: true, blendMode: 'NORMAL' }]
+    })
+    const avatar = graph.createNode('INSTANCE', pageId, {
+      componentId: avatarComponent.id,
+      width: 14,
+      height: 14
+    })
+
+    const dividerComponent = graph.createNode('COMPONENT', pageId, {
+      width: 112,
+      height: 28,
+      layoutMode: 'HORIZONTAL',
+      counterAxisAlign: 'CENTER'
+    })
+    const dividerSource = graph.createNode('RECTANGLE', dividerComponent.id, {
+      x: 0,
+      y: 13.5,
+      width: 112,
+      height: 1,
+      figmaDerivedLayout: { x: 0, y: 13.5, width: 112, height: 1 }
+    })
+    const dividerInstance = graph.createNode('INSTANCE', pageId, {
+      componentId: dividerComponent.id,
+      width: 112,
+      height: 28,
+      layoutMode: 'HORIZONTAL',
+      counterAxisAlign: 'CENTER'
+    })
+
+    populateAndApplyOverrides(graph, new Map(), new Map())
+
+    const avatarLeaf = graph.getChildren(avatar.id)[0]
+    expect(avatarLeaf).toMatchObject({ width: 14, height: 14 })
+    const divider = graph.getChildren(dividerInstance.id)[0]
+    expect(divider.componentId).toBe(dividerSource.id)
+    expect(divider.figmaDerivedLayout).toMatchObject({ x: 0, y: 13.5 })
+  })
+
+  test('leaves unrelated scaled vector and multi-child instance geometry unchanged', () => {
+    const graph = new SceneGraph()
+    const pageId = graph.getPages()[0].id
+    const vectorComponent = graph.createNode('COMPONENT', pageId, { width: 100, height: 100 })
+    graph.createNode('VECTOR', vectorComponent.id, {
+      width: 20,
+      height: 10,
+      horizontalConstraint: 'SCALE',
+      verticalConstraint: 'SCALE'
+    })
+    const vectorInstance = graph.createNode('INSTANCE', pageId, {
+      componentId: vectorComponent.id,
+      width: 50,
+      height: 50
+    })
+    const multiComponent = graph.createNode('COMPONENT', pageId, { width: 100, height: 100 })
+    graph.createNode('ROUNDED_RECTANGLE', multiComponent.id, {
+      width: 100,
+      height: 100,
+      horizontalConstraint: 'SCALE',
+      verticalConstraint: 'SCALE',
+      fills: [{ type: 'IMAGE', imageHash: 'avatar', opacity: 1, visible: true, blendMode: 'NORMAL' }]
+    })
+    graph.createNode('RECTANGLE', multiComponent.id, { width: 10, height: 10 })
+    const multiInstance = graph.createNode('INSTANCE', pageId, {
+      componentId: multiComponent.id,
+      width: 50,
+      height: 50
+    })
+
+    populateAndApplyOverrides(graph, new Map(), new Map())
+
+    expect(graph.getChildren(vectorInstance.id)[0]).toMatchObject({ width: 10, height: 5 })
+    expect(graph.getChildren(multiInstance.id)[0]).toMatchObject({ width: 50, height: 50 })
+  })
+
   test('resolves text clone chains to their source values', () => {
     const graph = new SceneGraph()
     const pageId = graph.getPages()[0].id

--- a/packages/scene-graph/src/index.ts
+++ b/packages/scene-graph/src/index.ts
@@ -24,7 +24,7 @@ import { CONTAINER_TYPES, createDefaultNode } from './node-defaults'
 import { updateNodePreview } from './preview'
 import { styleDetachmentChanges } from './shared-styles'
 import { markSourceFieldsEdited } from './source-metadata'
-import { TEXT_PICTURE_KEYS } from './text-picture'
+import { GLYPH_AFFECTING_KEYS, TEXT_PICTURE_KEYS } from './text-picture'
 import * as Variables from './variables'
 import { normalizeVectorNetwork } from './vector-network'
 
@@ -309,6 +309,7 @@ export class SceneGraph {
   }
 
   static TEXT_PICTURE_KEYS: ReadonlySet<string> = TEXT_PICTURE_KEYS
+  static GLYPH_AFFECTING_KEYS: ReadonlySet<string> = GLYPH_AFFECTING_KEYS
 
   static LAYOUT_AFFECTING_KEYS: ReadonlySet<string> = new Set([
     'x',
@@ -404,7 +405,8 @@ export class SceneGraph {
     if (node.type === 'TEXT') {
       const textChanged = Object.keys(changes).some((k) => TEXT_PICTURE_KEYS.has(k))
       if (node.textPicture && textChanged) node.textPicture = null
-      if (node.figmaDerivedTextGlyphs && textChanged) node.figmaDerivedTextGlyphs = null
+      const glyphChanged = Object.keys(changes).some((k) => GLYPH_AFFECTING_KEYS.has(k))
+      if (node.figmaDerivedTextGlyphs && glyphChanged) node.figmaDerivedTextGlyphs = null
     }
     const entries = Object.entries(changes) as Array<[string, unknown]>
     changes = Object.fromEntries(

--- a/packages/scene-graph/src/index.ts
+++ b/packages/scene-graph/src/index.ts
@@ -381,7 +381,15 @@ export class SceneGraph {
 
     const node = this.nodes.get(id)
     if (!node) return
+    let entries = Object.entries(changes) as Array<[string, unknown]>
+    changes = Object.fromEntries(
+      entries.filter(([, value]) => value !== undefined)
+    ) as Partial<SceneNode>
     changes = styleDetachmentChanges(node, changes)
+    entries = Object.entries(changes) as Array<[string, unknown]>
+    changes = Object.fromEntries(
+      entries.filter(([, value]) => value !== undefined)
+    ) as Partial<SceneNode>
 
     // Only clear absPosCache when layout-affecting properties change.
     // Fills, strokes, effects, plugin data changes do NOT affect absolute position.
@@ -408,10 +416,6 @@ export class SceneGraph {
       const glyphChanged = Object.keys(changes).some((k) => GLYPH_AFFECTING_KEYS.has(k))
       if (node.figmaDerivedTextGlyphs && glyphChanged) node.figmaDerivedTextGlyphs = null
     }
-    const entries = Object.entries(changes) as Array<[string, unknown]>
-    changes = Object.fromEntries(
-      entries.filter(([, value]) => value !== undefined)
-    ) as Partial<SceneNode>
     if (this.sourceMetadataPreservationDepth === 0) {
       markSourceFieldsEdited(node, Object.keys(changes))
     }

--- a/packages/scene-graph/src/preview.ts
+++ b/packages/scene-graph/src/preview.ts
@@ -51,9 +51,7 @@ export function updateNodePreview(
   const node = graph.nodes.get(id)
   if (!node) return null
   changes = Object.fromEntries(
-    (Object.entries(changes) as Array<[string, unknown]>).filter(
-      ([, value]) => value !== undefined
-    )
+    (Object.entries(changes) as Array<[string, unknown]>).filter(([, value]) => value !== undefined)
   ) as Partial<SceneNode>
   if ((Object.keys(changes) as (keyof SceneNode)[]).every((key) => node[key] === changes[key])) {
     return null

--- a/packages/scene-graph/src/preview.ts
+++ b/packages/scene-graph/src/preview.ts
@@ -1,3 +1,4 @@
+import { GLYPH_AFFECTING_KEYS, TEXT_PICTURE_KEYS } from './text-picture'
 import type { SceneNode } from './types'
 import { normalizeVectorNetwork } from './vector-network'
 
@@ -42,25 +43,6 @@ const LAYOUT_AFFECTING_KEYS = new Set<string>([
   'textAutoResize'
 ])
 
-const TEXT_PICTURE_KEYS = new Set<string>([
-  'text',
-  'fontSize',
-  'fontFamily',
-  'fontWeight',
-  'italic',
-  'textAlignHorizontal',
-  'textDirection',
-  'textAlignVertical',
-  'lineHeight',
-  'letterSpacing',
-  'textDecoration',
-  'textCase',
-  'styleRuns',
-  'fills',
-  'width',
-  'height'
-])
-
 export function updateNodePreview(
   graph: PreviewGraph,
   id: string,
@@ -76,7 +58,8 @@ export function updateNodePreview(
   if (node.type === 'TEXT') {
     const textChanged = Object.keys(changes).some((key) => TEXT_PICTURE_KEYS.has(key))
     if (node.textPicture && textChanged) node.textPicture = null
-    if (node.figmaDerivedTextGlyphs && textChanged) node.figmaDerivedTextGlyphs = null
+    const glyphChanged = Object.keys(changes).some((key) => GLYPH_AFFECTING_KEYS.has(key))
+    if (node.figmaDerivedTextGlyphs && glyphChanged) node.figmaDerivedTextGlyphs = null
   }
   const normalizedChanges = changes.vectorNetwork
     ? { ...changes, vectorNetwork: normalizeVectorNetwork(changes.vectorNetwork) }

--- a/packages/scene-graph/src/preview.ts
+++ b/packages/scene-graph/src/preview.ts
@@ -50,6 +50,11 @@ export function updateNodePreview(
 ): Partial<SceneNode> | null {
   const node = graph.nodes.get(id)
   if (!node) return null
+  changes = Object.fromEntries(
+    (Object.entries(changes) as Array<[string, unknown]>).filter(
+      ([, value]) => value !== undefined
+    )
+  ) as Partial<SceneNode>
   if ((Object.keys(changes) as (keyof SceneNode)[]).every((key) => node[key] === changes[key])) {
     return null
   }

--- a/packages/scene-graph/src/text-picture.ts
+++ b/packages/scene-graph/src/text-picture.ts
@@ -16,3 +16,16 @@ export const TEXT_PICTURE_KEYS: ReadonlySet<string> = new Set([
   'width',
   'height'
 ])
+
+/** Properties that change imported glyph outlines or per-glyph positioning. */
+export const GLYPH_AFFECTING_KEYS: ReadonlySet<string> = new Set([
+  'text',
+  'fontSize',
+  'fontFamily',
+  'fontWeight',
+  'italic',
+  'lineHeight',
+  'letterSpacing',
+  'textCase',
+  'styleRuns'
+])

--- a/packages/scene-graph/src/text-picture.ts
+++ b/packages/scene-graph/src/text-picture.ts
@@ -24,6 +24,7 @@ export const GLYPH_AFFECTING_KEYS: ReadonlySet<string> = new Set([
   'fontFamily',
   'fontWeight',
   'italic',
+  'textDirection',
   'lineHeight',
   'letterSpacing',
   'textCase',

--- a/tests/engine/io/fig/import/instance-regressions.test.ts
+++ b/tests/engine/io/fig/import/instance-regressions.test.ts
@@ -24,6 +24,20 @@ describe('derived instance layout regressions', () => {
     layoutNodes = collectAllNodes(layoutGraph)
   })
 
+  test('retains imported glyph outlines through non-glyph layout updates', () => {
+    const glyphCount = () =>
+      layoutNodes.filter(
+        (node) => node.type === 'TEXT' && (node.figmaDerivedTextGlyphs?.length ?? 0) > 0
+      ).length
+
+    expect(glyphCount()).toBe(43)
+
+    computeAllLayouts(layoutGraph)
+    layoutNodes = collectAllNodes(layoutGraph)
+
+    expect(glyphCount()).toBe(43)
+  })
+
   test('preserves repeated badge overrides without moving sibling component wrappers', () => {
     const input = previewChild(layoutGraph, layoutNodes, 'Input')
     const inputRoot = childNamed(layoutGraph, input, '_input')

--- a/tests/engine/io/fig/import/instance-regressions.test.ts
+++ b/tests/engine/io/fig/import/instance-regressions.test.ts
@@ -86,7 +86,25 @@ describe('derived instance layout regressions', () => {
       expect(closeIcon?.visible).toBe(true)
       expect(closeGlyph?.visible).toBe(true)
       expect(avatarShape?.fills.some((fill) => fill.type === 'IMAGE' && fill.visible)).toBe(true)
+      expect(avatarShape?.width).toBeCloseTo(avatar?.width ?? 0, 3)
+      expect(avatarShape?.height).toBeCloseTo(avatar?.height ?? 0, 3)
     }
+  })
+
+  test('keeps generated stepper dividers at their effective derived positions', () => {
+    const dividers = layoutNodes.filter(
+      (node) =>
+        node.name === 'Right Divider' &&
+        node.width > 100 &&
+        node.componentId &&
+        node.source.format === null
+    )
+    expect(dividers).toHaveLength(3)
+    const generatedDividers = dividers.filter(
+      (node) => layoutGraph.getNode(node.componentId)?.figmaDerivedLayout?.y === 13.5
+    )
+    expect(generatedDividers).toHaveLength(3)
+    for (const divider of generatedDividers) expect(divider.y).toBeCloseTo(13.5, 3)
   })
 
   test('does not collapse unrelated datepicker instances to the page origin', () => {

--- a/tests/engine/scene-graph/basic/text-picture-keys.test.ts
+++ b/tests/engine/scene-graph/basic/text-picture-keys.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from 'bun:test'
 
 import { SceneGraph } from '@open-pencil/core'
 
-describe('TEXT_PICTURE_KEYS membership', () => {
-  test('contains text rendering properties', () => {
+describe('text rendering invalidation keys', () => {
+  test('TEXT_PICTURE_KEYS contains rendered-picture properties', () => {
     const keys = SceneGraph.TEXT_PICTURE_KEYS
     for (const k of [
       'text',
@@ -27,7 +27,37 @@ describe('TEXT_PICTURE_KEYS membership', () => {
     }
   })
 
-  test('does NOT contain non-text properties', () => {
+  test('GLYPH_AFFECTING_KEYS contains only properties that change imported glyphs', () => {
+    const keys = SceneGraph.GLYPH_AFFECTING_KEYS
+    for (const k of [
+      'text',
+      'fontSize',
+      'fontFamily',
+      'fontWeight',
+      'italic',
+      'lineHeight',
+      'letterSpacing',
+      'textCase',
+      'styleRuns'
+    ]) {
+      expect(keys.has(k)).toBe(true)
+    }
+    for (const k of [
+      'x',
+      'y',
+      'width',
+      'height',
+      'fills',
+      'textAlignHorizontal',
+      'textDirection',
+      'textAlignVertical',
+      'textDecoration'
+    ]) {
+      expect(keys.has(k)).toBe(false)
+    }
+  })
+
+  test('TEXT_PICTURE_KEYS does NOT contain non-text properties', () => {
     const keys = SceneGraph.TEXT_PICTURE_KEYS
     for (const k of ['x', 'y', 'rotation', 'opacity', 'visible', 'name']) {
       expect(keys.has(k)).toBe(false)

--- a/tests/engine/scene-graph/basic/text-picture-keys.test.ts
+++ b/tests/engine/scene-graph/basic/text-picture-keys.test.ts
@@ -35,6 +35,7 @@ describe('text rendering invalidation keys', () => {
       'fontFamily',
       'fontWeight',
       'italic',
+      'textDirection',
       'lineHeight',
       'letterSpacing',
       'textCase',
@@ -49,7 +50,6 @@ describe('text rendering invalidation keys', () => {
       'height',
       'fills',
       'textAlignHorizontal',
-      'textDirection',
       'textAlignVertical',
       'textDecoration'
     ]) {

--- a/tests/engine/scene-graph/basic/update-node.test.ts
+++ b/tests/engine/scene-graph/basic/update-node.test.ts
@@ -200,7 +200,7 @@ describe('updateNode', () => {
     const textNode = expectDefined(graph.getNode(textId), 'text node')
     textNode.figmaDerivedTextGlyphs = glyphs
 
-    graph.updateNode(textId, { fontFamily: 'Noto Sans SC' })
+    graph.updateNode(textId, { textDirection: 'RTL' })
 
     expect(expectDefined(graph.getNode(textId), 'updated node').figmaDerivedTextGlyphs).toBeNull()
   })
@@ -211,7 +211,6 @@ describe('updateNode', () => {
       { height: 24 },
       { fills: [] },
       { textAlignHorizontal: 'CENTER' as const },
-      { textDirection: 'RTL' as const },
       { textAlignVertical: 'CENTER' as const },
       { textDecoration: 'UNDERLINE' as const }
     ]

--- a/tests/engine/scene-graph/basic/update-node.test.ts
+++ b/tests/engine/scene-graph/basic/update-node.test.ts
@@ -205,6 +205,38 @@ describe('updateNode', () => {
     expect(expectDefined(graph.getNode(textId), 'updated node').figmaDerivedTextGlyphs).toBeNull()
   })
 
+  test('figmaDerivedTextGlyphs survive picture-only text property changes', () => {
+    const pictureOnlyChanges = [
+      { width: 120 },
+      { height: 24 },
+      { fills: [] },
+      { textAlignHorizontal: 'CENTER' as const },
+      { textDirection: 'RTL' as const },
+      { textAlignVertical: 'CENTER' as const },
+      { textDecoration: 'UNDERLINE' as const }
+    ]
+
+    for (const changes of pictureOnlyChanges) {
+      const graph = new SceneGraph()
+      const page = pageId(graph)
+      const textId = graph.createNode('TEXT', page, {
+        name: 'T',
+        text: 'Imported text',
+        width: 100,
+        height: 20
+      }).id
+      const glyphs = [{ commandsBlob: new Uint8Array([4, 5, 6]), x: 0, y: 10, fontSize: 14 }]
+      const textNode = expectDefined(graph.getNode(textId), 'text node')
+      textNode.figmaDerivedTextGlyphs = glyphs
+
+      graph.updateNode(textId, changes)
+
+      expect(expectDefined(graph.getNode(textId), 'updated node').figmaDerivedTextGlyphs).toBe(
+        glyphs
+      )
+    }
+  })
+
   test('figmaDerivedTextGlyphs survive non-text property change on TEXT node', () => {
     const graph = new SceneGraph()
     const page = pageId(graph)


### PR DESCRIPTION
### Summary

Preserve authoritative text and clone geometry imported from Figma when later layout, appearance, or component-swap updates do not invalidate it. This prevents imported text from changing weight or shape and keeps swapped avatars and thin stepper dividers at their effective dimensions and positions.

### What changed

- Separate glyph-shaping invalidation from broader rendered-text-picture invalidation.
- Keep imported glyph outlines through size, alignment, fill, and decoration changes; invalidate them for shaping changes including text direction.
- Ignore undefined patch fields before cache checks or preview mutation.
- Reconcile authoritative image-leaf bounds after final component swaps.
- Preserve derived cross-axis positions for thin centered divider clones.
- Add synthetic scene-graph and Fig-package coverage plus Gold Preview fixture regressions.
- Credit Joseph Cumines for the earlier glyph-invalidation diagnosis and proposed split.

### Compatibility validation

- Gold Preview: 6 geometry records improved, 0 worsened.
- Shadcn: 14,253 records compared, 0 changes.
- Preline: 435,857 records compared; changes are limited to 969 scaled image leaves and 85 thin divider positions.

### AI assistance

Models: OpenAI Codex GPT-5.6

### Validation

- [x] `bun run check`
- [x] Focused scene-graph, Fig-package, and `.fig` regressions: 46 passed
- [x] Tests added or updated
- [x] `CHANGELOG.md` updated
- [x] Duplication check: 0 clones
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved imported Figma glyph outlines during text layout and appearance updates.
  * Prevented unnecessary glyph data from being cleared during text-picture-only changes.
  * Corrected sizing and positioning for swapped image avatars.
  * Preserved effective positioning for thin stepper dividers after instance scaling.

* **Tests**
  * Added regression coverage for glyph preservation, avatar dimensions, and divider geometry.

* **Documentation**
  * Added Unreleased changelog entries for these fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->