### PR TITLE
ci(docs): build packages before VitePress

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,9 @@ jobs:
 
       - uses: ./.github/actions/setup-bun
 
+      - name: Build SDK packages for documentation
+        run: bun run build:packages
+
       - run: bun run --filter @open-pencil/docs build
 
       - uses: cloudflare/wrangler-action@v4


### PR DESCRIPTION
## Summary

- build public workspace packages before the VitePress deployment build
- make Twoslash and SDK demos resolve package exports from a clean checkout

## Validation

- removed all `packages/*/dist` output and the Twoslash cache
- `bun run build:packages`
- `bun run --filter @open-pencil/docs build`

## AI assistance

GPT-5.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documentation builds now include the latest SDK packages before deployment.
  * Improved reliability and completeness of published documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->