### PR TITLE
fix(tauri): restore native text clipboard actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Restore native copy, cut, and paste shortcuts in desktop text inputs while preserving design clipboard handling on the canvas.
 - Complete translated app, accessibility, font, color, collaboration, import, connection-test, and browser fallback text across all supported locales, and keep the document language synchronized with the selected locale.
 
 ## 0.14.0 - 2026-08-10

--- a/desktop/src/menu.rs
+++ b/desktop/src/menu.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use tauri::menu::{MenuBuilder, MenuItemBuilder, Submenu, SubmenuBuilder};
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use tauri::menu::PredefinedMenuItem;
 
 #[derive(Deserialize)]
@@ -41,12 +41,38 @@ fn build_submenu<R: tauri::Runtime>(
             continue;
         }
 
+        // Ordinary menu accelerators emit a frontend command without preserving the
+        // WebView's focused editing control. Native edit items let WebKit/WebView2
+        // route copy, cut, and paste to inputs or dispatch canvas clipboard events.
+        // Keep Linux on the frontend path: muda's native edit items require optional
+        // X11 automation and are explicitly unsupported on Wayland.
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        if let Some(id) = entry.id.as_deref() {
+            let native_edit_item = match id {
+                "copy" => Some(PredefinedMenuItem::copy(app, Some(label))?),
+                "cut" => Some(PredefinedMenuItem::cut(app, Some(label))?),
+                "paste" => Some(PredefinedMenuItem::paste(app, Some(label))?),
+                _ => None,
+            };
+            if let Some(item) = native_edit_item {
+                builder = builder.item(&item);
+                continue;
+            }
+        }
+
         let mut item = MenuItemBuilder::new(label);
         if let Some(id) = &entry.id {
             item = item.id(id);
         }
-        if let Some(accelerator) = &entry.accelerator {
-            item = item.accelerator(accelerator);
+        // On Linux, muda's predefined edit commands depend on optional X11
+        // automation and do not work on Wayland. Leave these accelerators to the
+        // WebView instead, which preserves native input and canvas paste events.
+        let webview_handles_accelerator = cfg!(target_os = "linux")
+            && matches!(entry.id.as_deref(), Some("copy" | "cut" | "paste"));
+        if !webview_handles_accelerator {
+            if let Some(accelerator) = &entry.accelerator {
+                item = item.accelerator(accelerator);
+            }
         }
         builder = builder.item(&item.build(app)?);
     }

--- a/src/app/shell/keyboard/focus.ts
+++ b/src/app/shell/keyboard/focus.ts
@@ -1,7 +1,19 @@
-export function isEditing(e: Event) {
-  return e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement
+function isEditableTarget(target: EventTarget | null | undefined): boolean {
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    (target instanceof HTMLElement && target.isContentEditable)
+  )
 }
 
-export function isInputElement(el: EventTarget | null | undefined): boolean {
-  return el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement
+export function isEditing(event: Event) {
+  return event.composedPath().some(isEditableTarget)
+}
+
+export function isInputElement(element: EventTarget | null | undefined): boolean {
+  return (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement ||
+    (element instanceof HTMLElement && element.isContentEditable)
+  )
 }

--- a/src/components/MobileDrawer.vue
+++ b/src/components/MobileDrawer.vue
@@ -121,7 +121,11 @@ const drawerTransition = {
     @panEnd="onPanEnd"
   >
     <TabsRoot :model-value="getDrawerTab()" class="flex min-h-0 flex-1 flex-col">
-      <nav ref="headerRef" :aria-label="dialogs.mobilePanelNavigation" class="flex shrink-0 flex-col">
+      <nav
+        ref="headerRef"
+        :aria-label="dialogs.mobilePanelNavigation"
+        class="flex shrink-0 flex-col"
+      >
         <div class="flex w-full justify-center pt-2">
           <div class="h-1 w-8 rounded-full bg-muted/40" />
         </div>

--- a/src/components/font-picker/FontPicker.vue
+++ b/src/components/font-picker/FontPicker.vue
@@ -16,8 +16,8 @@ import { WEB_FONT_PROVIDER_IDS } from '@open-pencil/core/text'
 import type { FontPickerUI } from '@open-pencil/vue'
 
 const { panels } = useI18n()
-const props = defineProps<{ label?: string }>()
-const label = computed(() => props.label ?? panels.value.fontFamily)
+const { label: labelProp } = defineProps<{ label?: string }>()
+const label = computed(() => labelProp ?? panels.value.fontFamily)
 const modelValue = defineModel<string>({ required: true })
 const emit = defineEmits<{ select: [family: string] }>()
 

--- a/tests/e2e/clipboard/tauri-clipboard.spec.ts
+++ b/tests/e2e/clipboard/tauri-clipboard.spec.ts
@@ -189,12 +189,16 @@ test('Tauri clipboard events from editable fields keep native text behavior', as
   await page.evaluate(() => {
     const host = document.createElement('div')
     host.innerHTML =
-      '<input data-clipboard-probe><div contenteditable="true"><span>Text</span></div>'
+      '<input data-clipboard-probe="input"><textarea data-clipboard-probe="textarea"></textarea><div contenteditable="true"><span>Text</span></div>'
     document.body.append(host)
   })
 
-  await dispatchClipboardEvent(page, 'copy', '[data-clipboard-probe]')
+  await dispatchClipboardEvent(page, 'copy', '[data-clipboard-probe="input"]')
+  expect(await testClipboard(page)).toEqual(before)
+  await dispatchClipboardEvent(page, 'copy', '[data-clipboard-probe="textarea"]')
+  expect(await testClipboard(page)).toEqual(before)
   await dispatchClipboardEvent(page, 'cut', '[contenteditable] span')
+  expect(await testClipboard(page)).toEqual(before)
   await dispatchClipboardEvent(page, 'paste', '[contenteditable] span')
 
   expect(await testClipboard(page)).toEqual(before)

--- a/tests/e2e/clipboard/tauri-clipboard.spec.ts
+++ b/tests/e2e/clipboard/tauri-clipboard.spec.ts
@@ -107,10 +107,19 @@ function testClipboard(page: Page) {
   return page.evaluate(() => window.__OPENPENCIL_TEST_CLIPBOARD__)
 }
 
-async function dispatchClipboardEvent(page: Page, type: 'copy' | 'cut' | 'paste') {
-  await page.evaluate((eventType) => {
-    window.dispatchEvent(new ClipboardEvent(eventType, { bubbles: true, cancelable: true }))
-  }, type)
+async function dispatchClipboardEvent(
+  page: Page,
+  type: 'copy' | 'cut' | 'paste',
+  target = 'window'
+) {
+  await page.evaluate(
+    ({ eventType, selector }) => {
+      const eventTarget = selector === 'window' ? window : document.querySelector(selector)
+      if (!eventTarget) throw new Error(`Clipboard event target not found: ${selector}`)
+      eventTarget.dispatchEvent(new ClipboardEvent(eventType, { bubbles: true, cancelable: true }))
+    },
+    { eventType: type, selector: target }
+  )
 }
 
 test('Tauri copy writes selected design HTML without requiring ClipboardEvent.clipboardData', async ({
@@ -170,6 +179,26 @@ test('Tauri cut writes design data and deletes selection only after clipboard wr
   expect(clipboard.text).toBe('Rectangle')
   await expect(page.getByText('Clipboard access is blocked in this browser context')).toHaveCount(0)
   canvas.assertNoErrors()
+})
+
+test('Tauri clipboard events from editable fields keep native text behavior', async ({ page }) => {
+  const canvas = await createTauriEditorPage(page)
+  await canvas.drawRect(160, 160, 96, 72)
+  const before = await testClipboard(page)
+
+  await page.evaluate(() => {
+    const host = document.createElement('div')
+    host.innerHTML =
+      '<input data-clipboard-probe><div contenteditable="true"><span>Text</span></div>'
+    document.body.append(host)
+  })
+
+  await dispatchClipboardEvent(page, 'copy', '[data-clipboard-probe]')
+  await dispatchClipboardEvent(page, 'cut', '[contenteditable] span')
+  await dispatchClipboardEvent(page, 'paste', '[contenteditable] span')
+
+  expect(await testClipboard(page)).toEqual(before)
+  expect(await pageChildren(page)).toHaveLength(1)
 })
 
 test('Tauri context-menu copy uses plugin clipboard fallback instead of blocked browser command', async ({


### PR DESCRIPTION
## Summary

- Route macOS and Windows Edit-menu copy, cut, and paste through native platform commands
- Leave Linux clipboard accelerators to WebKitGTK so focused fields work on both X11 and Wayland
- Ignore canvas clipboard handling for inputs, textareas, and nested contenteditable event paths

## Testing

- `cargo check --manifest-path desktop/Cargo.toml`
- `cargo fmt --check --manifest-path desktop/Cargo.toml`
- `bunx playwright test tests/e2e/clipboard/tauri-clipboard.spec.ts --project=openpencil` — 5 passed
- Verified `⌘V` in an actual macOS Tauri/WebKit process using the Settings model-name field

## AI assistance

- OpenAI GPT-5.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Restored native copy, cut, and paste shortcuts for desktop text inputs on macOS and Windows.
  - Improved support for nested and content-editable text fields.
  - Preserved canvas clipboard behavior while editing text.

- **Bug Fixes**
  - Prevented text-editing clipboard actions from modifying canvas selections or plugin clipboard content.
  - Maintained WebView-managed keyboard shortcuts on Linux.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->