### PR TITLE
fix(tauri): prevent Windows font loading crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed Windows desktop crashes when loading large system fonts for non-Latin text by using Tauri's binary IPC path and resolving native script fallbacks without parsing full font files in JavaScript.
+
 ### Fixed
 
 - Preserve open vector segments when the same vector network also contains filled regions. (#450)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-- Fixed Windows desktop crashes when loading large system fonts for non-Latin text by using Tauri's binary IPC path and resolving native script fallbacks without parsing full font files in JavaScript.
-
 ### Fixed
+
+- Fixed Windows desktop crashes when loading large system fonts for non-Latin text by using Tauri's binary IPC path and resolving native script fallbacks without parsing full font files in JavaScript.
 
 - Preserve open vector segments when the same vector network also contains filled regions. (#450)
 - Match Figma Plugin API behavior for `rescale()`, page `backgrounds`, and nullable visual `absoluteRenderBounds`. (#442)

--- a/desktop/src/fonts.rs
+++ b/desktop/src/fonts.rs
@@ -112,8 +112,13 @@ fn load_system_font_blocking(family: String, style: String) -> Result<Vec<u8>, S
 }
 
 #[tauri::command]
-pub async fn load_system_font(family: String, style: String) -> Result<Vec<u8>, String> {
-    tauri::async_runtime::spawn_blocking(move || load_system_font_blocking(family, style))
-        .await
-        .map_err(|e| format!("Font load task failed: {e}"))?
+pub async fn load_system_font(
+    family: String,
+    style: String,
+) -> Result<tauri::ipc::Response, String> {
+    let data =
+        tauri::async_runtime::spawn_blocking(move || load_system_font_blocking(family, style))
+            .await
+            .map_err(|e| format!("Font load task failed: {e}"))??;
+    Ok(tauri::ipc::Response::new(data))
 }

--- a/packages/core/src/figma-api/render-bounds.ts
+++ b/packages/core/src/figma-api/render-bounds.ts
@@ -63,11 +63,7 @@ function hasRenderableGeometry(node: SceneNode): boolean {
   return node.fillGeometry.length > 0 || node.strokeGeometry.length > 0
 }
 
-function translatedBounds(
-  bounds: VisualBounds,
-  offset: Vector,
-  overflow: number
-): VisualBounds {
+function translatedBounds(bounds: VisualBounds, offset: Vector, overflow: number): VisualBounds {
   return {
     minX: bounds.minX + offset.x - overflow,
     minY: bounds.minY + offset.y - overflow,

--- a/packages/core/src/figma-api/render-bounds.ts
+++ b/packages/core/src/figma-api/render-bounds.ts
@@ -63,7 +63,11 @@ function hasRenderableGeometry(node: SceneNode): boolean {
   return node.fillGeometry.length > 0 || node.strokeGeometry.length > 0
 }
 
-function translatedBounds(bounds: VisualBounds, offset: Vector, overflow: number): VisualBounds {
+function translatedBounds(
+  bounds: VisualBounds,
+  offset: Vector,
+  overflow: number
+): VisualBounds {
   return {
     minX: bounds.minX + offset.x - overflow,
     minY: bounds.minY + offset.y - overflow,

--- a/packages/core/src/text/coverage.ts
+++ b/packages/core/src/text/coverage.ts
@@ -85,6 +85,19 @@ export function textNeedsFallbackScript(node: SceneNode, script: FontFallbackScr
   return false
 }
 
+export function textFallbackScriptsWithoutCoverage(node: SceneNode): FontFallbackScript[] {
+  if (node.type !== 'TEXT') return []
+  const scripts = new Set<FontFallbackScript>()
+  let index = 0
+  for (const char of node.text) {
+    const { language } = styleForCharacter(node, index)
+    const script = fontFallbackScriptForCharacter(char, language)
+    if (script) scripts.add(script)
+    index += char.length
+  }
+  return [...scripts]
+}
+
 export function textNeededFallbackScripts(node: SceneNode): FontFallbackScript[] {
   const scripts = new Set<FontFallbackScript>()
   if (textNeedsFallbackScript(node, 'arabic')) scripts.add('arabic')

--- a/packages/core/src/text/resolved-requirements.ts
+++ b/packages/core/src/text/resolved-requirements.ts
@@ -1,13 +1,14 @@
-import {
-  textFallbackScriptsWithoutCoverage,
-  textNeededFallbackScripts
-} from '#core/text/coverage'
+import { textFallbackScriptsWithoutCoverage, textNeededFallbackScripts } from '#core/text/coverage'
 import type { FontFallbackScript } from '#core/text/fallbacks'
 import type { GraphFontRequirements } from '#core/text/requirements'
 
+export interface MissingGraphFontScriptsOptions {
+  treatUnknownCoverageAsMissing?: boolean
+}
+
 export function missingGraphFontScripts(
   requirements: GraphFontRequirements,
-  options: { treatUnknownCoverageAsMissing?: boolean } = {}
+  options: MissingGraphFontScriptsOptions = {}
 ): FontFallbackScript[] {
   const scripts = new Set<FontFallbackScript>()
   for (const node of requirements.nodes) {

--- a/packages/core/src/text/resolved-requirements.ts
+++ b/packages/core/src/text/resolved-requirements.ts
@@ -1,12 +1,21 @@
-import { textNeededFallbackScripts } from '#core/text/coverage'
+import {
+  textFallbackScriptsWithoutCoverage,
+  textNeededFallbackScripts
+} from '#core/text/coverage'
 import type { FontFallbackScript } from '#core/text/fallbacks'
 import type { GraphFontRequirements } from '#core/text/requirements'
 
-export function missingGraphFontScripts(requirements: GraphFontRequirements): FontFallbackScript[] {
+export function missingGraphFontScripts(
+  requirements: GraphFontRequirements,
+  options: { treatUnknownCoverageAsMissing?: boolean } = {}
+): FontFallbackScript[] {
   const scripts = new Set<FontFallbackScript>()
   for (const node of requirements.nodes) {
     if (node.type !== 'TEXT') continue
-    for (const script of textNeededFallbackScripts(node)) scripts.add(script)
+    const neededScripts = options.treatUnknownCoverageAsMissing
+      ? textFallbackScriptsWithoutCoverage(node)
+      : textNeededFallbackScripts(node)
+    for (const script of neededScripts) scripts.add(script)
   }
   return Array.from(scripts)
 }

--- a/src/app/editor/fonts/index.ts
+++ b/src/app/editor/fonts/index.ts
@@ -22,6 +22,7 @@ import {
 import { toast } from '@/app/shell/ui'
 import { isTauri } from '@/app/tauri/env'
 import { tauriFetch } from '@/app/tauri/http'
+import { IS_TAURI } from '@/constants'
 
 if (typeof navigator !== 'undefined') {
   fontManager.setFallbackUserAgent(navigator.userAgent)
@@ -178,7 +179,7 @@ export async function ensureGraphFonts(
     const { characters } = requirements
     await Promise.all(fontKeys.map(([family, style]) => loadFont(family, style, characters)))
     const fallbackScripts = missingGraphFontScripts(requirements, {
-      treatUnknownCoverageAsMissing: isTauri()
+      treatUnknownCoverageAsMissing: IS_TAURI
     })
     if (fallbackScripts.length > 0) {
       const fallbacks = await fontManager.ensureFallbackPack(fallbackScripts, characters)

--- a/src/app/editor/fonts/index.ts
+++ b/src/app/editor/fonts/index.ts
@@ -177,7 +177,9 @@ export async function ensureGraphFonts(
     const requirements = collectGraphFontRequirements(graph, nodeIds)
     const { characters } = requirements
     await Promise.all(fontKeys.map(([family, style]) => loadFont(family, style, characters)))
-    const fallbackScripts = missingGraphFontScripts(requirements)
+    const fallbackScripts = missingGraphFontScripts(requirements, {
+      treatUnknownCoverageAsMissing: isTauri()
+    })
     if (fallbackScripts.length > 0) {
       const fallbacks = await fontManager.ensureFallbackPack(fallbackScripts, characters)
       if (Object.values(fallbacks).some((families) => families.length > 0)) {
@@ -207,9 +209,9 @@ async function loadSystemFont(family: string, style = 'Regular'): Promise<ArrayB
   if (!isTauri()) return null
   try {
     const { invoke } = await import('@tauri-apps/api/core')
-    const data = await invoke<number[] | null>('load_system_font', { family, style })
-    if (!data?.length) return null
-    return new Uint8Array(data).buffer
+    const data = await invoke<ArrayBuffer>('load_system_font', { family, style })
+    if (data.byteLength === 0) return null
+    return data
   } catch {
     return null
   }

--- a/tests/engine/app/font-loading.test.ts
+++ b/tests/engine/app/font-loading.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test'
 
-import { fontManager, type FontFallbackScript } from '@open-pencil/core/text'
+import {
+  collectGraphFontRequirements,
+  fontManager,
+  missingGraphFontScripts,
+  type FontFallbackScript
+} from '@open-pencil/core/text'
 import { SceneGraph } from '@open-pencil/scene-graph'
 
 import { ensureGraphFonts } from '@/app/editor/fonts'
@@ -9,6 +14,21 @@ import { expectDefined } from '#tests/helpers/assert'
 import { repoPath } from '#tests/helpers/paths'
 
 describe('app font loading', () => {
+  test('requests platform fallback before parsing large native primary fonts', () => {
+    const graph = new SceneGraph()
+    const page = graph.getPages()[0]
+    const text = graph.createNode('TEXT', page.id, {
+      text: '현대 소나타',
+      fontFamily: 'Native Arial',
+      fontSize: 32
+    })
+    const requirements = collectGraphFontRequirements(graph, [text.id])
+
+    expect(missingGraphFontScripts(requirements, { treatUnknownCoverageAsMissing: true })).toEqual([
+      'cjk-kr'
+    ])
+  })
+
   test('ensureGraphFonts loads fallback packs when loaded primary font misses CJK glyphs', async () => {
     const interData = await Bun.file(repoPath('public/Inter-Regular.ttf')).arrayBuffer()
     fontManager.markLoaded('Inter', 'Regular', interData)

--- a/tests/engine/layout/auto-layout/imported-derived-layout/effective-generated-text.test.ts
+++ b/tests/engine/layout/auto-layout/imported-derived-layout/effective-generated-text.test.ts
@@ -111,7 +111,7 @@ describe('effective generated FIG text layout', () => {
       componentId: 'parent',
       figmaDerivedLayout: { width: 120, height: 80 }
     })
-    const generatedText = graph.createNode('TEXT', parent.id, {
+    graph.createNode('TEXT', parent.id, {
       width: 100,
       height: 20,
       text: source.text,

--- a/tests/engine/tauri/fonts.test.ts
+++ b/tests/engine/tauri/fonts.test.ts
@@ -29,7 +29,7 @@ describe('Tauri font helpers', () => {
     await mockTauriIPC((cmd, args) => {
       expect(cmd).toBe('load_system_font')
       expect(args).toEqual({ family: 'System UI', style: 'Bold Italic' })
-      return [1, 2, 3, 4]
+      return new Uint8Array([1, 2, 3, 4]).buffer
     })
 
     const { loadFont } = await import('@/app/editor/fonts')


### PR DESCRIPTION
Fixes #486.

## What changed
- Return system font files through Tauri’s raw binary IPC response instead of serializing every byte as a JSON number
- On desktop, identify CJK/Arabic fallback scripts directly from text before attempting JS glyph-coverage parsing of large native fonts
- Add regression coverage for binary IPC and unknown native-font coverage
- Repair the current quality-gate regressions on `master`: use the shared `Vector` primitive, remove unsupported `SLICE` rescaling, and drop an unused test binding

## Windows reproduction and validation
Reproduced on the existing Windows Server 2025 libvirt VM: loading Korean text (`현대 소나타`) with Arial caused the WebView2 renderer to terminate with `Error code: Out of Memory`; Russian and Arabic text rendered, and `list_system_fonts` itself remained stable. A Malgun Gothic font file is ~13.5 MB, which made the old JSON byte-array IPC path especially costly.

Validated the native change on that VM: `load_system_font("Malgun Gothic")` now resolves as an `ArrayBuffer` of 13,459,196 bytes rather than a JS number array.

## Checks
- `bun run check`
- `bun run check:vue`
- `bun test tests/engine/app/font-loading.test.ts tests/engine/text/coverage.test.ts tests/engine/text/fonts/coverage.test.ts tests/engine/tauri/fonts.test.ts`
- `bun test tests/engine/figma/api/layout/plugin-compat.test.ts tests/engine/layout/auto-layout/imported-derived-layout/effective-generated-text.test.ts`
- `cargo fmt --manifest-path desktop/Cargo.toml --check`
- `cargo check --manifest-path desktop/Cargo.toml`
- `git diff --check`

The remaining two Oxlint `max-lines` diagnostics are warnings and do not fail the quality gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Windows desktop crashes when loading large system fonts for non-Latin text.
  * Improved fallback font handling so required scripts are identified before processing large font files.
  * Improved reliability when loading and registering system fonts.

* **Documentation**
  * Added an Unreleased changelog entry describing the Windows font-loading fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->