### PR TITLE
fix(app): retain recovery after closing unsaved tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Keep unsaved source-less documents recoverable after their editor tab is closed, matching Figma's retained offline-change behavior.
 - Decode zstd-compressed FIG containers, reject invalid compressed payloads, and preserve exact fixture byte ranges. (#397)
 - Compose caller CSS with Tailwind defaults when importing DOM/CSS documents. (#397)
 - Preserve desktop HTTP timeout, abort, and empty-response semantics. (#397)

--- a/src/app/document/recovery/controller.ts
+++ b/src/app/document/recovery/controller.ts
@@ -65,11 +65,9 @@ export function createDocumentRecovery({
     if (requestedVersion === protectedVersion) return
     if (!writing) {
       const generation = lifecycleGeneration
-      writing = runWrites(generation)
-        .catch((error) => console.warn('[Recovery] Snapshot failed:', error))
-        .finally(() => {
-          writing = null
-        })
+      writing = runWrites(generation).finally(() => {
+        writing = null
+      })
     }
     await writing
   }
@@ -77,7 +75,7 @@ export function createDocumentRecovery({
   const stop: WatchHandle = watchDebounced(
     () => state.sceneVersion,
     () => {
-      void persistNow()
+      void persistNow().catch((error) => console.warn('[Recovery] Snapshot failed:', error))
     },
     { debounce: 3000, maxWait: 10000 }
   )

--- a/src/app/tabs/index.ts
+++ b/src/app/tabs/index.ts
@@ -36,7 +36,6 @@ function generateTabId(): string {
 }
 
 const tabsRef = shallowRef<Tab[]>([])
-const pendingRecoveryDeletions = new Set<Promise<void>>()
 const activeTabId = shallowRef('')
 
 export const activeTab = computed(() => tabsRef.value.find((t) => t.id === activeTabId.value))
@@ -98,13 +97,7 @@ export async function closeTab(tabId: string): Promise<void> {
 
   const closingTab = tabsRef.value[idx]
   const wasActive = activeTabId.value === tabId
-  const deletion = closingTab.store.discardRecovery()
-  pendingRecoveryDeletions.add(deletion)
-  try {
-    await deletion
-  } finally {
-    pendingRecoveryDeletions.delete(deletion)
-  }
+  await closingTab.store.persistRecoveryNow()
   closingTab.store.dispose()
   tabsRef.value = tabsRef.value.filter((t) => t.id !== tabId)
 
@@ -304,10 +297,7 @@ export async function restoreRecoverySnapshot(id: string): Promise<void> {
 }
 
 export async function prepareForReload(): Promise<void> {
-  await Promise.all([
-    ...pendingRecoveryDeletions,
-    ...tabsRef.value.map((tab) => tab.store.persistRecoveryNow())
-  ])
+  await Promise.all(tabsRef.value.map((tab) => tab.store.persistRecoveryNow()))
 }
 
 export function tabCount(): number {

--- a/tests/e2e/autosave.spec.ts
+++ b/tests/e2e/autosave.spec.ts
@@ -67,8 +67,9 @@ test('autosave triggers after scene changes with a file handle', async () => {
   expect(writeHappened).toBe(true)
 })
 
-test('no autosave without file handle', async ({ browser }) => {
+test('no autosave without file handle', async ({ browser, baseURL }) => {
   const context = await browser.newContext({
+    baseURL,
     viewport: { width: 1280, height: 800 },
     deviceScaleFactor: 2
   })

--- a/tests/e2e/recovery.spec.ts
+++ b/tests/e2e/recovery.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '#tests/e2e/fixtures'
+import { CanvasHelper } from '#tests/helpers/canvas'
+
+test('keeps an unsaved document recoverable after its tab closes', async ({ browser, baseURL }) => {
+  const context = await browser.newContext({ baseURL })
+  const page = await context.newPage()
+  await page.goto('/')
+  const canvas = new CanvasHelper(page)
+  await canvas.waitForInit()
+
+  await page.evaluate(async () => {
+    const store = window.openPencil?.getStore?.()
+    if (!store) throw new Error('OpenPencil store not initialized')
+    const id = store.createShape('RECTANGLE', 120, 120, 240, 140)
+    store.updateNode(id, { name: 'Retained recovery rectangle' })
+    await store.persistRecoveryNow()
+  })
+
+  await page.keyboard.press('ControlOrMeta+t')
+  await expect(page.getByRole('button', { name: 'New tab' })).toBeVisible()
+  await page.getByTestId('tabbar-tab').first().getByTestId('tabbar-close').click()
+  await expect(page.getByTestId('tabbar-tab')).toHaveCount(0)
+  await expect
+    .poll(() =>
+      page.evaluate(async () => {
+        const request = indexedDB.open('open-pencil-recovery')
+        const database = await new Promise<IDBDatabase>((resolve, reject) => {
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+        const transaction = database.transaction('meta')
+        const countRequest = transaction.objectStore('meta').count()
+        return new Promise<number>((resolve, reject) => {
+          countRequest.onsuccess = () => resolve(countRequest.result)
+          countRequest.onerror = () => reject(countRequest.error)
+        })
+      })
+    )
+    .toBe(1)
+
+  await page.reload()
+  await expect(page.getByRole('alertdialog', { name: 'Recover unsaved work' })).toBeVisible()
+  await page.getByRole('button', { name: 'Restore' }).click()
+  await expect(page.getByText('Retained recovery rectangle')).toBeVisible()
+
+  await context.close()
+})

--- a/tests/e2e/recovery.spec.ts
+++ b/tests/e2e/recovery.spec.ts
@@ -12,14 +12,14 @@ test('keeps an unsaved document recoverable after its tab closes', async ({ brow
     const store = window.openPencil?.getStore?.()
     if (!store) throw new Error('OpenPencil store not initialized')
     const id = store.createShape('RECTANGLE', 120, 120, 240, 140)
-    store.updateNode(id, { name: 'Retained recovery rectangle' })
     await store.persistRecoveryNow()
+    store.updateNode(id, { name: 'Retained recovery rectangle' })
   })
 
   await page.keyboard.press('ControlOrMeta+t')
   await expect(page.getByRole('button', { name: 'New tab' })).toBeVisible()
   await page.getByTestId('tabbar-tab').first().getByTestId('tabbar-close').click()
-  await expect(page.getByTestId('tabbar-tab')).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'New tab' })).toBeHidden()
   await expect
     .poll(() =>
       page.evaluate(async () => {

--- a/tests/engine/app/document/recovery/controller.test.ts
+++ b/tests/engine/app/document/recovery/controller.test.ts
@@ -89,8 +89,12 @@ describe('document recovery controller', () => {
   test('propagates persistence failures to close and reload callers', async () => {
     const state = reactive({ ...createDefaultEditorState('page-1'), documentName: 'Draft' })
     const store = createMemoryRecoveryStore()
-    store.write = async () => {
-      throw new Error('recovery storage unavailable')
+    const memoryWrite = store.write.bind(store)
+    let writeAttempts = 0
+    store.write = async (input) => {
+      writeAttempts++
+      if (writeAttempts === 1) throw new Error('recovery storage unavailable')
+      return memoryWrite(input)
     }
     const recovery = createDocumentRecovery({
       state,
@@ -102,6 +106,9 @@ describe('document recovery controller', () => {
     state.sceneVersion = 1
 
     await expect(recovery.persistNow()).rejects.toThrow('recovery storage unavailable')
+    await recovery.persistNow()
+    expect(writeAttempts).toBe(2)
+    expect((await store.read('recovery-1'))?.sceneVersion).toBe(1)
     recovery.disposeRecovery()
   })
 

--- a/tests/engine/app/document/recovery/controller.test.ts
+++ b/tests/engine/app/document/recovery/controller.test.ts
@@ -86,6 +86,25 @@ describe('document recovery controller', () => {
     recovery.disposeRecovery()
   })
 
+  test('propagates persistence failures to close and reload callers', async () => {
+    const state = reactive({ ...createDefaultEditorState('page-1'), documentName: 'Draft' })
+    const store = createMemoryRecoveryStore()
+    store.write = async () => {
+      throw new Error('recovery storage unavailable')
+    }
+    const recovery = createDocumentRecovery({
+      state,
+      store,
+      recoveryId: 'recovery-1',
+      hasWritableSource: () => false,
+      buildFigFile: () => new Uint8Array([1])
+    })
+    state.sceneVersion = 1
+
+    await expect(recovery.persistNow()).rejects.toThrow('recovery storage unavailable')
+    recovery.disposeRecovery()
+  })
+
   test('successful save removes recovery data', async () => {
     const { state, store, recovery } = setup()
     state.sceneVersion = 1


### PR DESCRIPTION
## Summary
- Persist source-less document recovery before disposing a closed tab
- Keep the recovery snapshot available until an explicit save or discard instead of silently deleting the only durable copy
- Add an end-to-end close → reload → restore regression test
- Fix the existing manual Playwright context to inherit `baseURL`

## Figma comparison
Figma retains offline changes when a tab or app closes unless the user explicitly chooses a destructive discard action. This follow-up applies the same safety principle to OpenPencil pathless documents while retaining the existing startup recovery dialog.

## Validation
- `bun run check`
- `bun run format:check`
- `bunx playwright test tests/e2e/recovery.spec.ts --project=openpencil`
- Visual recovery-dialog and restore/discard smoke test with `agent-browser` was completed on the underlying recovery feature

Follow-up to #499.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unsaved documents without a file handle remain recoverable after their editor tab is closed.
  * Recovery data persists across page reloads, allowing closed documents to be restored.
  * Improved reliability when saving recovery state, reducing the risk of losing recoverable work.
  * Recovery failures are handled more reliably, and subsequent save attempts can succeed without compromising restoration.
* **Tests**
  * Added coverage for restoring unsaved documents after tab closure and page reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->