### PR TITLE
fix: adapt FIG parsing and package hardening from PR 397

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 ### Fixed
 
+- Decode zstd-compressed FIG containers, reject invalid compressed payloads, and preserve exact fixture byte ranges. (#397)
+- Compose caller CSS with Tailwind defaults when importing DOM/CSS documents. (#397)
+- Preserve desktop HTTP timeout, abort, and empty-response semantics. (#397)
+- Escape Vue SDK test selectors when the browser `CSS` global is unavailable. (#397)
+- Report whether missing Figma clipboard images were actually fetched. (#397)
 - Report exhausted provider credit, request failures, and output-token limits through localized chat toasts and copied diagnostics. (#451, #454)
 - Prevent Windows desktop crashes when loading large system fonts for non-Latin text.
 - Preserve open vector segments when the same vector network also contains filled regions. (#450)

--- a/desktop/src/http.rs
+++ b/desktop/src/http.rs
@@ -61,16 +61,22 @@ pub async fn proxy_http_request(request: ProxyHttpRequest) -> Result<ProxyHttpRe
     } else {
         reqwest::redirect::Policy::none()
     };
-    let mut client_builder = reqwest::Client::builder().redirect(redirect_policy);
-    if let Some(timeout_ms) = request.timeout_ms {
-        client_builder = client_builder.timeout(Duration::from_millis(timeout_ms));
-    }
-    let client = client_builder.build().map_err(|e| e.to_string())?;
+    let client = reqwest::Client::builder()
+        .redirect(redirect_policy)
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| e.to_string())?;
     let mut builder = client
         .request(request_method(request.method)?, parsed)
         .headers(request_headers(request.headers));
     if let Some(body) = request.body {
         builder = builder.body(body);
+    }
+    if let Some(timeout_ms) = request.timeout_ms {
+        if timeout_ms == 0 {
+            return Err("timeoutMs must be greater than 0".into());
+        }
+        builder = builder.timeout(Duration::from_millis(timeout_ms));
     }
 
     let mut response = builder.send().await.map_err(|e| e.to_string())?;

--- a/packages/core/src/editor/clipboard.ts
+++ b/packages/core/src/editor/clipboard.ts
@@ -206,7 +206,7 @@ export function createClipboardActions(ctx: EditorContext) {
       ctx.emitEditorEvent('clipboard:images-missing', {
         total: hashes.length,
         missing,
-        fetchAttempted: resolver !== null
+        fetchAttempted: Boolean(resolver)
       })
     }
   }

--- a/packages/dom-css/src/tailwind.ts
+++ b/packages/dom-css/src/tailwind.ts
@@ -12,7 +12,7 @@ export async function compileTailwindCSS(
   classes: string | Iterable<string>,
   options: CompileTailwindCSSOptions = {}
 ): Promise<string> {
-  const compiler = await compile(options.css ?? DEFAULT_TAILWIND_CSS, {
+  const compiler = await compile(tailwindCompilerCSS(options.css), {
     base: options.base,
     loadStylesheet: async (id, base) => {
       const content = options.loadStylesheet
@@ -22,6 +22,20 @@ export async function compileTailwindCSS(
     }
   })
   return compiler.build(normalizeClasses(classes))
+}
+
+function tailwindCompilerCSS(css: string | undefined): string {
+  const trimmed = css?.trim()
+  if (!trimmed) return DEFAULT_TAILWIND_CSS
+  if (containsTailwindImport(trimmed)) return trimmed
+  return `${DEFAULT_TAILWIND_CSS}\n${trimmed}`
+}
+
+function containsTailwindImport(css: string): boolean {
+  const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '')
+  return /^\s*@import\s+(?:"tailwindcss(?:\/[^"]*)?"|'tailwindcss(?:\/[^']*)?')/m.test(
+    withoutComments
+  )
 }
 
 function normalizeClasses(classes: string | Iterable<string>): string[] {

--- a/packages/dom-css/tests/tailwind.test.ts
+++ b/packages/dom-css/tests/tailwind.test.ts
@@ -18,6 +18,17 @@ describe('@open-pencil/dom-css Tailwind', () => {
     expect(css).toContain('.rounded-xl')
   })
 
+  it('combines caller CSS with generated Tailwind utilities', async () => {
+    const css = await compileTailwindCSS(['w-60', 'p-6'], {
+      css: '.card { color: red; }'
+    })
+
+    expect(css).toContain('.card')
+    expect(css).toContain('color: red')
+    expect(css).toContain('.w-60')
+    expect(css).toContain('.p-6')
+  })
+
   it('feeds Tailwind generated CSS through headless style computation', async () => {
     const runtime = createHeadlessCSSRuntime()
     const classes = [...tailwindCardClasses]

--- a/packages/kiwi/src/fig/container.ts
+++ b/packages/kiwi/src/fig/container.ts
@@ -1,6 +1,14 @@
 import { deflateSync, inflateSync } from 'fflate'
+import { decompress as fzstdDecompressSync } from 'fzstd'
+
+import { isZstdCompressed } from './protocol'
 
 export const FIG_KIWI_DEFAULT_VERSION = 101
+
+function bunZstdDecompressSync(data: Uint8Array): Uint8Array | undefined {
+  const g = globalThis as { Bun?: { zstdDecompressSync?: (data: Uint8Array) => Uint8Array } }
+  return g.Bun?.zstdDecompressSync?.(data)
+}
 
 export function parseFigKiwiChunks(binary: Uint8Array): Uint8Array[] | null {
   const header = new TextDecoder().decode(binary.slice(0, 8))
@@ -20,6 +28,12 @@ export function parseFigKiwiChunks(binary: Uint8Array): Uint8Array[] | null {
 }
 
 export function decompressFigKiwiData(compressed: Uint8Array): Uint8Array {
+  if (isZstdCompressed(compressed)) {
+    const decompressed = bunZstdDecompressSync(compressed)
+    if (decompressed) return decompressed
+    return fzstdDecompressSync(compressed)
+  }
+
   try {
     return inflateSync(compressed)
   } catch {
@@ -28,11 +42,15 @@ export function decompressFigKiwiData(compressed: Uint8Array): Uint8Array {
 }
 
 export async function decompressFigKiwiDataAsync(compressed: Uint8Array): Promise<Uint8Array> {
+  if (isZstdCompressed(compressed)) {
+    const bunDecompressed = bunZstdDecompressSync(compressed)
+    if (bunDecompressed) return bunDecompressed
+    return fzstdDecompressSync(compressed)
+  }
   try {
     return inflateSync(compressed)
   } catch {
-    const fzstd = await import('fzstd')
-    return fzstd.decompress(compressed)
+    throw new Error('Failed to decompress fig-kiwi data')
   }
 }
 
@@ -41,9 +59,18 @@ export function buildFigKiwi(
   dataRaw: Uint8Array,
   version = FIG_KIWI_DEFAULT_VERSION
 ): Uint8Array {
-  const dataDeflated = deflateSync(dataRaw)
+  let dataCompressed: Uint8Array
+  const zstdCompress: ((data: Uint8Array) => Uint8Array) | undefined = (() => {
+    const g = globalThis as { Bun?: { zstdCompressSync?: (data: Uint8Array) => Uint8Array } }
+    return g.Bun?.zstdCompressSync
+  })()
+  if (zstdCompress) {
+    dataCompressed = zstdCompress(dataRaw)
+  } else {
+    dataCompressed = deflateSync(dataRaw)
+  }
 
-  const total = 8 + 4 + 4 + schemaDeflated.length + 4 + dataDeflated.length
+  const total = 8 + 4 + 4 + schemaDeflated.length + 4 + dataCompressed.length
   const out = new Uint8Array(total)
   const view = new DataView(out.buffer)
 
@@ -56,9 +83,9 @@ export function buildFigKiwi(
   out.set(schemaDeflated, offset)
   offset += schemaDeflated.length
 
-  view.setUint32(offset, dataDeflated.length, true)
+  view.setUint32(offset, dataCompressed.length, true)
   offset += 4
-  out.set(dataDeflated, offset)
+  out.set(dataCompressed, offset)
 
   return out
 }

--- a/packages/kiwi/src/fig/parse.ts
+++ b/packages/kiwi/src/fig/parse.ts
@@ -74,7 +74,11 @@ export function parseFigKiwiContainer(data: Uint8Array): FigKiwiPayload | null {
   if (isZstdCompressed(compressed)) {
     dataRaw = zstdDecompress(compressed)
   } else {
-    dataRaw = inflateSync(compressed)
+    try {
+      dataRaw = inflateSync(compressed)
+    } catch {
+      throw new Error('Failed to decompress fig-kiwi data chunk')
+    }
   }
 
   return { schemaDeflated: chunks[0], dataRaw, version }

--- a/packages/kiwi/tests/container.test.ts
+++ b/packages/kiwi/tests/container.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../src/fig/container'
 
 describe('Figma FIG Kiwi container helpers', () => {
-  test('builds and parses fig-kiwi chunks', () => {
+  test('builds and parses fig-kiwi chunks', async () => {
     const schemaDeflated = new Uint8Array([1, 2, 3])
     const dataRaw = new TextEncoder().encode('payload')
     const binary = buildFigKiwi(schemaDeflated, dataRaw)
@@ -20,7 +20,14 @@ describe('Figma FIG Kiwi container helpers', () => {
 
     expect(chunks).not.toBeNull()
     expect(chunks?.[0]).toEqual(schemaDeflated)
-    expect(chunks?.[1]).toEqual(deflateSync(dataRaw))
+    // A well-formed fig-kiwi container always carries a payload chunk; dereference it
+    // explicitly so a missing second chunk fails the test directly instead of being
+    // masked by an empty-buffer fallback.
+    const dataChunk = chunks?.[1]
+    expect(dataChunk).toBeInstanceOf(Uint8Array)
+    expect(dataChunk?.length).toBeGreaterThan(0)
+    expect(decompressFigKiwiData(dataChunk as Uint8Array)).toEqual(dataRaw)
+    await expect(decompressFigKiwiDataAsync(dataChunk as Uint8Array)).resolves.toEqual(dataRaw)
   })
 
   test('uses the default container version', () => {

--- a/packages/vue/src/testing/test-id.ts
+++ b/packages/vue/src/testing/test-id.ts
@@ -1,6 +1,6 @@
 export type TestId = string
 
-type CssEscapeRuntime = {
+type CSSEscapeRuntime = {
   CSS?: {
     escape?: (value: string) => string
   }
@@ -35,7 +35,7 @@ export function acpPermissionOptionTestId(kind: string): TestId {
 }
 
 function cssEscape(value: string): string {
-  const runtime = globalThis as CssEscapeRuntime
+  const runtime = globalThis as CSSEscapeRuntime
   const nativeEscape = runtime.CSS?.escape
   if (typeof nativeEscape === 'function') {
     return nativeEscape(value)

--- a/packages/vue/src/testing/test-id.ts
+++ b/packages/vue/src/testing/test-id.ts
@@ -1,5 +1,11 @@
 export type TestId = string
 
+type CssEscapeRuntime = {
+  CSS?: {
+    escape?: (value: string) => string
+  }
+}
+
 export function testId(id?: TestId | null): { 'data-test-id'?: TestId } {
   return id ? { 'data-test-id': id } : {}
 }
@@ -29,5 +35,66 @@ export function acpPermissionOptionTestId(kind: string): TestId {
 }
 
 function cssEscape(value: string): string {
-  return CSS.escape(value)
+  const runtime = globalThis as CssEscapeRuntime
+  const nativeEscape = runtime.CSS?.escape
+  if (typeof nativeEscape === 'function') {
+    return nativeEscape(value)
+  }
+
+  return cssEscapeFallback(value)
+}
+
+function cssEscapeFallback(value: string): string {
+  let escaped = ''
+
+  for (let index = 0; index < value.length; ) {
+    const codePoint = value.codePointAt(index)
+    if (codePoint === undefined) {
+      break
+    }
+
+    const character = String.fromCodePoint(codePoint)
+    const nextIndex = index + character.length
+    const isFirst = index === 0
+    const isSecondAfterHyphen = index === 1 && value.charCodeAt(0) === 0x002d
+
+    if (codePoint === 0x0000) {
+      escaped += '\uFFFD'
+    } else if (
+      isControlCodePoint(codePoint) ||
+      (isFirst && isDigitCodePoint(codePoint)) ||
+      (isSecondAfterHyphen && isDigitCodePoint(codePoint))
+    ) {
+      escaped += `\\${codePoint.toString(16)} `
+    } else if (isFirst && codePoint === 0x002d && nextIndex >= value.length) {
+      escaped += '\\-'
+    } else if (isSafeIdentifierCodePoint(codePoint)) {
+      escaped += character
+    } else {
+      escaped += `\\${character}`
+    }
+
+    index = nextIndex
+  }
+
+  return escaped
+}
+
+function isControlCodePoint(codePoint: number): boolean {
+  return (codePoint >= 0x0001 && codePoint <= 0x001f) || codePoint === 0x007f
+}
+
+function isDigitCodePoint(codePoint: number): boolean {
+  return codePoint >= 0x0030 && codePoint <= 0x0039
+}
+
+function isSafeIdentifierCodePoint(codePoint: number): boolean {
+  return (
+    codePoint >= 0x0080 ||
+    codePoint === 0x002d ||
+    codePoint === 0x005f ||
+    isDigitCodePoint(codePoint) ||
+    (codePoint >= 0x0041 && codePoint <= 0x005a) ||
+    (codePoint >= 0x0061 && codePoint <= 0x007a)
+  )
 }

--- a/src/app/tauri/http.ts
+++ b/src/app/tauri/http.ts
@@ -1,9 +1,9 @@
-interface ProxyHttpHeader {
+export interface ProxyHttpHeader {
   name: string
   value: string
 }
 
-interface ProxyHttpRequest {
+export interface ProxyHttpRequest {
   url: string
   method?: string
   headers?: ProxyHttpHeader[]
@@ -13,11 +13,18 @@ interface ProxyHttpRequest {
   timeout_ms?: number
 }
 
-interface ProxyHttpResponse {
+export interface ProxyHttpResponse {
   status: number
   headers: ProxyHttpHeader[]
   body: number[]
   url: string
+}
+
+const NULL_BODY_STATUS_CODES = new Set([204, 205, 304])
+
+function responseBodyForStatus(response: ProxyHttpResponse): BodyInit | null {
+  if (NULL_BODY_STATUS_CODES.has(response.status)) return null
+  return Uint8Array.from(response.body)
 }
 
 function headersToProxyHeaders(headers: Headers): ProxyHttpHeader[] {
@@ -60,6 +67,15 @@ export function withAbortSignal<T>(promise: Promise<T>, signal: AbortSignal): Pr
   })
 }
 
+export interface TauriFetchOptions {
+  timeoutMs?: number
+  maxResponseBytes?: number
+}
+
+export function createTauriFetch(options: TauriFetchOptions = {}): typeof fetch {
+  return (input, init) => tauriFetch(input, init, options.maxResponseBytes, options.timeoutMs)
+}
+
 export async function tauriFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
@@ -69,6 +85,7 @@ export async function tauriFetch(
   const request = new Request(input, init)
   request.signal.throwIfAborted()
   const { invoke } = await import('@tauri-apps/api/core')
+  request.signal.throwIfAborted()
   const payload: ProxyHttpRequest = {
     url: request.url,
     method: request.method,
@@ -83,7 +100,7 @@ export async function tauriFetch(
     invoke<ProxyHttpResponse>('proxy_http_request', { request: payload }),
     request.signal
   )
-  const proxiedResponse = new Response(new Uint8Array(response.body), {
+  const proxiedResponse = new Response(responseBodyForStatus(response), {
     status: response.status,
     headers: response.headers.map(({ name, value }): [string, string] => [name, value])
   })

--- a/tests/engine/io/fig/heavy/component-metadata.test.ts
+++ b/tests/engine/io/fig/heavy/component-metadata.test.ts
@@ -1,16 +1,15 @@
 import { expect, setDefaultTimeout, test } from 'bun:test'
-import { readFileSync } from 'node:fs'
 
 import { parseFigBuffer } from '@open-pencil/fig'
 
 import { importNodeChanges } from '#core/kiwi'
 
 import { expectDefined } from '#tests/helpers/assert'
+import { readFixtureArrayBuffer } from '#tests/helpers/fig-fixtures'
 import { heavy } from '#tests/helpers/test-utils'
 
 function importFixture(name: string) {
-  const buffer = readFileSync(`tests/fixtures/${name}`).buffer
-  const { nodeChanges, blobs, images } = parseFigBuffer(buffer)
+  const { nodeChanges, blobs, images } = parseFigBuffer(readFixtureArrayBuffer(name))
   return importNodeChanges(nodeChanges, blobs, new Map(images))
 }
 

--- a/tests/engine/tauri/http.test.ts
+++ b/tests/engine/tauri/http.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import {
+  createTauriFetch,
+  tauriFetch,
+  type ProxyHttpRequest,
+  type ProxyHttpResponse
+} from '@/app/tauri/http'
+
+import { clearTauriMocks, mockTauriIPC } from '#tests/helpers/tauri/mocks'
+
+type InvokeArgs = { request: ProxyHttpRequest }
+
+function proxyBodyText(request: ProxyHttpRequest): string {
+  return new TextDecoder().decode(new Uint8Array(request.body ?? []))
+}
+
+function proxyHeaderValue(request: ProxyHttpRequest, name: string): string | null {
+  return request.headers?.find((header) => header.name.toLowerCase() === name)?.value ?? null
+}
+
+async function withBrowserStrictNullBodyResponse<T>(callback: () => Promise<T>): Promise<T> {
+  const originalResponse = globalThis.Response
+  const StrictResponse = class extends originalResponse {
+    constructor(body?: BodyInit | null, init?: ResponseInit) {
+      const status = init?.status
+      if ((status === 204 || status === 205 || status === 304) && body != null) {
+        throw new TypeError('Response with null body status cannot have body')
+      }
+      super(body, init)
+    }
+  } as typeof Response
+
+  globalThis.Response = StrictResponse
+  try {
+    return await callback()
+  } finally {
+    globalThis.Response = originalResponse
+  }
+}
+
+afterEach(async () => {
+  await clearTauriMocks()
+})
+
+describe('tauriFetch', () => {
+  test('passes request timeout metadata to the desktop HTTP command', async () => {
+    let captured: InvokeArgs | null = null
+    await mockTauriIPC((command, args) => {
+      expect(command).toBe('proxy_http_request')
+      captured = args as InvokeArgs
+      return {
+        status: 201,
+        headers: [{ name: 'x-open-pencil', value: 'ok' }],
+        body: [...new TextEncoder().encode('OK')]
+      }
+    })
+
+    const response = await createTauriFetch({ timeoutMs: 15_000 })('https://example.test/check', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"ok":true}'
+    })
+
+    if (!captured) throw new Error('Expected proxy_http_request to be invoked')
+    expect(response.status).toBe(201)
+    expect(response.headers.get('x-open-pencil')).toBe('ok')
+    expect(await response.text()).toBe('OK')
+    expect(captured.request.url).toBe('https://example.test/check')
+    expect(captured.request.method).toBe('POST')
+    expect(captured.request.timeout_ms).toBe(15_000)
+    expect(captured.request.body).toEqual([...new TextEncoder().encode('{"ok":true}')])
+  })
+
+  test('forwards bodies from Request inputs', async () => {
+    let captured: InvokeArgs | null = null
+    await mockTauriIPC((command, args) => {
+      expect(command).toBe('proxy_http_request')
+      captured = args as InvokeArgs
+      return { status: 204, headers: [], body: [] }
+    })
+
+    const request = new Request('https://example.test/from-request', {
+      method: 'POST',
+      body: 'from-request'
+    })
+
+    const response = await tauriFetch(request)
+
+    if (!captured) throw new Error('Expected proxy_http_request to be invoked')
+    expect(response.status).toBe(204)
+    expect(captured.request.method).toBe('POST')
+    expect(proxyBodyText(captured.request)).toBe('from-request')
+  })
+
+  test('constructs null bodies for browser null-body response statuses', async () => {
+    await mockTauriIPC((command) => {
+      expect(command).toBe('proxy_http_request')
+      return { status: 204, headers: [{ name: 'x-no-content', value: '1' }], body: [] }
+    })
+
+    await withBrowserStrictNullBodyResponse(async () => {
+      const response = await tauriFetch('https://example.test/no-content')
+
+      expect(response.status).toBe(204)
+      expect(response.headers.get('x-no-content')).toBe('1')
+      expect(await response.text()).toBe('')
+    })
+  })
+
+  test('forwards FormData bytes with the Request-generated content boundary', async () => {
+    let captured: InvokeArgs | null = null
+    await mockTauriIPC((command, args) => {
+      expect(command).toBe('proxy_http_request')
+      captured = args as InvokeArgs
+      return { status: 204, headers: [], body: [] }
+    })
+
+    const formData = new FormData()
+    formData.append('family', 'Inter')
+
+    await tauriFetch('https://example.test/upload', { method: 'POST', body: formData })
+
+    if (!captured) throw new Error('Expected proxy_http_request to be invoked')
+    const contentType = proxyHeaderValue(captured.request, 'content-type')
+    const boundary = contentType?.match(/boundary=(.+)$/)?.[1]
+    if (!boundary) throw new Error(`Expected multipart boundary in content-type: ${contentType}`)
+
+    const body = proxyBodyText(captured.request)
+    expect(body).toContain(`--${boundary}`)
+    expect(body).toContain('name="family"')
+    expect(body).toContain('Inter')
+  })
+
+  test('rejects already-aborted requests before invoking the desktop command', async () => {
+    let calls = 0
+    await mockTauriIPC(() => {
+      calls += 1
+      return { status: 204, headers: [], body: [] }
+    })
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      tauriFetch('https://example.test/slow', { signal: controller.signal })
+    ).rejects.toHaveProperty('name', 'AbortError')
+    expect(calls).toBe(0)
+  })
+
+  test('rejects when an in-flight desktop command is aborted', async () => {
+    let calls = 0
+    let markStarted: (() => void) | null = null
+    let resolvePendingResponse: ((value: ProxyHttpResponse) => void) | null = null
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve
+    })
+    await mockTauriIPC(() => {
+      calls += 1
+      const resolve = markStarted
+      if (!resolve) throw new Error('Expected start resolver to be installed')
+      resolve()
+      return new Promise<ProxyHttpResponse>((pendingResolve) => {
+        resolvePendingResponse = pendingResolve
+      })
+    })
+    const controller = new AbortController()
+
+    const request = tauriFetch('https://example.test/slow', { signal: controller.signal })
+    await started
+    controller.abort()
+
+    await expect(request).rejects.toHaveProperty('name', 'AbortError')
+    expect(calls).toBe(1)
+    expect(resolvePendingResponse).toBeTypeOf('function')
+  })
+})

--- a/tests/engine/vue/testing/test-id.test.ts
+++ b/tests/engine/vue/testing/test-id.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { testIdSelector } from '@open-pencil/vue'
+
+const originalCssDescriptor = Reflect.getOwnPropertyDescriptor(globalThis, 'CSS')
+
+function restoreCssGlobal() {
+  if (originalCssDescriptor) {
+    Object.defineProperty(globalThis, 'CSS', originalCssDescriptor)
+  } else {
+    Reflect.deleteProperty(globalThis, 'CSS')
+  }
+}
+
+afterEach(() => {
+  restoreCssGlobal()
+})
+
+describe('testIdSelector', () => {
+  test('escapes selectors without requiring a browser CSS global', () => {
+    Reflect.deleteProperty(globalThis, 'CSS')
+
+    expect(testIdSelector('plain-id')).toBe('[data-test-id="plain-id"]')
+    expect(testIdSelector('a"b c')).toBe('[data-test-id="a\\"b\\ c"]')
+    expect(testIdSelector('1starts-with-digit')).toBe('[data-test-id="\\31 starts-with-digit"]')
+    expect(testIdSelector('-1after-hyphen')).toBe('[data-test-id="-\\31 after-hyphen"]')
+    expect(testIdSelector('-')).toBe('[data-test-id="\\-"]')
+    expect(testIdSelector('null\u0000char')).toBe('[data-test-id="null�char"]')
+  })
+
+  test('uses native CSS.escape when the runtime provides it', () => {
+    Object.defineProperty(globalThis, 'CSS', {
+      configurable: true,
+      value: {
+        escape(value: string) {
+          return `native-${value}`
+        }
+      }
+    })
+
+    expect(testIdSelector('id')).toBe('[data-test-id="native-id"]')
+  })
+})

--- a/tests/engine/vue/testing/test-id.test.ts
+++ b/tests/engine/vue/testing/test-id.test.ts
@@ -2,18 +2,18 @@ import { afterEach, describe, expect, test } from 'bun:test'
 
 import { testIdSelector } from '@open-pencil/vue'
 
-const originalCssDescriptor = Reflect.getOwnPropertyDescriptor(globalThis, 'CSS')
+const originalCSSDescriptor = Reflect.getOwnPropertyDescriptor(globalThis, 'CSS')
 
-function restoreCssGlobal() {
-  if (originalCssDescriptor) {
-    Object.defineProperty(globalThis, 'CSS', originalCssDescriptor)
+function restoreCSSGlobal() {
+  if (originalCSSDescriptor) {
+    Object.defineProperty(globalThis, 'CSS', originalCSSDescriptor)
   } else {
     Reflect.deleteProperty(globalThis, 'CSS')
   }
 }
 
 afterEach(() => {
-  restoreCssGlobal()
+  restoreCSSGlobal()
 })
 
 describe('testIdSelector', () => {

--- a/tests/helpers/fig-fixtures.ts
+++ b/tests/helpers/fig-fixtures.ts
@@ -1,8 +1,12 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-import { parseFigFile } from '@open-pencil/core'
-import type { ParseFigFileOptions, SceneGraph, SceneNode } from '@open-pencil/core'
+import {
+  parseFigFile,
+  type ParseFigFileOptions,
+  type SceneGraph,
+  type SceneNode
+} from '@open-pencil/core'
 
 import { collectAllNodes } from './fig-traversal'
 
@@ -33,12 +37,26 @@ export function readFixtureBytes(name: string): Uint8Array {
   return readFileSync(resolve(FIXTURES, name))
 }
 
+export function uint8ArrayToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const buffer = bytes.buffer
+  if (buffer instanceof ArrayBuffer) {
+    return buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+  }
+
+  const copy = new Uint8Array(bytes.byteLength)
+  copy.set(bytes)
+  return copy.buffer
+}
+
+export function readFixtureArrayBuffer(name: string): ArrayBuffer {
+  return uint8ArrayToArrayBuffer(readFixtureBytes(name))
+}
+
 export async function parseFixture(
   name: string,
   options?: ParseFigFileOptions
 ): Promise<SceneGraph> {
-  const bytes = readFixtureBytes(name)
-  return parseFigFile(bytes.buffer as ArrayBuffer, options)
+  return parseFigFile(readFixtureArrayBuffer(name), options)
 }
 
 export async function parseGoldPreviewFixture(): Promise<{

--- a/tools/package-quality/src/check/metadata.ts
+++ b/tools/package-quality/src/check/metadata.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 
 import { publicPackageDirs } from '../packages'
 
-interface PackageJSON {
+interface PackageJson {
   name: string
   version: string
   main?: string
@@ -16,11 +16,15 @@ interface PackageJSON {
 
 const errors: string[] = []
 
-function readPackageJSON(packageDir: string): PackageJSON {
+function isDeclarationPath(value: string): boolean {
+  return /\.d\.[cm]?ts$/.test(value)
+}
+
+function readPackageJson(packageDir: string): PackageJson {
   return JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8'))
 }
 
-const rootPackage = readPackageJSON('.')
+const rootPackage = readPackageJson('.')
 const expectedVersion = rootPackage.version
 
 function checkRuntimePath(packageName: string, field: string, value: string): void {
@@ -48,21 +52,51 @@ function checkIncludedRuntimePath(
   }
 }
 
-function walkExports(packageName: string, value: unknown, path: string[] = []): void {
+function checkIncludedTypePath(
+  packageName: string,
+  field: string,
+  value: string,
+  files: string[]
+): void {
+  if (!isDeclarationPath(value)) {
+    errors.push(`${packageName}: ${field} must point to a declaration file (${value})`)
+  }
+  if (value.startsWith('./src/')) {
+    errors.push(`${packageName}: ${field} must not point to source files (${value})`)
+  }
+  const normalized = value.replace(/^\.\//, '')
+  const topLevelDir = normalized.split('/')[0]
+  if (topLevelDir && !files.includes(topLevelDir)) {
+    errors.push(
+      `${packageName}: ${field} points to ${value}, but files does not include ${topLevelDir}`
+    )
+  }
+}
+
+function walkExports(
+  packageName: string,
+  value: unknown,
+  files: string[],
+  path: string[] = []
+): void {
   if (typeof value === 'string') {
     const key = path.at(-1)
-    if (key !== 'types' && key !== 'bun')
+    if (key === 'bun') return
+    if (key === 'types') {
+      checkIncludedTypePath(packageName, `exports.${path.join('.')}`, value, files)
+    } else {
       checkRuntimePath(packageName, `exports.${path.join('.')}`, value)
+    }
     return
   }
   if (!value || typeof value !== 'object') return
   for (const [key, child] of Object.entries(value)) {
-    walkExports(packageName, child, [...path, key])
+    walkExports(packageName, child, files, [...path, key])
   }
 }
 
 for (const packageDir of publicPackageDirs) {
-  const pkg = readPackageJSON(packageDir)
+  const pkg = readPackageJson(packageDir)
 
   if (pkg.version !== expectedVersion) {
     errors.push(`${pkg.name}: version ${pkg.version} must match root version ${expectedVersion}`)
@@ -73,6 +107,7 @@ for (const packageDir of publicPackageDirs) {
   }
 
   if (pkg.main) checkRuntimePath(pkg.name, 'main', pkg.main)
+  if (pkg.types) checkIncludedTypePath(pkg.name, 'types', pkg.types, pkg.files ?? [])
 
   if (typeof pkg.bin === 'string') {
     checkIncludedRuntimePath(pkg.name, 'bin', pkg.bin, pkg.files ?? [])
@@ -82,7 +117,7 @@ for (const packageDir of publicPackageDirs) {
     }
   }
 
-  walkExports(pkg.name, pkg.exports)
+  walkExports(pkg.name, pkg.exports, pkg.files ?? [])
 
   if (
     pkg.publishConfig &&

--- a/tools/package-quality/src/check/metadata.ts
+++ b/tools/package-quality/src/check/metadata.ts
@@ -3,16 +3,14 @@ import { join } from 'node:path'
 
 import { publicPackageDirs } from '../packages'
 
-interface PackageJson {
-  name: string
-  version: string
-  main?: string
-  types?: string
-  files?: string[]
-  bin?: Record<string, string> | string
-  exports?: unknown
-  publishConfig?: Record<string, unknown>
-}
+interface PackageJSON { name: string
+version: string
+main?: string
+types?: string
+files?: string[]
+bin?: Record<string, string> | string
+exports?: unknown
+publishConfig?: Record<string, unknown> }
 
 const errors: string[] = []
 
@@ -20,11 +18,11 @@ function isDeclarationPath(value: string): boolean {
   return /\.d\.[cm]?ts$/.test(value)
 }
 
-function readPackageJson(packageDir: string): PackageJson {
+function readPackageJSON(packageDir: string): PackageJSON {
   return JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8'))
 }
 
-const rootPackage = readPackageJson('.')
+const rootPackage = readPackageJSON('.')
 const expectedVersion = rootPackage.version
 
 function checkRuntimePath(packageName: string, field: string, value: string): void {
@@ -96,7 +94,7 @@ function walkExports(
 }
 
 for (const packageDir of publicPackageDirs) {
-  const pkg = readPackageJson(packageDir)
+  const pkg = readPackageJSON(packageDir)
 
   if (pkg.version !== expectedVersion) {
     errors.push(`${pkg.name}: version ${pkg.version} must match root version ${expectedVersion}`)

--- a/tools/package-quality/src/check/metadata.ts
+++ b/tools/package-quality/src/check/metadata.ts
@@ -3,14 +3,16 @@ import { join } from 'node:path'
 
 import { publicPackageDirs } from '../packages'
 
-interface PackageJSON { name: string
-version: string
-main?: string
-types?: string
-files?: string[]
-bin?: Record<string, string> | string
-exports?: unknown
-publishConfig?: Record<string, unknown> }
+interface PackageJSON {
+  name: string
+  version: string
+  main?: string
+  types?: string
+  files?: string[]
+  bin?: Record<string, string> | string
+  exports?: unknown
+  publishConfig?: Record<string, unknown>
+}
 
 const errors: string[] = []
 

--- a/tools/package-quality/src/smoke.ts
+++ b/tools/package-quality/src/smoke.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -6,6 +6,12 @@ import { fileURLToPath } from 'node:url'
 import { publicPackageDirs } from './packages'
 
 const rootDir = fileURLToPath(new URL('../../..', import.meta.url))
+const tsgoBin = join(
+  rootDir,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'tsgo.cmd' : 'tsgo'
+)
 
 function run(command: string[], cwd = rootDir): string {
   const proc = Bun.spawnSync(command, { cwd, stdout: 'pipe', stderr: 'pipe' })
@@ -20,8 +26,150 @@ function run(command: string[], cwd = rootDir): string {
   return stdout.trim()
 }
 
+const EVAL_TIMEOUT_S = 30
+
 function nodeEval(code: string, cwd: string): void {
-  run(['node', '--input-type=module', '--eval', code], cwd)
+  const args =
+    process.platform === 'win32'
+      ? ['node', '--input-type=module', '--eval', code]
+      : ['timeout', String(EVAL_TIMEOUT_S), 'node', '--input-type=module', '--eval', code]
+  run(args, cwd)
+}
+
+function writeTypeConsumer(cwd: string): void {
+  writeFileSync(
+    join(cwd, 'tsconfig.package-smoke.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          target: 'ES2022',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          lib: ['ES2022', 'DOM'],
+          typeRoots: [join(rootDir, 'node_modules', '@types')],
+          skipLibCheck: true,
+          noEmit: true
+        },
+        include: ['package-type-consumer.ts']
+      },
+      null,
+      2
+    ),
+    'utf8'
+  )
+
+  writeFileSync(
+    join(cwd, 'package-type-consumer.ts'),
+    `import { createEditor, type Editor } from '@open-pencil/core'
+import { htmlToDesignDocument, type DesignDocument } from '@open-pencil/dom-css'
+import { FIG_PACKAGE_STATUS, type FigContainerDocument } from '@open-pencil/fig'
+import { FIG_KIWI_DEFAULT_VERSION, buildFigKiwi } from '@open-pencil/kiwi/fig/container'
+import { type GUID as KiwiGUID } from '@open-pencil/kiwi/fig'
+import { parsePenFile, type PenDocument } from '@open-pencil/pen'
+import { SceneGraph, type Color, type SceneNode, type Vector } from '@open-pencil/scene-graph'
+import { testIdSelector } from '@open-pencil/vue'
+
+const graph = new SceneGraph()
+const editorFactory: typeof createEditor = createEditor
+declare const editor: Editor
+declare const designDocument: DesignDocument
+
+const color: Color = { r: 1, g: 0.5, b: 0, a: 1 }
+const vector: Vector = { x: 1, y: 2 }
+const maybeNode: SceneNode | undefined = graph.getPages()[0]
+const penDocument: PenDocument = { version: '1', children: [] }
+const figDocument: FigContainerDocument = {
+  schemaDeflated: new Uint8Array([1]),
+  dataRaw: new Uint8Array([2])
+}
+const kiwiGuid: KiwiGUID = { sessionID: 1, localID: 2 }
+
+void editorFactory
+void editor
+void designDocument
+void color
+void vector
+void maybeNode
+void penDocument
+void figDocument
+void kiwiGuid
+void FIG_PACKAGE_STATUS
+void FIG_KIWI_DEFAULT_VERSION
+void buildFigKiwi
+void parsePenFile
+void htmlToDesignDocument
+void testIdSelector
+`,
+    'utf8'
+  )
+}
+
+function checkTypeConsumer(cwd: string): void {
+  writeTypeConsumer(cwd)
+  run([tsgoBin, '--noEmit', '-p', 'tsconfig.package-smoke.json'], cwd)
+}
+
+interface PackageJson {
+  name: string
+  types?: string
+  exports?: unknown
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function readPackageJson(packageDir: string): PackageJson {
+  return JSON.parse(readFileSync(join(rootDir, packageDir, 'package.json'), 'utf8'))
+}
+
+function collectExportTypePaths(value: unknown, paths: string[] = []): string[] {
+  if (typeof value === 'string') return paths
+  if (!value || typeof value !== 'object') return paths
+  for (const [key, child] of Object.entries(value)) {
+    if (key === 'types' && typeof child === 'string') paths.push(child)
+    else collectExportTypePaths(child, paths)
+  }
+  return paths
+}
+
+function packageArchivePath(path: string): string {
+  return `package/${path.replace(/^\.\//, '')}`
+}
+
+function exportKeyToSpecifier(packageName: string, exportKey: string): string | null {
+  if (exportKey === './package.json') return null
+  if (exportKey === '.') return packageName
+  if (!exportKey.startsWith('./')) {
+    throw new Error(`${packageName}: unsupported export key ${exportKey}`)
+  }
+  if (exportKey.includes('*')) {
+    throw new Error(
+      `${packageName}: package smoke cannot exhaustively import pattern export ${exportKey}`
+    )
+  }
+  return `${packageName}/${exportKey.slice(2)}`
+}
+
+function collectPublicImportSpecifiers(packageJSON: PackageJson): string[] {
+  const { exports } = packageJSON
+  if (!exports) return []
+  if (typeof exports === 'string') return [packageJSON.name]
+  if (!isRecord(exports)) return []
+
+  const keys = Object.keys(exports)
+  if (keys.length === 0) return []
+
+  const hasExportMapKeys = keys.some((key) => key.startsWith('.'))
+  if (!hasExportMapKeys) return [packageJSON.name]
+
+  const specifiers: string[] = []
+  for (const key of keys) {
+    const specifier = exportKeyToSpecifier(packageJSON.name, key)
+    if (specifier) specifiers.push(specifier)
+  }
+  return specifiers
 }
 
 const tempDir = mkdtempSync(join(tmpdir(), 'open-pencil-package-smoke-'))
@@ -30,7 +178,12 @@ try {
   run(['bun', 'run', 'build:packages'])
 
   const tarballs: string[] = []
+  const publicImportSpecifiers = new Set<string>()
   for (const packageDir of publicPackageDirs) {
+    const packageJSON = readPackageJson(packageDir)
+    for (const specifier of collectPublicImportSpecifiers(packageJSON)) {
+      publicImportSpecifiers.add(specifier)
+    }
     const output = run(
       ['bun', 'pm', 'pack', '--destination', tempDir, '--quiet'],
       join(rootDir, packageDir)
@@ -51,35 +204,37 @@ try {
       console.error(`${basename(tarball)} includes runtime TypeScript:\n${runtimeTs.join('\n')}`)
       process.exit(1)
     }
+
+    const entries = new Set(contents.split('\n'))
+    const typePaths = [
+      ...(packageJSON.types ? [packageJSON.types] : []),
+      ...collectExportTypePaths(packageJSON.exports)
+    ]
+    const missingTypePaths = typePaths
+      .map(packageArchivePath)
+      .filter((entry) => !entries.has(entry))
+    if (missingTypePaths.length > 0) {
+      console.error(
+        `${basename(tarball)} is missing declared type files:\n${missingTypePaths.join('\n')}`
+      )
+      process.exit(1)
+    }
   }
 
   run(['npm', 'init', '-y'], tempDir)
   run(['npm', 'install', '--ignore-scripts', '--no-audit', '--no-fund', ...tarballs], tempDir)
 
-  nodeEval("await import('@open-pencil/kiwi')", tempDir)
-  nodeEval("await import('@open-pencil/kiwi/schema-runtime')", tempDir)
-  nodeEval("await import('@open-pencil/kiwi/fig')", tempDir)
-  nodeEval("await import('@open-pencil/kiwi/fig/codec')", tempDir)
-  nodeEval("await import('@open-pencil/kiwi/fig/container')", tempDir)
-  nodeEval("await import('@open-pencil/kiwi/fig/guid')", tempDir)
-  nodeEval("await import('@open-pencil/kiwi/fig/parse')", tempDir)
-  nodeEval("await import('@open-pencil/fig')", tempDir)
-  nodeEval("await import('@open-pencil/scene-graph')", tempDir)
-  nodeEval("await import('@open-pencil/scene-graph/copy')", tempDir)
-  nodeEval("await import('@open-pencil/scene-graph/coordinate')", tempDir)
-  nodeEval("await import('@open-pencil/scene-graph/geometry')", tempDir)
-  nodeEval("await import('@open-pencil/scene-graph/images')", tempDir)
-  nodeEval("await import('@open-pencil/scene-graph/matrix')", tempDir)
-  nodeEval("await import('@open-pencil/scene-graph/parse-path')", tempDir)
-  nodeEval("await import('@open-pencil/scene-graph/primitives')", tempDir)
-  nodeEval("await import('@open-pencil/pen')", tempDir)
-  nodeEval("await import('@open-pencil/core')", tempDir)
-  nodeEval("await import('@open-pencil/dom-css')", tempDir)
-  nodeEval("await import('@open-pencil/dom-css/browser')", tempDir)
-  nodeEval("await import('@open-pencil/dom-css/jsx-runtime')", tempDir)
-  nodeEval("await import('@open-pencil/dom-css/jsx-dev-runtime')", tempDir)
-  nodeEval("await import('@open-pencil/vue')", tempDir)
-  nodeEval("await import('@open-pencil/mcp')", tempDir)
+  // @open-pencil/mcp/stdio is a CLI entry point that creates a WebSocket
+  // connection on import. It is verified via the openpencil-mcp --help
+  // command below, not via import eval.
+  const evalSkipSpecifiers = new Set(['@open-pencil/mcp/stdio'])
+
+  for (const specifier of [...publicImportSpecifiers].sort()) {
+    if (evalSkipSpecifiers.has(specifier)) continue
+    nodeEval(`await import(${JSON.stringify(specifier)})`, tempDir)
+  }
+
+  checkTypeConsumer(tempDir)
 
   nodeEval(
     "const { guidToString } = await import('@open-pencil/kiwi/fig/guid'); if (guidToString({ sessionID: 1, localID: 2 }) !== '1:2') throw new Error('Kiwi GUID subpath failed')",

--- a/tools/package-quality/src/smoke.ts
+++ b/tools/package-quality/src/smoke.ts
@@ -110,17 +110,15 @@ function checkTypeConsumer(cwd: string): void {
   run([tsgoBin, '--noEmit', '-p', 'tsconfig.package-smoke.json'], cwd)
 }
 
-interface PackageJson {
-  name: string
-  types?: string
-  exports?: unknown
-}
+interface PackageJSON { name: string
+types?: string
+exports?: unknown }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
-function readPackageJson(packageDir: string): PackageJson {
+function readPackageJSON(packageDir: string): PackageJSON {
   return JSON.parse(readFileSync(join(rootDir, packageDir, 'package.json'), 'utf8'))
 }
 
@@ -152,7 +150,7 @@ function exportKeyToSpecifier(packageName: string, exportKey: string): string | 
   return `${packageName}/${exportKey.slice(2)}`
 }
 
-function collectPublicImportSpecifiers(packageJSON: PackageJson): string[] {
+function collectPublicImportSpecifiers(packageJSON: PackageJSON): string[] {
   const { exports } = packageJSON
   if (!exports) return []
   if (typeof exports === 'string') return [packageJSON.name]
@@ -180,7 +178,7 @@ try {
   const tarballs: string[] = []
   const publicImportSpecifiers = new Set<string>()
   for (const packageDir of publicPackageDirs) {
-    const packageJSON = readPackageJson(packageDir)
+    const packageJSON = readPackageJSON(packageDir)
     for (const specifier of collectPublicImportSpecifiers(packageJSON)) {
       publicImportSpecifiers.add(specifier)
     }

--- a/tools/package-quality/src/smoke.ts
+++ b/tools/package-quality/src/smoke.ts
@@ -110,9 +110,11 @@ function checkTypeConsumer(cwd: string): void {
   run([tsgoBin, '--noEmit', '-p', 'tsconfig.package-smoke.json'], cwd)
 }
 
-interface PackageJSON { name: string
-types?: string
-exports?: unknown }
+interface PackageJSON {
+  name: string
+  types?: string
+  exports?: unknown
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)


### PR DESCRIPTION
## Summary

This supersedes the mergeable parts of #397 on current `master` while leaving out stale or incompatible changes.

- Harden FIG container decompression, including zstd payloads and clear failures
- Compose caller CSS with Tailwind defaults during DOM/CSS import
- Preserve exact fixture buffer boundaries
- Preserve desktop HTTP timeout, abort, and null-body semantics
- Escape Vue SDK test selectors outside browser runtimes
- Strengthen packed-package runtime and type smoke checks
- Report clipboard image-fetch attempts accurately

Not carried forward: LFS removal, committed fixture binaries, removed `testId` prop APIs, cross-package forwarding shims, stale layout/text invalidation changes, and overlapping synced-delete snapshots.

## Attribution

Adapted from #397 by @joeycumines. Functional commits retain Joseph Cumines as co-author.

## Validation

- `bun run check`
- `bun run test:packages`
- 25 focused Kiwi, FIG, DOM/CSS, Tauri HTTP, Vue SDK, and clipboard tests
- `cargo test --manifest-path desktop/Cargo.toml http --lib`

Supersedes #397.

## AI assistance

- OpenAI GPT-5.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved desktop HTTP requests with default and configurable timeouts, cancellation support, multipart uploads, and correct empty-response handling.
  - Added support for compressed FIG data using zstd, with clearer errors for invalid data.
  - Improved Tailwind CSS composition with custom CSS and utility generation.
  - Vue test selectors now escape special characters reliably, even without browser CSS APIs.

- **Bug Fixes**
  - Missing clipboard images now accurately report whether fetching was attempted.
  - Improved package type validation and release compatibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->