### PR TITLE
fix(tauri): transfer FIG exports over binary IPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Transfer native `.fig` exports over binary Tauri IPC instead of JSON byte arrays, preventing large desktop saves from being truncated or exhausting WebView memory. (#484)
 - Keep unsaved source-less documents recoverable after their editor tab is closed, matching Figma's retained offline-change behavior.
 - Decode zstd-compressed FIG containers, reject invalid compressed payloads, and preserve exact fixture byte ranges. (#397)
 - Compose caller CSS with Tailwind defaults when importing DOM/CSS documents. (#397)

--- a/desktop/src/fig_container.rs
+++ b/desktop/src/fig_container.rs
@@ -15,7 +15,7 @@ pub fn build_fig_file(
     meta_json: String,
     images: Option<Vec<ImageEntry>>,
     fig_kiwi_version: Option<u32>,
-) -> Result<Vec<u8>, String> {
+) -> Result<tauri::ipc::Response, String> {
     let mut encoder = zstd::Encoder::new(Vec::new(), 3).map_err(|e| e.to_string())?;
     encoder
         .include_contentsize(true)
@@ -63,5 +63,5 @@ pub fn build_fig_file(
     }
 
     let result = zip.finish().map_err(|e| e.to_string())?;
-    Ok(result.into_inner())
+    Ok(tauri::ipc::Response::new(result.into_inner()))
 }

--- a/packages/core/src/io/formats/fig/export.ts
+++ b/packages/core/src/io/formats/fig/export.ts
@@ -554,7 +554,7 @@ export async function exportFigFile(
   if (IS_TAURI) {
     const { invoke } = await import('@tauri-apps/api/core')
     return new Uint8Array(
-      await invoke<number[]>('build_fig_file', {
+      await invoke<ArrayBuffer>('build_fig_file', {
         schemaDeflated: Array.from(schemaDeflated),
         kiwiData: Array.from(kiwiData),
         thumbnailPng: Array.from(thumbnailPNG),

--- a/tests/helpers/tauri/fig-export-fixture.ts
+++ b/tests/helpers/tauri/fig-export-fixture.ts
@@ -20,7 +20,7 @@ mockIPC((cmd, args) => {
   if (payload.thumbnailPng.length === 0) throw new Error('thumbnailPng is empty')
   if (payload.images.length !== 0) throw new Error('images should be empty')
   JSON.parse(payload.metaJson)
-  return [7, 8, 9]
+  return new Uint8Array([7, 8, 9]).buffer
 })
 
 const [{ exportFigFile }, { SceneGraph }] = await Promise.all([


### PR DESCRIPTION
## Summary

- Return Tauri-built `.fig` archives as raw binary IPC responses
- Consume native export results as `ArrayBuffer` instead of JSON number arrays
- Preserve the binary IPC contract in the Tauri export fixture

## Why

Desktop `.fig` export currently serializes the complete archive as a JSON array of byte numbers. A 19 MB archive becomes a much larger JSON payload and JavaScript object graph, which can exhaust WebView memory or leave a bad save result. This is the same unsafe IPC pattern previously fixed for large Windows system fonts.

The reporter's affected file is not available, so this addresses the concrete size-dependent failure in the macOS Tauri save path; it does not claim recovery of an already-corrupted file.

Fixes #484.

## Validation

- `bun test tests/engine/tauri/fig-export.test.ts`
- `cargo test --manifest-path desktop/Cargo.toml fig_container --lib`
- `bun run check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved large desktop `.fig` exports by transferring binary data more efficiently.
  * Prevented potential file truncation and excessive WebView memory usage during saves.

* **Tests**
  * Updated export test coverage to reflect the improved binary transfer format.

* **Documentation**
  * Added a changelog entry describing the enhanced desktop export behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->