### PR TITLE
perf(clipboard): index pasted node children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Performance
 
+- Index Figma clipboard children once during import instead of rescanning every pasted node, keeping large flat pastes linear. (#500)
 - Reduce peak memory during `.fig` export by sharing immutable binary resources with the isolated export graph.
 
 ### Fixed

--- a/packages/core/src/clipboard.ts
+++ b/packages/core/src/clipboard.ts
@@ -139,25 +139,31 @@ export function figmaNodesBounds(
 interface ClipboardImportMaps {
   guidMap: Map<string, KiwiNodeChange>
   parentMap: Map<string, string>
+  childMap: Map<string, string[]>
 }
 
 function buildClipboardMaps(nodeChanges: KiwiNodeChange[]): ClipboardImportMaps {
   const guidMap = new Map<string, KiwiNodeChange>()
   const parentMap = new Map<string, string>()
+  const childMap = new Map<string, string[]>()
   for (const nc of nodeChanges) {
     if (!nc.guid) continue
     const id = `${nc.guid.sessionID}:${nc.guid.localID}`
     guidMap.set(id, nc)
     if (nc.parentIndex?.guid) {
-      parentMap.set(id, `${nc.parentIndex.guid.sessionID}:${nc.parentIndex.guid.localID}`)
+      const parentId = `${nc.parentIndex.guid.sessionID}:${nc.parentIndex.guid.localID}`
+      parentMap.set(id, parentId)
+      const siblings = childMap.get(parentId)
+      if (siblings) siblings.push(id)
+      else childMap.set(parentId, [id])
     }
   }
-  return { guidMap, parentMap }
+  return { guidMap, parentMap, childMap }
 }
 
 function findInternalNodeIds(
   guidMap: Map<string, KiwiNodeChange>,
-  parentMap: Map<string, string>
+  childMap: Map<string, string[]>
 ): { internalCanvasIds: Set<string>; internalFigmaIds: Set<string> } {
   const internalCanvasIds = new Set<string>()
   for (const [id, nc] of guidMap) {
@@ -169,8 +175,8 @@ function findInternalNodeIds(
   const internalFigmaIds = new Set<string>()
   function markInternal(id: string) {
     internalFigmaIds.add(id)
-    for (const [childId, pid] of parentMap) {
-      if (pid === id && !internalFigmaIds.has(childId)) markInternal(childId)
+    for (const childId of childMap.get(id) ?? []) {
+      if (!internalFigmaIds.has(childId)) markInternal(childId)
     }
   }
   for (const canvasId of internalCanvasIds) markInternal(canvasId)
@@ -230,8 +236,8 @@ export function importClipboardNodes(
   offsetY = 0,
   blobs: Uint8Array[] = []
 ): string[] {
-  const { guidMap, parentMap } = buildClipboardMaps(nodeChanges)
-  const { internalCanvasIds, internalFigmaIds } = findInternalNodeIds(guidMap, parentMap)
+  const { guidMap, parentMap, childMap } = buildClipboardMaps(nodeChanges)
+  const { internalCanvasIds, internalFigmaIds } = findInternalNodeIds(guidMap, childMap)
   const { topLevel, internalTopLevel } = classifyTopLevelNodes(
     guidMap,
     parentMap,
@@ -262,12 +268,9 @@ export function importClipboardNodes(
     created.set(figmaId, node.id)
     if (ourParentId === targetParentId && !internalFigmaIds.has(figmaId)) createdIds.push(node.id)
 
-    const children: string[] = []
-    for (const [childId, pid] of parentMap) {
-      if (pid === figmaId && !NON_VISUAL_TYPES.has(guidMap.get(childId)?.type ?? '')) {
-        children.push(childId)
-      }
-    }
+    const children = (childMap.get(figmaId) ?? []).filter(
+      (childId) => !NON_VISUAL_TYPES.has(guidMap.get(childId)?.type ?? '')
+    )
     sortChildren(children, nc, guidMap)
     for (const childId of children) {
       createNode(childId, node.id)


### PR DESCRIPTION
## Summary

- Build a parent-to-children index while decoding Figma clipboard node changes
- Reuse that index for hierarchy creation and internal-component traversal
- Remove repeated full parent-map scans for every pasted node

## Why

Large Figma clipboard pastes were doing an O(n²) hierarchy walk: each imported node scanned the complete parent map to find its children. This directly matches the reporter's long main-thread stalls when pasting a page with many frames.

A synthetic flat 30,000-node clipboard import on the same machine changed from about **5.5 seconds** to about **0.5 seconds** in the isolated importer benchmark. A 10,000-node import changed from about **0.94 seconds** to about **0.18 seconds**.

This is a focused import-time fix. It does not claim to eliminate every source of memory growth or post-paste selection cost in the issue, so the issue should remain open until the reporter-scale workflow is retested.

Related to #500.

## Validation

- 28 focused clipboard import and Figma clipboard round-trip tests
- `bun run check`
- `git diff --check`

## AI assistance

- OpenAI GPT-5.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved clipboard import performance by indexing child relationships for faster processing of complex designs.
  * Preserved existing filtering and ordering behavior during imports.

* **Documentation**
  * Added a changelog entry describing the improved linear-time indexing performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->