### PR TITLE
perf(app): defer inactive Code panel generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Performance
 
+- Defer JSX generation and syntax highlighting until the Code panel is active, keeping large canvas selections responsive. (#500)
 - Index Figma clipboard children once during import instead of rescanning every pasted node, keeping large flat pastes linear. (#500)
 - Reduce peak memory during `.fig` export by sharing immutable binary resources with the isolated export graph.
 

--- a/src/components/CodePanel.vue
+++ b/src/components/CodePanel.vue
@@ -14,6 +14,7 @@ import Tip from '@/components/ui/Tip.vue'
 
 import type { JSXFormat } from '@open-pencil/core/design-jsx'
 
+const { active = true } = defineProps<{ active?: boolean }>()
 const store = useEditorStore()
 const { copy, copied } = useClipboard({ copiedDuring: 2000 })
 const { dialogs } = useI18n()
@@ -29,6 +30,7 @@ function toggleFormat() {
 }
 
 const jsxCode = useSceneComputed(() => {
+  if (!active) return ''
   void store.state.sceneVersion
   const ids = [...store.state.selectedIds]
   if (ids.length === 0) return ''

--- a/src/components/MobileDrawer.vue
+++ b/src/components/MobileDrawer.vue
@@ -190,7 +190,7 @@ const drawerTransition = {
 
         <TabsContent value="code" class="mt-0 h-full data-[state=inactive]:hidden">
           <div data-test-id="mobile-drawer-code" class="flex h-full flex-col">
-            <CodePanel :active="getDrawerTab() === 'code'" />
+            <CodePanel :active="isOpen && getDrawerTab() === 'code'" />
           </div>
         </TabsContent>
 

--- a/src/components/MobileDrawer.vue
+++ b/src/components/MobileDrawer.vue
@@ -190,7 +190,7 @@ const drawerTransition = {
 
         <TabsContent value="code" class="mt-0 h-full data-[state=inactive]:hidden">
           <div data-test-id="mobile-drawer-code" class="flex h-full flex-col">
-            <CodePanel />
+            <CodePanel :active="getDrawerTab() === 'code'" />
           </div>
         </TabsContent>
 

--- a/src/components/PropertiesPanel.vue
+++ b/src/components/PropertiesPanel.vue
@@ -62,7 +62,7 @@ const { panels } = useI18n()
         :force-mount="true"
         :hidden="activeTab !== 'code'"
       >
-        <CodePanel />
+        <CodePanel :active="activeTab === 'code'" />
       </TabsContent>
 
       <TabsContent

--- a/tests/e2e/code/mobile-panel.spec.ts
+++ b/tests/e2e/code/mobile-panel.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect, useEditorSetup } from '#tests/e2e/fixtures'
+
+const editor = useEditorSetup()
+
+test.use({ viewport: { width: 390, height: 844 } })
+
+test('closed mobile Code drawer defers JSX until reopened', async () => {
+  await editor.page.evaluate(() => {
+    const store = window.openPencil?.getStore?.()
+    if (!store) throw new Error('OpenPencil store not initialized')
+    const frameId = store.createShape('FRAME', 0, 0, 100, 100)
+    store.select([frameId])
+  })
+
+  await editor.page.getByTestId('mobile-ribbon-code').click()
+  await expect(editor.page.getByTestId('code-panel')).toBeVisible()
+
+  await editor.page.getByTestId('mobile-ribbon-code').click()
+  await expect
+    .poll(() => editor.page.evaluate(() => window.openPencil?.getStore?.().state.mobileDrawerSnap))
+    .toBe('closed')
+
+  await editor.page.evaluate(() => {
+    const store = window.openPencil?.getStore?.()
+    if (!store) throw new Error('OpenPencil store not initialized')
+    store.clearSelection()
+    const rectangleId = store.createShape('RECTANGLE', 120, 0, 100, 100)
+    store.select([rectangleId])
+  })
+
+  await editor.page.getByTestId('mobile-ribbon-code').click()
+  await expect(editor.page.getByTestId('code-panel')).toContainText('Rectangle')
+})

--- a/tests/e2e/code/panel.spec.ts
+++ b/tests/e2e/code/panel.spec.ts
@@ -27,7 +27,7 @@ function copyButton() {
 }
 
 test('inactive Code tab skips JSX generation for large selections', async () => {
-  const selectionDuration = await editor.page.evaluate(() => {
+  const selectionDuration = await editor.page.evaluate(async () => {
     const store = window.openPencil?.getStore?.()
     if (!store) throw new Error('OpenPencil store not initialized')
     const pageId = store.state.currentPageId
@@ -41,10 +41,13 @@ test('inactive Code tab skips JSX generation for large selections', async () => 
     }
     const startedAt = performance.now()
     store.select(ids)
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    })
     return performance.now() - startedAt
   })
 
-  expect(selectionDuration).toBeLessThan(100)
+  expect(selectionDuration).toBeLessThan(1000)
   await expect(designTab()).toHaveAttribute('data-state', 'active')
 
   await codeTab().click()

--- a/tests/e2e/code/panel.spec.ts
+++ b/tests/e2e/code/panel.spec.ts
@@ -26,6 +26,34 @@ function copyButton() {
   return editor.page.getByTestId('code-panel-copy')
 }
 
+test('inactive Code tab skips JSX generation for large selections', async () => {
+  const selectionDuration = await editor.page.evaluate(() => {
+    const store = window.openPencil?.getStore?.()
+    if (!store) throw new Error('OpenPencil store not initialized')
+    const pageId = store.state.currentPageId
+    const ids: string[] = []
+    for (let frameIndex = 0; frameIndex < 50; frameIndex++) {
+      const frame = store.graph.createNode('FRAME', pageId, { name: `Frame ${frameIndex}` })
+      ids.push(frame.id)
+      for (let childIndex = 0; childIndex < 100; childIndex++) {
+        store.graph.createNode('RECTANGLE', frame.id, { name: `Child ${childIndex}` })
+      }
+    }
+    const startedAt = performance.now()
+    store.select(ids)
+    return performance.now() - startedAt
+  })
+
+  expect(selectionDuration).toBeLessThan(100)
+  await expect(designTab()).toHaveAttribute('data-state', 'active')
+
+  await codeTab().click()
+  await expect(codePanel()).toContainText('Frame')
+
+  await editor.page.evaluate(() => window.openPencil?.getStore?.().clearSelection())
+  await designTab().click()
+})
+
 test('Code tab shows empty state with no selection', async () => {
   await codeTab().click()
   await expect(codePanelEmpty()).toBeVisible()


### PR DESCRIPTION
## Summary

- Skip Code-panel JSX generation while the Code tab is inactive
- Apply the same activation gate to desktop and mobile panel shells
- Cover large selections on the Design tab and generation after opening Code

## Why

Profiling the 30,150-node issue #500 smoke document found that selection itself and canvas overlay rendering were fast, but the force-mounted hidden Code panel reacted to every selection. It serialized the complete selected subtrees to JSX, syntax-highlighted the result, converted it to HTML, and patched the hidden DOM.

For a 150-frame / 30,000-child selection, this produced a **2.0–3.0 second main-thread task**. The CPU profile was dominated by `refractor`, `hast-util-to-html`, DOM property patching, node removal, and garbage collection.

With Code generation gated by the active tab, the same browser smoke measurement changed from roughly **3.0 seconds** to roughly **114 ms**. Code is still generated immediately when the user opens the Code tab.

Related to #500.

## Validation

- Browser smoke test with 30,150 nodes and 150 selected roots
- `bunx playwright test tests/e2e/code/panel.spec.ts --project=openpencil`
- `bun run check`
- `git diff --check`

## AI assistance

- OpenAI GPT-5.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness when selecting large designs by deferring JSX generation and syntax highlighting until the Code panel is opened.
  * Design and Properties views remain responsive while the Code tab is inactive.
  * Code output continues to appear when the Code tab is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->