### PR TITLE
fix(app): use callable fetch adapter type

### DIFF
--- a/src/app/ai/chat/model.ts
+++ b/src/app/ai/chat/model.ts
@@ -2,6 +2,7 @@ import type { LanguageModel } from 'ai'
 
 import { modelProviderAdapter } from '@/app/ai/providers/registry'
 import type { ModelConfig } from '@/app/ai/providers/types'
+import type { FetchFunction } from '@/app/http/types'
 import { isTauri } from '@/app/tauri/env'
 import { tauriFetch } from '@/app/tauri/http'
 
@@ -20,7 +21,7 @@ export function resolveLanguageModelID(
   return config.modelID
 }
 
-function desktopFetch(): typeof fetch | undefined {
+function desktopFetch(): FetchFunction | undefined {
   return isTauri() ? tauriFetch : undefined
 }
 

--- a/src/app/ai/providers/types.ts
+++ b/src/app/ai/providers/types.ts
@@ -2,6 +2,8 @@ import type { LanguageModel } from 'ai'
 
 import type { AIProviderID } from '@open-pencil/core/constants'
 
+import type { FetchFunction } from '@/app/http/types'
+
 export type ModelConfig = {
   providerID: AIProviderID
   apiKey: string
@@ -12,7 +14,7 @@ export type ModelConfig = {
 }
 
 export type ModelProviderRuntime = {
-  fetch?: typeof fetch
+  fetch?: FetchFunction
 }
 
 export interface ModelProviderAdapter {

--- a/src/app/http/types.ts
+++ b/src/app/http/types.ts
@@ -1,0 +1,1 @@
+export type FetchFunction = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>

--- a/src/app/tauri/http.ts
+++ b/src/app/tauri/http.ts
@@ -1,3 +1,5 @@
+import type { FetchFunction } from '@/app/http/types'
+
 export interface ProxyHttpHeader {
   name: string
   value: string
@@ -72,7 +74,7 @@ export interface TauriFetchOptions {
   maxResponseBytes?: number
 }
 
-export function createTauriFetch(options: TauriFetchOptions = {}): typeof fetch {
+export function createTauriFetch(options: TauriFetchOptions = {}): FetchFunction {
   return (input, init) => tauriFetch(input, init, options.maxResponseBytes, options.timeoutMs)
 }
 


### PR DESCRIPTION
## Summary

- Add an application-owned callable fetch type for custom HTTP adapters.
- Use it for the Tauri fetch factory and AI provider runtime.
- Avoid requiring Bun-specific static properties such as `fetch.preconnect` from custom fetch implementations.

The callable signature matches the custom `fetch` contract accepted by the AI SDK providers.

## Validation

- `bun run check`
- `bun test tests/engine/tauri/http.test.ts tests/engine/app/ai/model.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency across internal HTTP and AI provider integrations.
  * Standardized fetch-compatible handling to support a broader range of runtime environments.
  * No visible changes to application behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->