### PR TITLE
ci: derive GitHub Release metadata from changelog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,47 +54,17 @@ jobs:
       - uses: ./.github/actions/setup-bun
 
       - name: Extract release notes
+        if: startsWith(github.ref, 'refs/tags/v')
         id: changelog
         shell: bash
         run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          NOTES_FILE="$RUNNER_TEMP/release-notes.md"
+          bun tools/release-packages/src/extract-release-notes.ts "$VERSION" "$NOTES_FILE"
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "release_notes<<$EOF" >> "$GITHUB_OUTPUT"
-          awk '/^## /{if(found)exit; found=1; next} found{print}' CHANGELOG.md >> "$GITHUB_OUTPUT"
+          cat "$NOTES_FILE" >> "$GITHUB_OUTPUT"
           echo "$EOF" >> "$GITHUB_OUTPUT"
-
-      - name: Add new contributors to release notes
-        if: startsWith(github.ref, 'refs/tags/v')
-        id: release_body
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_NOTES: ${{ steps.changelog.outputs.release_notes }}
-        run: |
-          PREV_TAG=$(git tag -l 'v*' --sort=-version:refname | sed -n '2p')
-          NEW=""
-          if [ -n "$PREV_TAG" ]; then
-            PREV=$(git log "$PREV_TAG" --format='%aE' | sort -u)
-            NEW=$(comm -23 \
-              <(git log "${PREV_TAG}..${{ github.ref_name }}" --format='%aE' | sort -u) \
-              <(echo "$PREV") \
-            | while read -r email; do
-                git log "${PREV_TAG}..${{ github.ref_name }}" --format="%aE %aN" \
-                  | grep "^${email} " | head -1 | sed 's/^[^ ]* //'
-              done)
-          fi
-
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          {
-            echo "body<<$EOF"
-            printf '%s\n' "$RELEASE_NOTES"
-            if [ -n "$NEW" ]; then
-              echo ""
-              echo "### New Contributors"
-              echo ""
-              echo "$NEW" | while read -r name; do echo "- $name"; done
-            fi
-            echo "$EOF"
-          } >> "$GITHUB_OUTPUT"
 
       - name: Build Tauri
         uses: tauri-apps/tauri-action@v0
@@ -111,8 +81,8 @@ jobs:
           tauriScript: bunx tauri
           args: --target ${{ matrix.target }}
           tagName: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
-          releaseName: ${{ startsWith(github.ref, 'refs/tags/v') && format('OpenPencil {0}', github.ref_name) || '' }}
-          releaseBody: ${{ steps.release_body.outputs.body || steps.changelog.outputs.release_notes }}
+          releaseName: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+          releaseBody: ${{ steps.changelog.outputs.release_notes }}
           releaseDraft: true
           uploadUpdaterJson: true
           uploadUpdaterSignatures: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,13 +83,14 @@ App dialogs compose the Reka-backed components under `src/components/ui/dialog/`
 2. Update `CHANGELOG.md` — move "Unreleased" items under new version heading with date
 3. Commit: `Release v0.x.y`
 4. Tag: `git tag v0.x.y && git push --tags`
-5. Ensure GitHub release secrets include `TAURI_SIGNING_PRIVATE_KEY` (and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` if the updater key is password-protected); the public updater key is configured in `desktop/tauri.conf.json`.
+5. Ensure GitHub release secrets include `TAURI_SIGNING_PRIVATE_KEY` (and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` if the updater key is password-protected); the public updater key is configured in `desktop/tauri.conf.json`. macOS signing and notarization additionally require `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_PASSWORD`, and `APPLE_TEAM_ID`.
 6. The `build.yml` workflow triggers on `v*` tags and:
    - Builds Tauri binaries for macOS (arm64 + x64), Windows (x64 + arm64), Linux (x64)
-   - Creates a draft GitHub Release with all platform binaries
-   - Publishes public workspace packages to npm with provenance. Keep the exact package list in sync with `.github/workflows/build.yml`.
+   - Creates a draft GitHub Release whose title exactly matches the tag and whose body is the matching version section from `CHANGELOG.md`
+   - Uploads platform installers, updater signatures, and `latest.json`
+   - Publishes public workspace packages to npm with provenance. Keep the exact package list in sync with `.github/workflows/build.yml` and `tools/release-packages/src/publish-dirs.ts`.
 7. The production web app/docs deploy workflows (`app.yml`, `docs.yml`) also trigger on `v*` tags. They do **not** deploy on ordinary `master` pushes.
-8. Go to GitHub Releases → edit the draft → paste changelog section → publish
+8. Verify the draft’s title and changelog-derived body, then publish it. Publishing the GitHub Release triggers `homebrew.yml`, which updates the Homebrew cask from the signed macOS updater archives.
 
 ### CI workflows
 

--- a/bun.lock
+++ b/bun.lock
@@ -103,6 +103,7 @@
         "@wdio/mocha-framework": "9.30.1",
         "@wdio/spec-reporter": "9.30.1",
         "@wdio/tauri-service": "1.3.0",
+        "changelog-parser": "^4.1.0",
         "cloudflare-redirect-parser": "^1.0.0",
         "esbuild": "^0.27.3",
         "expect-webdriverio": "5.7.0",
@@ -1798,6 +1799,8 @@
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "changelog-parser": ["changelog-parser@4.1.0", "", { "dependencies": { "remove-markdown": "^0.6.4" }, "bin": { "changelog-parser": "dist/cli.js" } }, "sha512-FzpTTPllU+AhXrlR2R8kFjHeyz+c/htnK58GqpwBBtduFqjiRNA/fPg1rHKiJVGcMZDamWEuYMJZ93jyWVvd+A=="],
+
     "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
@@ -3151,6 +3154,8 @@
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
+
+    "remove-markdown": ["remove-markdown@0.6.4", "", {}, "sha512-BompiLClzjfh46irZmzv+1Q61jZYlKN3iq/hzae9EOUwf7ctr/5wpD4qwgn/FWDAYE18RORO7z/yr+HXZJCY8Q=="],
 
     "repeat-string": ["repeat-string@1.6.1", "", {}, "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="],
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "packages/docs",
     "tools/docs"
   ],
-  "packageManager": "bun@1.3.10",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -162,6 +161,7 @@
     "@wdio/mocha-framework": "9.30.1",
     "@wdio/spec-reporter": "9.30.1",
     "@wdio/tauri-service": "1.3.0",
+    "changelog-parser": "^4.1.0",
     "cloudflare-redirect-parser": "^1.0.0",
     "esbuild": "^0.27.3",
     "expect-webdriverio": "5.7.0",
@@ -197,5 +197,6 @@
   "overrides": {
     "protobufjs": "7.5.5",
     "websocket-driver": "0.7.5"
-  }
+  },
+  "packageManager": "bun@1.3.10"
 }

--- a/tools/release-packages/src/extract-release-notes.ts
+++ b/tools/release-packages/src/extract-release-notes.ts
@@ -1,0 +1,12 @@
+import { writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import { readReleaseNotes } from './release-notes'
+
+const [version, outputPath] = process.argv.slice(2)
+if (!version || !outputPath) {
+  throw new Error('Usage: bun extract-release-notes.ts <version> <output-path>')
+}
+
+const notes = await readReleaseNotes(resolve('CHANGELOG.md'), version)
+await writeFile(resolve(outputPath), notes)

--- a/tools/release-packages/src/release-notes.ts
+++ b/tools/release-packages/src/release-notes.ts
@@ -1,45 +1,11 @@
-import { readFile } from 'node:fs/promises'
-
-import type { Heading, RootContent } from 'mdast'
-import { fromMarkdown } from 'mdast-util-from-markdown'
-
-function headingText(node: Heading): string {
-  return node.children
-    .map((child) => ('value' in child && typeof child.value === 'string' ? child.value : ''))
-    .join('')
-    .trim()
-}
-
-function headingOffset(node: RootContent, edge: 'start' | 'end'): number {
-  const offset = node.position?.[edge].offset
-  if (offset === undefined) throw new Error('Changelog heading is missing source position data')
-  return offset
-}
-
-export function releaseNotesFromChangelog(markdown: string, version: string): string {
-  const tree = fromMarkdown(markdown)
-  const versionPrefix = `${version} `
-  const headingIndex = tree.children.findIndex(
-    (node) =>
-      node.type === 'heading' &&
-      node.depth === 2 &&
-      (headingText(node) === version || headingText(node).startsWith(versionPrefix))
-  )
-  if (headingIndex === -1) throw new Error(`Changelog section not found for ${version}`)
-
-  const heading = tree.children[headingIndex]
-  if (!heading || heading.type !== 'heading')
-    throw new Error(`Invalid changelog section for ${version}`)
-  const nextHeading = tree.children
-    .slice(headingIndex + 1)
-    .find((node) => node.type === 'heading' && node.depth === 2)
-  const start = headingOffset(heading, 'end')
-  const end = nextHeading ? headingOffset(nextHeading, 'start') : markdown.length
-  const notes = markdown.slice(start, end).trim()
-  if (!notes) throw new Error(`Changelog section is empty for ${version}`)
-  return `${notes}\n`
-}
+import { parseChangelog } from 'changelog-parser'
 
 export async function readReleaseNotes(path: string, version: string): Promise<string> {
-  return releaseNotesFromChangelog(await readFile(path, 'utf8'), version)
+  const changelog = await parseChangelog({ filePath: path, removeMarkdown: false })
+  const release = changelog.versions.find((entry) => entry.version === version)
+  if (!release) throw new Error(`Changelog section not found for ${version}`)
+
+  const notes = release.body.trim()
+  if (!notes) throw new Error(`Changelog section is empty for ${version}`)
+  return `${notes}\n`
 }

--- a/tools/release-packages/src/release-notes.ts
+++ b/tools/release-packages/src/release-notes.ts
@@ -1,0 +1,45 @@
+import { readFile } from 'node:fs/promises'
+
+import type { Heading, RootContent } from 'mdast'
+import { fromMarkdown } from 'mdast-util-from-markdown'
+
+function headingText(node: Heading): string {
+  return node.children
+    .map((child) => ('value' in child && typeof child.value === 'string' ? child.value : ''))
+    .join('')
+    .trim()
+}
+
+function headingOffset(node: RootContent, edge: 'start' | 'end'): number {
+  const offset = node.position?.[edge].offset
+  if (offset === undefined) throw new Error('Changelog heading is missing source position data')
+  return offset
+}
+
+export function releaseNotesFromChangelog(markdown: string, version: string): string {
+  const tree = fromMarkdown(markdown)
+  const versionPrefix = `${version} `
+  const headingIndex = tree.children.findIndex(
+    (node) =>
+      node.type === 'heading' &&
+      node.depth === 2 &&
+      (headingText(node) === version || headingText(node).startsWith(versionPrefix))
+  )
+  if (headingIndex === -1) throw new Error(`Changelog section not found for ${version}`)
+
+  const heading = tree.children[headingIndex]
+  if (!heading || heading.type !== 'heading')
+    throw new Error(`Invalid changelog section for ${version}`)
+  const nextHeading = tree.children
+    .slice(headingIndex + 1)
+    .find((node) => node.type === 'heading' && node.depth === 2)
+  const start = headingOffset(heading, 'end')
+  const end = nextHeading ? headingOffset(nextHeading, 'start') : markdown.length
+  const notes = markdown.slice(start, end).trim()
+  if (!notes) throw new Error(`Changelog section is empty for ${version}`)
+  return `${notes}\n`
+}
+
+export async function readReleaseNotes(path: string, version: string): Promise<string> {
+  return releaseNotesFromChangelog(await readFile(path, 'utf8'), version)
+}

--- a/tools/release-packages/tests/release-notes.test.ts
+++ b/tools/release-packages/tests/release-notes.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
-import { releaseNotesFromChangelog } from '../src/release-notes'
+import { readReleaseNotes } from '../src/release-notes'
 
 const changelog = `# Changelog
 
@@ -14,7 +17,7 @@ const changelog = `# Changelog
 
 ### Added
 
-- Shipped feature.
+- Shipped **feature**.
 
 ### Fixed
 
@@ -27,12 +30,20 @@ const changelog = `# Changelog
 - Previous fix.
 `
 
-describe('releaseNotesFromChangelog', () => {
-  test('extracts the requested version without its heading', () => {
-    expect(releaseNotesFromChangelog(changelog, '1.2.0')).toBe(
+async function changelogPath(contents = changelog) {
+  const directory = join(tmpdir(), `open-pencil-release-notes-${crypto.randomUUID()}`)
+  await mkdir(directory, { recursive: true })
+  const path = join(directory, 'CHANGELOG.md')
+  await writeFile(path, contents)
+  return path
+}
+
+describe('readReleaseNotes', () => {
+  test('extracts the requested version without its heading and preserves Markdown', async () => {
+    expect(await readReleaseNotes(await changelogPath(), '1.2.0')).toBe(
       `### Added
 
-- Shipped feature.
+- Shipped **feature**.
 
 ### Fixed
 
@@ -41,12 +52,12 @@ describe('releaseNotesFromChangelog', () => {
     )
   })
 
-  test('rejects missing and empty release sections', () => {
-    expect(() => releaseNotesFromChangelog(changelog, '9.9.9')).toThrow(
+  test('rejects missing and empty release sections', async () => {
+    await expect(readReleaseNotes(await changelogPath(), '9.9.9')).rejects.toThrow(
       'Changelog section not found for 9.9.9'
     )
-    expect(() => releaseNotesFromChangelog('## 1.2.0 — 2026-08-16\n', '1.2.0')).toThrow(
-      'Changelog section is empty for 1.2.0'
-    )
+    await expect(
+      readReleaseNotes(await changelogPath('## 1.2.0 — 2026-08-16\n'), '1.2.0')
+    ).rejects.toThrow('Changelog section is empty for 1.2.0')
   })
 })

--- a/tools/release-packages/tests/release-notes.test.ts
+++ b/tools/release-packages/tests/release-notes.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test'
+
+import { releaseNotesFromChangelog } from '../src/release-notes'
+
+const changelog = `# Changelog
+
+## Unreleased
+
+### Added
+
+- Pending work.
+
+## 1.2.0 — 2026-08-16
+
+### Added
+
+- Shipped feature.
+
+### Fixed
+
+- Corrected behavior.
+
+## 1.1.0 — 2026-08-01
+
+### Fixed
+
+- Previous fix.
+`
+
+describe('releaseNotesFromChangelog', () => {
+  test('extracts the requested version without its heading', () => {
+    expect(releaseNotesFromChangelog(changelog, '1.2.0')).toBe(
+      `### Added
+
+- Shipped feature.
+
+### Fixed
+
+- Corrected behavior.
+`
+    )
+  })
+
+  test('rejects missing and empty release sections', () => {
+    expect(() => releaseNotesFromChangelog(changelog, '9.9.9')).toThrow(
+      'Changelog section not found for 9.9.9'
+    )
+    expect(() => releaseNotesFromChangelog('## 1.2.0 — 2026-08-16\n', '1.2.0')).toThrow(
+      'Changelog section is empty for 1.2.0'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- derive draft GitHub Release titles and bodies from the pushed tag and its matching changelog section
- use `changelog-parser` to preserve the section's Markdown while rejecting missing or empty releases
- document signing, updater artifacts, npm publication, production deployment, and Homebrew handoff

## Why

The release workflow previously selected the first changelog section, which is `Unreleased`, and generated a title that differed from the tag. This keeps release metadata tied to the tagged version and makes the documented release path match the workflows.

## Validation

- `bun run check`
- `bun run test:tools`
- extracted the `0.14.0` section from the tagged changelog and compared it with the existing release text
- parsed `build.yml`, `app.yml`, `docs.yml`, and `homebrew.yml` as YAML
- verified all nine public runtime packages are included in release publication configuration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Improvements**
  * GitHub releases now use the version tag as the release title.
  * Release descriptions are populated with the matching version’s notes from the changelog.
  * Release note extraction preserves Markdown formatting and reports missing or empty sections clearly.

* **Documentation**
  * Updated release guidance covering signing, notarization, updater configuration, package publishing, verification, and Homebrew updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->