### PR TITLE
perf(chat): release completed streaming parser history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ### Performance
 
+- Release obsolete streamed Markdown parser history after each AI response completes, preventing chat memory from multiplying with every streamed chunk. (#544)
 - Use cached axis-aligned world positions for hit testing untransformed layer chains and add representative 500/2,000-node interaction profiles. (#527)
 - Coalesce writable-document autosaves that overlap an active `.fig` export while preserving a trailing save for newer edits. (#528)
 - Defer JSX generation and syntax highlighting until the Code panel is active, keeping large canvas selections responsive. (#500)

--- a/src/components/ChatPanel.vue
+++ b/src/components/ChatPanel.vue
@@ -73,6 +73,13 @@ const failureMessage = computed(() => {
   }
 })
 const status = computed(() => chat.value?.status ?? 'ready')
+function isStreamingMessage(message: UIMessage, index: number): boolean {
+  return (
+    message.role === 'assistant' &&
+    index === messages.value.length - 1 &&
+    (status.value === 'submitted' || status.value === 'streaming')
+  )
+}
 const isThinking = computed(() => {
   const s = status.value
   if (s !== 'submitted' && s !== 'streaming') return false
@@ -254,7 +261,12 @@ function handleClearChat() {
 
           <!-- Messages -->
           <div v-else data-test-id="chat-messages" class="flex flex-col gap-3">
-            <ChatMessage v-for="msg in messages" :key="msg.id" :message="msg" />
+            <ChatMessage
+              v-for="(msg, index) in messages"
+              :key="msg.id"
+              :message="msg"
+              :streaming="isStreamingMessage(msg, index)"
+            />
 
             <!-- Thinking indicator: shown when AI is working but no visible activity -->
             <div v-if="isThinking" data-test-id="chat-typing-indicator" class="flex gap-2">

--- a/src/components/chat/ChatMessage.vue
+++ b/src/components/chat/ChatMessage.vue
@@ -15,9 +15,13 @@ import ImageAttachment from '@/components/chat/attachment/image/ImageAttachment.
 
 import type { UIDataTypes, UIMessage, UIMessagePart, UITools } from 'ai'
 
-const { message } = defineProps<{ message: UIMessage }>()
+const { message, streaming = false } = defineProps<{
+  message: UIMessage
+  streaming?: boolean
+}>()
 const { dialogs } = useI18n()
 const isDark = computed(() => resolvedAppTheme.value === 'dark')
+const markdownMode = computed(() => (streaming ? 'streaming' : 'static'))
 const imageAttachments = imageAttachmentsForMessage(message.id)
 
 type ToolPart = Extract<UIMessagePart<UIDataTypes, UITools>, { toolCallId: string }>
@@ -121,9 +125,12 @@ function partKey(part: UIMessagePart<UIDataTypes, UITools>, index: number): stri
             class="rounded-xl rounded-tl-md bg-hover px-3 py-2 text-xs leading-relaxed text-surface"
           >
             <Markdown
+              :key="markdownMode"
               :content="part.text"
               :is-dark="isDark"
               :mermaid="false"
+              :mode="markdownMode"
+              :data-chat-markdown-mode="markdownMode"
               class="chat-markdown [&_[data-stream-markdown=code]]:!bg-input"
             />
           </div>

--- a/tests/e2e/chat/panel.spec.ts
+++ b/tests/e2e/chat/panel.spec.ts
@@ -261,6 +261,16 @@ test('assistant responds', async () => {
   }
 })
 
+test('completed Markdown responses release streaming parser history', async () => {
+  await chatInput().fill('Show a code block')
+  await chatInput().press('Enter')
+
+  const markdown = page.locator('.chat-markdown').last()
+  await expect(markdown).toBeVisible()
+  await expect(markdown).toHaveAttribute('data-chat-markdown-mode', 'static')
+  await expect(markdown.locator('.shiki').first()).toBeVisible()
+})
+
 test('assistant code blocks follow the active theme with readable contrast', async () => {
   await chatInput().fill('Show a code block')
   await chatInput().press('Enter')


### PR DESCRIPTION
## Summary

- keep only the active assistant response in streaming Markdown mode
- remount completed responses in static mode to release incremental parser AST caches
- preserve final Markdown, Shiki code blocks, and theme behavior

## Why

Each completed assistant response retained the Markdown parser’s incremental streaming history. Long conversations therefore kept many obsolete AST versions per response, multiplying retained memory beyond the final transcript size.

Fixes #544.

## Memory verification

Production build, 30 large streamed responses, forced garbage collection before each sample:

| State | Before | After |
|---|---:|---:|
| Start | 36.2 MB | 36.2 MB |
| 10 messages | 80.4 MB | 48.2 MB |
| 20 messages | 120.8 MB | 56.0 MB |
| 30 messages | 163.2 MB | 63.8 MB |
| 40 messages | 202.2 MB | 70.9 MB |
| 50 messages | 239.2 MB | 79.2 MB |
| 60 messages | 278.5 MB | 86.3 MB |
| After Clear | 52.2 MB | 44.7 MB |

At 60 messages, retained JavaScript heap was about 69% lower.

## Validation

- `bun run check`
- `bun run test:dupes`
- complete chat E2E suite — 19 passed
- production-build heap probe with large streamed text and code blocks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved chat performance by clearing temporary Markdown processing data after AI responses finish.
* **Bug Fixes**
  * Completed Markdown responses now reliably switch to their finalized display format.
  * Code blocks in completed responses receive syntax highlighting consistently.
* **Tests**
  * Added coverage to verify finalized Markdown rendering, performance cleanup, and code highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->