### PR TITLE
ci: remove Storybook metadata bottleneck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,16 @@ jobs:
       - name: Lint, typecheck, architecture, package, and tooling checks
         run: bun run check
 
+  storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Build packages
+        run: bun run build:packages
+
       - name: Build Storybook
         run: bun run build-storybook
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -10,12 +10,7 @@ const config: StorybookConfig = {
   addons: ['@storybook/addon-docs', '@storybook/addon-a11y', '@storybook/addon-themes'],
   framework: {
     name: '@storybook/vue3-vite',
-    options: {
-      docgen: {
-        plugin: 'vue-component-meta',
-        tsconfig: 'tsconfig.json'
-      }
-    }
+    options: {}
   },
   viteFinal(config) {
     const excludedPluginPrefixes = [


### PR DESCRIPTION
## Root cause

The `quality` job spent 7m01s of its 11m28s in `storybook build`. Vite plugin timing attributed the Storybook build to:

- `unplugin-icons`: 72%
- `storybook:vue-component-meta-plugin`: 18%

This is not specific to the CanvasKit PR: recent Storybook steps took 5m32s–7m53s.

## Fix

- Disable Storybook's duplicate `vue-component-meta` docgen pass. Public SDK API tables are already generated and validated through the VitePress documentation toolchain; Storybook is the internal component-state workshop.
- Run Storybook as an independent CI job so it no longer serially blocks format/lint/type/architecture checks.
- Build workspace packages explicitly in the Storybook job.

## Measured result

Local production Storybook build:

- Before: 8m19s
- After: 3.2s

## Verification

- `bun run build:packages`
- `bun run build-storybook`
- `bun run check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated Storybook build validation to the continuous integration process.
  * Ensures packages are built successfully before Storybook is checked.
* **Documentation**
  * Updated Storybook configuration to streamline component documentation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->