### PR TITLE
feat(canvas): add Figma guide feedback parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Duplicate guides with Option/Alt-drag, show active guide coordinates in rulers, measure ruler-created guides against selected frames and their contents, and remove guides from the context menu.
 - Create, select, move, transfer, and delete canvas and frame guides directly from rulers, with undoable edits and `.fig` round-trip fidelity.
 - Snap vector points, moved layers, and resized edges to nearby geometry, sibling layer bounds, canvas and frame layout guides, and whole-pixel coordinates with visible alignment guides, fractional-coordinate preservation when pixel snapping is off, and persistent geometry, object, and pixel-grid controls in General settings and the Preferences menu.
 - Run Pi through AI SDK HarnessAgent as a configurable desktop provider with multiple saved model profiles, secure credentials, existing MCP design tools, and per-profile thinking and permission settings.

--- a/packages/core/src/canvas/guides/redlines.ts
+++ b/packages/core/src/canvas/guides/redlines.ts
@@ -1,0 +1,88 @@
+import type { SceneGraph, SceneNode } from '@open-pencil/scene-graph'
+import { getAxisAlignedWorldBounds } from '@open-pencil/scene-graph/coordinate'
+import type { Rect } from '@open-pencil/scene-graph/primitives'
+
+import type { GuideRedline } from './types'
+
+function axisGap(axis: 'x' | 'y', position: number, bounds: Rect) {
+  const start = axis === 'x' ? bounds.x : bounds.y
+  const end = start + (axis === 'x' ? bounds.width : bounds.height)
+  if (position < start) return { from: position, to: start, value: start - position }
+  if (position > end) return { from: end, to: position, value: position - end }
+  return null
+}
+
+function frameRedline(axis: 'x' | 'y', position: number, frame: SceneNode, graph: SceneGraph) {
+  const bounds = getAxisAlignedWorldBounds(frame, graph)
+  const gap = axisGap(axis, position, bounds)
+  if (!gap) return null
+  return {
+    segment: {
+      axis,
+      ...gap,
+      cross: axis === 'x' ? bounds.y + bounds.height / 2 : bounds.x + bounds.width / 2
+    },
+    targetId: frame.id
+  } satisfies GuideRedline
+}
+
+function objectRedline(
+  axis: 'x' | 'y',
+  position: number,
+  frame: SceneNode,
+  graph: SceneGraph,
+  deep: boolean
+): GuideRedline | null {
+  const frameBounds = getAxisAlignedWorldBounds(frame, graph)
+  let closest: GuideRedline | null = null
+  const visit = (owner: SceneNode) => {
+    for (const childId of owner.childIds) {
+      const child = graph.getNode(childId)
+      if (!child || !child.visible) continue
+      const bounds = getAxisAlignedWorldBounds(child, graph)
+      const gap = axisGap(axis, position, bounds)
+      if (gap) {
+        const candidate = {
+          segment: {
+            axis,
+            ...gap,
+            cross:
+              axis === 'x'
+                ? Math.max(
+                    frameBounds.y,
+                    Math.min(frameBounds.y + frameBounds.height, bounds.y + bounds.height / 2)
+                  )
+                : Math.max(
+                    frameBounds.x,
+                    Math.min(frameBounds.x + frameBounds.width, bounds.x + bounds.width / 2)
+                  )
+          },
+          targetId: child.id
+        } satisfies GuideRedline
+        if (!closest || candidate.segment.value < closest.segment.value) closest = candidate
+      }
+      if (deep) visit(child)
+    }
+  }
+  visit(frame)
+  return closest
+}
+
+export function computeGuideRedline(
+  graph: SceneGraph,
+  pageId: string,
+  frameId: string,
+  axis: 'x' | 'y',
+  position: number,
+  deep = false
+): GuideRedline | null {
+  const frame = graph.getNode(frameId)
+  if (!frame || frame.parentId !== pageId) return null
+  const frameBounds = getAxisAlignedWorldBounds(frame, graph)
+  const coordinate = position
+  const start = axis === 'x' ? frameBounds.x : frameBounds.y
+  const end = start + (axis === 'x' ? frameBounds.width : frameBounds.height)
+  return coordinate >= start && coordinate <= end
+    ? objectRedline(axis, position, frame, graph, deep)
+    : frameRedline(axis, position, frame, graph)
+}

--- a/packages/core/src/canvas/guides/types.ts
+++ b/packages/core/src/canvas/guides/types.ts
@@ -10,12 +10,24 @@ export interface GuidePreview {
   source?: GuideSelection
 }
 
+export interface GuideRedline {
+  segment: {
+    axis: 'x' | 'y'
+    from: number
+    to: number
+    cross: number
+    value: number
+  }
+  targetId: string
+}
+
 export interface GuideOverlayState {
   preview: GuidePreview | null
   hovered: GuideSelection | null
   selected: GuideSelection | null
+  redline: GuideRedline | null
 }
 
 export function createGuideOverlayState(): GuideOverlayState {
-  return { preview: null, hovered: null, selected: null }
+  return { preview: null, hovered: null, selected: null, redline: null }
 }

--- a/packages/core/src/canvas/index.ts
+++ b/packages/core/src/canvas/index.ts
@@ -10,6 +10,7 @@ export {
   type GuideScreenSegment,
   type GuideViewport
 } from './guides/geometry'
+export { computeGuideRedline } from './guides/redlines'
 export { hitTestGuides, type GuideHit } from './guides/hit-test'
 export type { GuideOverlayState, GuidePreview, GuideSelection } from './guides/types'
 export { SkiaRenderer, type RenderOverlays, type RulerTheme } from './renderer'

--- a/packages/core/src/canvas/overlays/measurement.ts
+++ b/packages/core/src/canvas/overlays/measurement.ts
@@ -205,6 +205,31 @@ function drawTargetOutline(r: SkiaRenderer, canvas: Canvas, graph: SceneGraph, t
   immutablePath.delete()
 }
 
+export function drawMeasurementSegment(
+  r: SkiaRenderer,
+  canvas: Canvas,
+  segment: MeasurementSegment
+): void {
+  r.auxStroke.setStrokeWidth(1)
+  r.auxStroke.setColor(
+    r.ck.Color4f(MEASUREMENT_COLOR.r, MEASUREMENT_COLOR.g, MEASUREMENT_COLOR.b, 1)
+  )
+  r.auxStroke.setPathEffect(null)
+  if (segment.axis === 'x') {
+    const x1 = segment.from * r.zoom + r.panX
+    const x2 = segment.to * r.zoom + r.panX
+    const y = segment.cross * r.zoom + r.panY
+    canvas.drawLine(x1, y, x2, y, r.auxStroke)
+    drawPill(r, canvas, String(Math.round(segment.value)), center(x1, x2 - x1), y)
+  } else {
+    const x = segment.cross * r.zoom + r.panX
+    const y1 = segment.from * r.zoom + r.panY
+    const y2 = segment.to * r.zoom + r.panY
+    canvas.drawLine(x, y1, x, y2, r.auxStroke)
+    drawPill(r, canvas, String(Math.round(segment.value)), x, center(y1, y2 - y1))
+  }
+}
+
 export function drawMeasurements(
   r: SkiaRenderer,
   canvas: Canvas,
@@ -228,19 +253,5 @@ export function drawMeasurements(
   drawTargetOutline(r, canvas, graph, target)
   if (segments.length === 0) return
 
-  for (const segment of segments) {
-    if (segment.axis === 'x') {
-      const x1 = segment.from * r.zoom + r.panX
-      const x2 = segment.to * r.zoom + r.panX
-      const y = segment.cross * r.zoom + r.panY
-      canvas.drawLine(x1, y, x2, y, r.auxStroke)
-      drawPill(r, canvas, String(Math.round(segment.value)), center(x1, x2 - x1), y)
-    } else {
-      const x = segment.cross * r.zoom + r.panX
-      const y1 = segment.from * r.zoom + r.panY
-      const y2 = segment.to * r.zoom + r.panY
-      canvas.drawLine(x, y1, x, y2, r.auxStroke)
-      drawPill(r, canvas, String(Math.round(segment.value)), x, center(y1, y2 - y1))
-    }
-  }
+  for (const segment of segments) drawMeasurementSegment(r, canvas, segment)
 }

--- a/packages/core/src/canvas/renderer.ts
+++ b/packages/core/src/canvas/renderer.ts
@@ -268,7 +268,12 @@ export class SkiaRenderer {
     graph: SceneGraph,
     cursors?: RenderOverlays['remoteCursors']
   ) => void
-  declare drawRulers: (canvas: Canvas, graph: SceneGraph, selectedIds: Set<string>) => void
+  declare drawRulers: (
+    canvas: Canvas,
+    graph: SceneGraph,
+    selectedIds: Set<string>,
+    guides?: RenderOverlays['guides']
+  ) => void
   declare drawSectionTitles: (canvas: Canvas, graph: SceneGraph) => void
   declare drawComponentLabels: (canvas: Canvas, graph: SceneGraph) => void
   declare renderNode: (

--- a/packages/core/src/canvas/renderer/methods.ts
+++ b/packages/core/src/canvas/renderer/methods.ts
@@ -142,8 +142,13 @@ const rendererMethods: ThisType<SkiaRenderer> = {
     PenOverlay.drawRemoteCursors(this, canvas, graph, cursors)
   },
 
-  drawRulers(canvas: Canvas, graph: SceneGraph, selectedIds: Set<string>): void {
-    Rulers.drawRulers(this, canvas, graph, selectedIds)
+  drawRulers(
+    canvas: Canvas,
+    graph: SceneGraph,
+    selectedIds: Set<string>,
+    guides?: RenderOverlays['guides']
+  ): void {
+    Rulers.drawRulers(this, canvas, graph, selectedIds, guides)
   },
 
   drawSectionTitles(canvas: Canvas, graph: SceneGraph): void {

--- a/packages/core/src/canvas/renderer/overlay-pass.ts
+++ b/packages/core/src/canvas/renderer/overlay-pass.ts
@@ -3,6 +3,7 @@ import type { Canvas } from 'canvaskit-wasm'
 import type { SceneGraph } from '@open-pencil/scene-graph'
 
 import { drawGuides } from '#core/canvas/guides/draw'
+import { drawMeasurementSegment } from '#core/canvas/overlays/measurement'
 import type { RenderOverlays, SkiaRenderer } from '#core/canvas/renderer'
 
 function measurementVisible(overlays: RenderOverlays): boolean {
@@ -45,6 +46,7 @@ export function drawOverlayPass(
   r.profiler.endPhase('render:selection')
 
   r.drawFlashes(canvas, graph)
+  if (overlays.guides?.redline) drawMeasurementSegment(r, canvas, overlays.guides.redline.segment)
   drawGuides(r, canvas, graph, overlays.guides)
   r.drawSnapGuides(canvas, overlays.snapGuides)
   r.drawMarquee(canvas, overlays.marquee)
@@ -59,10 +61,11 @@ export function drawChromePass(
   r: SkiaRenderer,
   canvas: Canvas,
   graph: SceneGraph,
-  selectedIds: Set<string>
+  selectedIds: Set<string>,
+  overlays: RenderOverlays
 ): void {
   r.profiler.beginPhase('render:rulers')
-  if (r.showRulers) r.drawRulers(canvas, graph, selectedIds)
+  if (r.showRulers) r.drawRulers(canvas, graph, selectedIds, overlays.guides)
   r.profiler.endPhase('render:rulers')
   r.profiler.drawHUD(canvas, r.showRulers)
 }

--- a/packages/core/src/canvas/renderer/pipeline.ts
+++ b/packages/core/src/canvas/renderer/pipeline.ts
@@ -219,7 +219,7 @@ export function render(
     canvas.scale(r.dpr, r.dpr)
 
     drawOverlayPass(r, canvas, graph, selectedIds, overlays)
-    drawChromePass(r, canvas, graph, selectedIds)
+    drawChromePass(r, canvas, graph, selectedIds, overlays)
 
     canvas.restore()
   }

--- a/packages/core/src/canvas/rulers.ts
+++ b/packages/core/src/canvas/rulers.ts
@@ -3,7 +3,10 @@ import type { Canvas, CanvasKit } from 'canvaskit-wasm'
 import type { SceneNode, SceneGraph } from '@open-pencil/scene-graph'
 import { computeAbsoluteBounds } from '@open-pencil/scene-graph/geometry'
 
+import { getGuideScreenSegment } from '#core/canvas/guides/geometry'
+import type { GuideOverlayState, GuideSelection } from '#core/canvas/guides/types'
 import {
+  MEASUREMENT_COLOR,
   RULER_SIZE,
   RULER_BADGE_HEIGHT,
   RULER_BADGE_PADDING,
@@ -122,7 +125,8 @@ export function drawRulers(
   r: SkiaRenderer,
   canvas: Canvas,
   graph: SceneGraph,
-  selectedIds: Set<string>
+  selectedIds: Set<string>,
+  guides?: GuideOverlayState
 ): void {
   const R = RULER_SIZE
   const vw = r.viewportWidth
@@ -193,6 +197,101 @@ export function drawRulers(
       0,
       selBounds.sy2,
       'vertical'
+    )
+  }
+
+  drawGuideRulerPositions(r, canvas, graph, font, guides)
+}
+
+function guideSelections(guides?: GuideOverlayState): GuideSelection[] {
+  if (guides?.preview) return []
+  const selections: GuideSelection[] = []
+  if (guides?.selected) selections.push(guides.selected)
+  if (
+    guides?.hovered &&
+    (guides.hovered.ownerId !== guides.selected?.ownerId ||
+      guides.hovered.guideId !== guides.selected.guideId)
+  ) {
+    selections.push(guides.hovered)
+  }
+  return selections
+}
+
+function drawGuideRulerLabel(
+  r: SkiaRenderer,
+  canvas: Canvas,
+  font: InstanceType<CanvasKit['Font']>,
+  axis: 'x' | 'y',
+  position: number,
+  screenPosition: number
+): void {
+  const label = String(Math.round(position * 100) / 100)
+  r.auxFill.setColor(r.ck.Color4f(MEASUREMENT_COLOR.r, MEASUREMENT_COLOR.g, MEASUREMENT_COLOR.b, 1))
+  if (axis === 'x') {
+    const widths = font.getGlyphWidths(font.getGlyphIDs(label))
+    const textWidth = widths.reduce((sum, width) => sum + width, 0)
+    canvas.drawText(
+      label,
+      screenPosition - textWidth / 2,
+      RULER_SIZE * RULER_TEXT_BASELINE,
+      r.auxFill,
+      font
+    )
+  } else {
+    canvas.save()
+    canvas.translate(RULER_SIZE * RULER_TEXT_BASELINE, screenPosition)
+    canvas.rotate(-90, 0, 0)
+    canvas.drawText(label, 2, 3, r.auxFill, font)
+    canvas.restore()
+  }
+}
+
+function drawGuideRulerPositions(
+  r: SkiaRenderer,
+  canvas: Canvas,
+  graph: SceneGraph,
+  font: InstanceType<CanvasKit['Font']>,
+  guides?: GuideOverlayState
+): void {
+  if (guides?.preview) {
+    const owner = graph.getNode(guides.preview.ownerId)
+    if (!owner) return
+    const segment = getGuideScreenSegment(graph, owner, guides.preview, {
+      panX: r.panX,
+      panY: r.panY,
+      zoom: r.zoom,
+      width: r.viewportWidth,
+      height: r.viewportHeight
+    })
+    drawGuideRulerLabel(
+      r,
+      canvas,
+      font,
+      guides.preview.axis,
+      guides.preview.position,
+      guides.preview.axis === 'x' ? segment.x1 : segment.y1
+    )
+    return
+  }
+
+  for (const selection of guideSelections(guides)) {
+    const owner = graph.getNode(selection.ownerId)
+    const guide = owner?.guides.find((candidate) => candidate.id === selection.guideId)
+    if (!owner || !guide) continue
+    const segment = getGuideScreenSegment(graph, owner, guide, {
+      panX: r.panX,
+      panY: r.panY,
+      zoom: r.zoom,
+      width: r.viewportWidth,
+      height: r.viewportHeight
+    })
+    drawGuideRulerLabel(
+      r,
+      canvas,
+      font,
+      guide.axis,
+      guide.position,
+      guide.axis === 'x' ? segment.x1 : segment.y1
     )
   }
 }

--- a/packages/core/src/editor/create.ts
+++ b/packages/core/src/editor/create.ts
@@ -209,7 +209,7 @@ export function createEditor(options?: EditorOptions) {
     state.hoveredNodeId = null
     state.measurementMode = 'off'
     state.snapGuides = []
-    state.guides = { preview: null, hovered: null, selected: null }
+    state.guides = { preview: null, hovered: null, selected: null, redline: null }
     state.layoutInsertIndicator = null
     state.dropTargetId = null
     pages.clearPageViewports()

--- a/packages/core/src/editor/selection/overlays.ts
+++ b/packages/core/src/editor/selection/overlays.ts
@@ -27,6 +27,11 @@ export function createSelectionOverlayActions(ctx: EditorContext) {
     ctx.requestRepaint()
   }
 
+  function setGuideRedline(redline: typeof ctx.state.guides.redline) {
+    ctx.state.guides.redline = redline
+    ctx.requestRepaint()
+  }
+
   function setSelectedGuide(selection: typeof ctx.state.guides.selected) {
     ctx.state.guides.selected = selection
     if (selection) ctx.setSelectedIds(new Set())
@@ -81,6 +86,7 @@ export function createSelectionOverlayActions(ctx: EditorContext) {
     setSnapGuides,
     setGuidePreview,
     setHoveredGuide,
+    setGuideRedline,
     setSelectedGuide,
     setRotationPreview,
     setHoveredNode,

--- a/packages/vue/src/canvas/guides/input.ts
+++ b/packages/vue/src/canvas/guides/input.ts
@@ -15,6 +15,13 @@ interface GuideInputOptions {
   setCursor: (cursor: string | null) => void
 }
 
+export function selectedTopLevelGuideFrameId(editor: Editor): string | null {
+  if (editor.state.selectedIds.size !== 1) return null
+  const id = [...editor.state.selectedIds][0]
+  const node = editor.graph.getNode(id)
+  return node?.type === 'FRAME' && node.parentId === editor.state.currentPageId ? node.id : null
+}
+
 export function createGuideInput({
   canvasRef,
   editor,

--- a/packages/vue/src/canvas/guides/input.ts
+++ b/packages/vue/src/canvas/guides/input.ts
@@ -135,7 +135,7 @@ export function createGuideInput({
       return
     drag.dragStarted = true
     setCursor(cursor(drag.axis))
-    drag.ownerId = ownerAt(cx, cy)
+    drag.ownerId = redlines?.frameId ?? ownerAt(cx, cy)
     drag.position = positionFor(drag.ownerId, drag.axis, cx, cy)
     editor.setGuidePreview({
       ownerId: drag.ownerId,

--- a/packages/vue/src/canvas/guides/input.ts
+++ b/packages/vue/src/canvas/guides/input.ts
@@ -1,9 +1,10 @@
 import type { Ref } from 'vue'
 
-import { hitTestGuides } from '@open-pencil/core/canvas'
+import { computeGuideRedline, hitTestGuides } from '@open-pencil/core/canvas'
 import { RULER_SIZE } from '@open-pencil/core/constants'
 import type { Editor } from '@open-pencil/core/editor'
 
+import { isPastPointerDragThreshold } from '#vue/shared/input/drag-threshold'
 import type { DragGuide, DragState } from '#vue/shared/input/types'
 
 interface GuideInputOptions {
@@ -73,7 +74,7 @@ export function createGuideInput({
     return hit ? cursor(hit.axis) : null
   }
 
-  function tryStartExisting(sx: number, sy: number): boolean {
+  function tryStartExisting(sx: number, sy: number, duplicate = false): boolean {
     if (rulerAxis(sx, sy)) return false
     const hit = hitTest(sx, sy)
     if (!hit) return false
@@ -92,7 +93,8 @@ export function createGuideInput({
       dragStarted: false,
       guideId: hit.guideId,
       originalOwnerId: hit.ownerId,
-      originalPosition: hit.position
+      originalPosition: hit.position,
+      duplicate
     })
     return true
   }
@@ -116,10 +118,21 @@ export function createGuideInput({
     return true
   }
 
-  function handleMove(drag: DragGuide, sx: number, sy: number, cx: number, cy: number): void {
+  function handleMove(
+    drag: DragGuide,
+    sx: number,
+    sy: number,
+    cx: number,
+    cy: number,
+    redlines?: { frameId: string; deep: boolean }
+  ): void {
     drag.currentScreenX = sx
     drag.currentScreenY = sy
-    if (!drag.dragStarted && Math.hypot(sx - drag.startScreenX, sy - drag.startScreenY) < 3) return
+    if (
+      !drag.dragStarted &&
+      !isPastPointerDragThreshold(drag.startScreenX, drag.startScreenY, sx, sy)
+    )
+      return
     drag.dragStarted = true
     setCursor(cursor(drag.axis))
     drag.ownerId = ownerAt(cx, cy)
@@ -129,18 +142,38 @@ export function createGuideInput({
       axis: drag.axis,
       position: drag.position,
       source:
-        drag.guideId && drag.originalOwnerId
+        !drag.duplicate && drag.guideId && drag.originalOwnerId
           ? { ownerId: drag.originalOwnerId, guideId: drag.guideId }
           : undefined
     })
+    editor.setGuideRedline(
+      redlines
+        ? computeGuideRedline(
+            editor.graph,
+            editor.state.currentPageId,
+            redlines.frameId,
+            drag.axis,
+            drag.position,
+            redlines.deep
+          )
+        : null
+    )
   }
 
   function finish(drag: DragGuide): void {
     if (drag.dragStarted) {
       if (drag.currentScreenX < RULER_SIZE || drag.currentScreenY < RULER_SIZE) {
-        if (drag.guideId && drag.originalOwnerId) {
+        if (!drag.duplicate && drag.guideId && drag.originalOwnerId) {
           editor.removeGuide(drag.originalOwnerId, drag.guideId)
           editor.setSelectedGuide(null)
+        }
+      } else if (drag.duplicate && drag.guideId && drag.originalOwnerId) {
+        const source = editor.graph
+          .getNode(drag.originalOwnerId)
+          ?.guides.find((guide) => guide.id === drag.guideId)
+        if (source) {
+          const guideId = editor.addGuide(drag.ownerId, drag.axis, drag.position)
+          if (guideId) editor.setSelectedGuide({ ownerId: drag.ownerId, guideId })
         }
       } else if (drag.guideId && drag.originalOwnerId) {
         if (drag.ownerId === drag.originalOwnerId)
@@ -167,6 +200,7 @@ export function createGuideInput({
 
   function clearHoverAndPreview(): void {
     editor.setGuidePreview(null)
+    editor.setGuideRedline(null)
     editor.setHoveredGuide(null)
   }
 

--- a/packages/vue/src/canvas/useCanvasInput.ts
+++ b/packages/vue/src/canvas/useCanvasInput.ts
@@ -208,6 +208,13 @@ export function useCanvasInput(
     autoLayoutPaddingEdit.value = null
   }
 
+  function selectedTopLevelFrameId(): string | null {
+    if (editor.state.selectedIds.size !== 1) return null
+    const id = [...editor.state.selectedIds][0]
+    const node = editor.graph.getNode(id)
+    return node?.type === 'FRAME' && node.parentId === editor.state.currentPageId ? node.id : null
+  }
+
   function onDblClick(e: MouseEvent) {
     if (startAutoLayoutPaddingEdit(e)) return
     onTextDblClick(e)
@@ -224,7 +231,7 @@ export function useCanvasInput(
     if (!editor.state.editingTextId) canvasRef.value?.focus()
     editor.setHoveredNode(null)
     const { sx, sy, cx, cy } = getCoords(e)
-    if (e.button === 0 && guideInput.tryStartExisting(sx, sy)) {
+    if (e.button === 0 && guideInput.tryStartExisting(sx, sy, e.altKey)) {
       e.preventDefault()
       return
     }
@@ -295,7 +302,15 @@ export function useCanvasInput(
     const { sx, sy, cx, cy } = getCoords(e)
 
     if (d.type === 'guide') {
-      guideInput.handleMove(d, sx, sy, cx, cy)
+      const frameId = e.altKey && !d.guideId ? selectedTopLevelFrameId() : null
+      guideInput.handleMove(
+        d,
+        sx,
+        sy,
+        cx,
+        cy,
+        frameId ? { frameId, deep: e.metaKey || e.ctrlKey } : undefined
+      )
       return
     }
 

--- a/packages/vue/src/canvas/useCanvasInput.ts
+++ b/packages/vue/src/canvas/useCanvasInput.ts
@@ -4,7 +4,7 @@ import { onScopeDispose, ref, type Ref } from 'vue'
 import type { Editor } from '@open-pencil/core/editor'
 import type { SceneNode } from '@open-pencil/scene-graph'
 
-import { createGuideInput } from '#vue/canvas/guides/input'
+import { createGuideInput, selectedTopLevelGuideFrameId } from '#vue/canvas/guides/input'
 import {
   handleBendHandleMove,
   handleNodeEditMouseUp,
@@ -208,13 +208,6 @@ export function useCanvasInput(
     autoLayoutPaddingEdit.value = null
   }
 
-  function selectedTopLevelFrameId(): string | null {
-    if (editor.state.selectedIds.size !== 1) return null
-    const id = [...editor.state.selectedIds][0]
-    const node = editor.graph.getNode(id)
-    return node?.type === 'FRAME' && node.parentId === editor.state.currentPageId ? node.id : null
-  }
-
   function onDblClick(e: MouseEvent) {
     if (startAutoLayoutPaddingEdit(e)) return
     onTextDblClick(e)
@@ -302,7 +295,7 @@ export function useCanvasInput(
     const { sx, sy, cx, cy } = getCoords(e)
 
     if (d.type === 'guide') {
-      const frameId = e.altKey && !d.guideId ? selectedTopLevelFrameId() : null
+      const frameId = e.altKey && !d.guideId ? selectedTopLevelGuideFrameId(editor) : null
       guideInput.handleMove(
         d,
         sx,

--- a/packages/vue/src/i18n/locales/de/menu.json
+++ b/packages/vue/src/i18n/locales/de/menu.json
@@ -65,5 +65,6 @@
   "settings": "Einstellungen…",
   "splitRight": "Nach rechts teilen",
   "splitDown": "Nach unten teilen",
-  "closeView": "Ansicht schließen"
+  "closeView": "Ansicht schließen",
+  "removeGuide": "Hilfslinie entfernen"
 }

--- a/packages/vue/src/i18n/locales/es/menu.json
+++ b/packages/vue/src/i18n/locales/es/menu.json
@@ -65,5 +65,6 @@
   "settings": "Ajustes…",
   "splitRight": "Dividir a la derecha",
   "splitDown": "Dividir hacia abajo",
-  "closeView": "Cerrar vista"
+  "closeView": "Cerrar vista",
+  "removeGuide": "Eliminar guía"
 }

--- a/packages/vue/src/i18n/locales/fr/menu.json
+++ b/packages/vue/src/i18n/locales/fr/menu.json
@@ -65,5 +65,6 @@
   "settings": "Paramètres…",
   "splitRight": "Diviser à droite",
   "splitDown": "Diviser vers le bas",
-  "closeView": "Fermer la vue"
+  "closeView": "Fermer la vue",
+  "removeGuide": "Supprimer le repère"
 }

--- a/packages/vue/src/i18n/locales/it/menu.json
+++ b/packages/vue/src/i18n/locales/it/menu.json
@@ -65,5 +65,6 @@
   "settings": "Impostazioni…",
   "splitRight": "Dividi a destra",
   "splitDown": "Dividi in basso",
-  "closeView": "Chiudi vista"
+  "closeView": "Chiudi vista",
+  "removeGuide": "Rimuovi guida"
 }

--- a/packages/vue/src/i18n/locales/ja/menu.json
+++ b/packages/vue/src/i18n/locales/ja/menu.json
@@ -65,5 +65,6 @@
   "settings": "設定…",
   "splitRight": "右に分割",
   "splitDown": "下に分割",
-  "closeView": "ビューを閉じる"
+  "closeView": "ビューを閉じる",
+  "removeGuide": "ガイドを削除"
 }

--- a/packages/vue/src/i18n/locales/pl/menu.json
+++ b/packages/vue/src/i18n/locales/pl/menu.json
@@ -65,5 +65,6 @@
   "settings": "Ustawienia…",
   "splitRight": "Podziel w prawo",
   "splitDown": "Podziel w dół",
-  "closeView": "Zamknij widok"
+  "closeView": "Zamknij widok",
+  "removeGuide": "Usuń prowadnicę"
 }

--- a/packages/vue/src/i18n/locales/ru/menu.json
+++ b/packages/vue/src/i18n/locales/ru/menu.json
@@ -65,5 +65,6 @@
   "settings": "Настройки…",
   "splitRight": "Разделить вправо",
   "splitDown": "Разделить вниз",
-  "closeView": "Закрыть вид"
+  "closeView": "Закрыть вид",
+  "removeGuide": "Удалить направляющую"
 }

--- a/packages/vue/src/i18n/locales/zh-cn/menu.json
+++ b/packages/vue/src/i18n/locales/zh-cn/menu.json
@@ -65,5 +65,6 @@
   "settings": "设置…",
   "splitRight": "向右拆分",
   "splitDown": "向下拆分",
-  "closeView": "关闭视图"
+  "closeView": "关闭视图",
+  "removeGuide": "移除参考线"
 }

--- a/packages/vue/src/i18n/messages/menu.ts
+++ b/packages/vue/src/i18n/messages/menu.ts
@@ -73,7 +73,8 @@ export const menuMessageDefaults = {
   zoomOut: 'Zoom out',
   splitRight: 'Split right',
   splitDown: 'Split down',
-  closeView: 'Close view'
+  closeView: 'Close view',
+  removeGuide: 'Remove guide'
 } as const
 
 export const menuMessages = i18n('menu', menuMessageDefaults)

--- a/packages/vue/src/shared/input/drag-threshold.ts
+++ b/packages/vue/src/shared/input/drag-threshold.ts
@@ -1,0 +1,13 @@
+export const POINTER_DRAG_START_THRESHOLD_PX = 3
+
+export function isPastPointerDragThreshold(
+  startX: number,
+  startY: number,
+  currentX: number,
+  currentY: number,
+  threshold = POINTER_DRAG_START_THRESHOLD_PX
+): boolean {
+  const dx = currentX - startX
+  const dy = currentY - startY
+  return dx * dx + dy * dy >= threshold * threshold
+}

--- a/packages/vue/src/shared/input/move.ts
+++ b/packages/vue/src/shared/input/move.ts
@@ -2,6 +2,10 @@ import {
   computeAutoLayoutIndicator,
   computeAutoLayoutIndicatorForFrame
 } from '#vue/shared/input/auto-layout'
+import {
+  isPastPointerDragThreshold,
+  POINTER_DRAG_START_THRESHOLD_PX
+} from '#vue/shared/input/drag-threshold'
 import { findMoveDropTarget, reparentOutsideNodes } from '#vue/shared/input/drop-target'
 export { duplicateAndDrag } from '#vue/shared/input/duplicate-drag'
 import { AUTO_LAYOUT_BREAK_THRESHOLD } from '@open-pencil/core/constants'
@@ -12,7 +16,7 @@ import type { DragMove } from '#vue/shared/input/types'
 
 const AUTO_LAYOUT_REORDER_CLICK_SLOP = 3
 const AUTO_LAYOUT_CROSS_AXIS_DRAG_TOLERANCE = 96
-export const MOVE_DRAG_START_THRESHOLD_PX = 3
+export const MOVE_DRAG_START_THRESHOLD_PX = POINTER_DRAG_START_THRESHOLD_PX
 
 function isInsideAutoLayoutDragBounds(parentId: string, cx: number, cy: number, editor: Editor) {
   const parent = editor.graph.getNode(parentId)
@@ -46,9 +50,7 @@ export function detectAutoLayoutParent(editor: Editor): string | undefined {
 }
 
 function isPastDragStartThreshold(d: DragMove, sx: number, sy: number) {
-  const dx = sx - d.startScreenX
-  const dy = sy - d.startScreenY
-  return dx * dx + dy * dy >= MOVE_DRAG_START_THRESHOLD_PX * MOVE_DRAG_START_THRESHOLD_PX
+  return isPastPointerDragThreshold(d.startScreenX, d.startScreenY, sx, sy)
 }
 
 export function handleMoveMove(

--- a/packages/vue/src/shared/input/types.ts
+++ b/packages/vue/src/shared/input/types.ts
@@ -138,6 +138,7 @@ export interface DragGuide {
   currentScreenX: number
   currentScreenY: number
   dragStarted: boolean
+  duplicate?: boolean
   guideId?: string
   originalOwnerId?: string
   originalPosition?: number

--- a/src/app/editor/canvas/context-selection.ts
+++ b/src/app/editor/canvas/context-selection.ts
@@ -1,5 +1,7 @@
 import type { Ref } from 'vue'
 
+import { hitTestGuides } from '@open-pencil/core/canvas'
+
 import type { EditorStore } from '@/app/editor/active-store'
 
 export function createCanvasContextSelection(
@@ -10,10 +12,27 @@ export function createCanvasContextSelection(
     const canvas = canvasRef.value
     if (!canvas) return
     const rect = canvas.getBoundingClientRect()
-    const { x: cx, y: cy } = store.screenToCanvas(
-      event.clientX - rect.left,
-      event.clientY - rect.top
+    const sx = event.clientX - rect.left
+    const sy = event.clientY - rect.top
+    const guide = hitTestGuides(
+      store.graph,
+      store.state.currentPageId,
+      {
+        panX: store.state.panX,
+        panY: store.state.panY,
+        zoom: store.state.zoom,
+        width: rect.width,
+        height: rect.height
+      },
+      sx,
+      sy
     )
+    if (guide) {
+      store.setSelectedGuide({ ownerId: guide.ownerId, guideId: guide.guideId })
+      return
+    }
+    store.setSelectedGuide(null)
+    const { x: cx, y: cy } = store.screenToCanvas(sx, sy)
     store.selectAtPoint(cx, cy)
   }
 

--- a/src/app/editor/panes/state.ts
+++ b/src/app/editor/panes/state.ts
@@ -33,7 +33,7 @@ export function cloneCanvasPaneState(id: string, source: CanvasPaneState): Canva
     editingTextId: null,
     marquee: null,
     snapGuides: [],
-    guides: { preview: null, hovered: null, selected: null },
+    guides: { preview: null, hovered: null, selected: null, redline: null },
     rotationPreview: null,
     dropTargetId: null,
     layoutInsertIndicator: null,

--- a/src/components/EditorCanvas.vue
+++ b/src/components/EditorCanvas.vue
@@ -131,7 +131,7 @@ const cursor = computed(() => toolCursor(store.state.activeTool, cursorOverride.
 
 <template>
   <ContextMenuRoot :modal="false">
-    <ContextMenuTrigger as-child @contextmenu="selectAtContextPoint">
+    <ContextMenuTrigger as-child @contextmenu.capture="selectAtContextPoint">
       <div
         data-test-id="canvas-area"
         :data-pane-id="paneId"

--- a/src/components/canvas/CanvasMenu.vue
+++ b/src/components/canvas/CanvasMenu.vue
@@ -24,7 +24,7 @@ import {
   editorCommandMetadata,
   formatShortcut
 } from '@open-pencil/vue'
-import type { Component } from 'vue'
+import { computed, type Component } from 'vue'
 import type { EditorCommandId } from '@open-pencil/vue'
 
 import { useEditorStore } from '@/app/editor/active-store'
@@ -45,6 +45,15 @@ const { menu: t } = useI18n()
 const canvasMenuActions = createCanvasMenuActions(store, selectedIds)
 const { execCommand } = canvasMenuActions
 const contextMenu = useCanvasContextMenu(canvasMenu, hasSelection, editor, canvasMenuActions, t)
+
+const selectedGuide = computed(() => store.state.guides.selected)
+
+function removeSelectedGuide() {
+  const guide = selectedGuide.value
+  if (!guide) return
+  store.removeGuide(guide.ownerId, guide.guideId)
+  store.setSelectedGuide(null)
+}
 
 const menuCls = useMenuUI({
   content: 'min-w-56 shadow-[0_8px_30px_rgb(0_0_0/0.4)] animate-in fade-in zoom-in-95',
@@ -82,111 +91,122 @@ function contextCommandIcon(id: EditorCommandId | undefined): Component | undefi
 
 <template>
   <ContextMenuContent :class="cls.menu" :side-offset="2" align="start">
-    <ContextMenuItem
-      data-test-id="context-copy"
-      :class="cls.item"
-      :disabled="!hasSelection"
-      @select="execCommand('copy')"
-    >
-      <span>{{ t.copy }}</span
-      ><AppShortcutText>{{ appMenuShortcutLabel('copy') }}</AppShortcutText>
-    </ContextMenuItem>
-    <ContextMenuItem
-      data-test-id="context-cut"
-      :class="cls.item"
-      :disabled="!hasSelection"
-      @select="execCommand('cut')"
-    >
-      <span>{{ t.cut }}</span
-      ><AppShortcutText>{{ appMenuShortcutLabel('cut') }}</AppShortcutText>
-    </ContextMenuItem>
-    <ContextMenuItem data-test-id="context-paste" :class="cls.item" @select="execCommand('paste')">
-      <span>{{ t.pasteHere }}</span
-      ><AppShortcutText>{{ appMenuShortcutLabel('paste') }}</AppShortcutText>
-    </ContextMenuItem>
-    <ContextMenuItem
-      data-test-id="context-paste-to-replace"
-      :class="cls.item"
-      :disabled="!hasSelection"
-      @select="canvasMenuActions.pasteToReplace"
-    >
-      <span>{{ t.pasteToReplace }}</span>
-    </ContextMenuItem>
-    <ContextMenuItem
-      data-test-id="context-duplicate"
-      :class="cls.item"
-      :disabled="!hasSelection"
-      @select="getCommand('selection.duplicate').run()"
-    >
-      <span>{{ getCommand('selection.duplicate').label }}</span
-      ><AppShortcutText>{{
-        formatShortcut(editorCommandMetadata('selection.duplicate').shortcut)
-      }}</AppShortcutText>
-    </ContextMenuItem>
-    <ContextMenuItem
-      data-test-id="context-delete"
-      :class="cls.item"
-      :disabled="!hasSelection"
-      @select="getCommand('selection.delete').run()"
-    >
-      <span>{{ getCommand('selection.delete').label }}</span
-      ><AppShortcutText>{{ editorCommandMetadata('selection.delete').shortcut }}</AppShortcutText>
-    </ContextMenuItem>
-
-    <template v-for="(item, i) in contextMenu" :key="`menu-${i}`">
-      <ContextMenuSeparator v-if="item.separator" :class="cls.sep" />
-      <ContextMenuSub v-else-if="item.sub">
-        <ContextMenuSubTrigger v-test-id="item.testId" :class="cls.item">
-          <span>{{ item.label }}</span
-          ><span class="text-sm text-muted">›</span>
-        </ContextMenuSubTrigger>
-        <ContextMenuPortal>
-          <ContextMenuSubContent :class="cls.submenu">
-            <ContextMenuItem
-              v-for="(sub, j) in item.sub"
-              :key="j"
-              :class="cls.item"
-              v-test-id="sub.separator ? undefined : sub.testId"
-              :disabled="sub.separator ? true : sub.disabled"
-              @select="!sub.separator && sub.action?.()"
-            >
-              <template v-if="!sub.separator">
-                <span class="flex min-w-0 flex-1 items-center gap-2">
-                  <component
-                    :is="contextCommandIcon(sub.id)"
-                    v-if="contextCommandIcon(sub.id)"
-                    class="size-3.5 shrink-0 text-muted"
-                  />
-                  <span class="truncate">{{ sub.label }}</span>
-                </span>
-                <AppShortcutText v-if="sub.shortcut">{{ sub.shortcut }}</AppShortcutText>
-              </template>
-            </ContextMenuItem>
-          </ContextMenuSubContent>
-        </ContextMenuPortal>
-      </ContextMenuSub>
-      <ContextMenuItem
-        v-else
-        v-test-id="item.testId ?? contextCommandTestId(item.id)"
-        :class="canvasMenuItemClass(item.label, cls)"
-        :disabled="item.disabled"
-        @select="item.action?.()"
-      >
-        <span class="flex min-w-0 flex-1 items-center gap-2">
-          <component
-            :is="contextCommandIcon(item.id)"
-            v-if="contextCommandIcon(item.id)"
-            class="size-3.5 shrink-0 text-muted"
-          />
-          <span class="truncate">{{ item.label }}</span>
-        </span>
-        <span
-          v-if="item.shortcut"
-          class="text-[11px]"
-          :class="canvasMenuShortcutClass(item.label)"
-          >{{ item.shortcut }}</span
-        >
+    <template v-if="selectedGuide">
+      <ContextMenuItem data-property="guide" :class="cls.item" @select="removeSelectedGuide">
+        <span>{{ t.removeGuide }}</span>
       </ContextMenuItem>
+    </template>
+    <template v-else>
+      <ContextMenuItem
+        data-test-id="context-copy"
+        :class="cls.item"
+        :disabled="!hasSelection"
+        @select="execCommand('copy')"
+      >
+        <span>{{ t.copy }}</span
+        ><AppShortcutText>{{ appMenuShortcutLabel('copy') }}</AppShortcutText>
+      </ContextMenuItem>
+      <ContextMenuItem
+        data-test-id="context-cut"
+        :class="cls.item"
+        :disabled="!hasSelection"
+        @select="execCommand('cut')"
+      >
+        <span>{{ t.cut }}</span
+        ><AppShortcutText>{{ appMenuShortcutLabel('cut') }}</AppShortcutText>
+      </ContextMenuItem>
+      <ContextMenuItem
+        data-test-id="context-paste"
+        :class="cls.item"
+        @select="execCommand('paste')"
+      >
+        <span>{{ t.pasteHere }}</span
+        ><AppShortcutText>{{ appMenuShortcutLabel('paste') }}</AppShortcutText>
+      </ContextMenuItem>
+      <ContextMenuItem
+        data-test-id="context-paste-to-replace"
+        :class="cls.item"
+        :disabled="!hasSelection"
+        @select="canvasMenuActions.pasteToReplace"
+      >
+        <span>{{ t.pasteToReplace }}</span>
+      </ContextMenuItem>
+      <ContextMenuItem
+        data-test-id="context-duplicate"
+        :class="cls.item"
+        :disabled="!hasSelection"
+        @select="getCommand('selection.duplicate').run()"
+      >
+        <span>{{ getCommand('selection.duplicate').label }}</span
+        ><AppShortcutText>{{
+          formatShortcut(editorCommandMetadata('selection.duplicate').shortcut)
+        }}</AppShortcutText>
+      </ContextMenuItem>
+      <ContextMenuItem
+        data-test-id="context-delete"
+        :class="cls.item"
+        :disabled="!hasSelection"
+        @select="getCommand('selection.delete').run()"
+      >
+        <span>{{ getCommand('selection.delete').label }}</span
+        ><AppShortcutText>{{ editorCommandMetadata('selection.delete').shortcut }}</AppShortcutText>
+      </ContextMenuItem>
+
+      <template v-for="(item, i) in contextMenu" :key="`menu-${i}`">
+        <ContextMenuSeparator v-if="item.separator" :class="cls.sep" />
+        <ContextMenuSub v-else-if="item.sub">
+          <ContextMenuSubTrigger v-test-id="item.testId" :class="cls.item">
+            <span>{{ item.label }}</span
+            ><span class="text-sm text-muted">›</span>
+          </ContextMenuSubTrigger>
+          <ContextMenuPortal>
+            <ContextMenuSubContent :class="cls.submenu">
+              <ContextMenuItem
+                v-for="(sub, j) in item.sub"
+                :key="j"
+                :class="cls.item"
+                v-test-id="sub.separator ? undefined : sub.testId"
+                :disabled="sub.separator ? true : sub.disabled"
+                @select="!sub.separator && sub.action?.()"
+              >
+                <template v-if="!sub.separator">
+                  <span class="flex min-w-0 flex-1 items-center gap-2">
+                    <component
+                      :is="contextCommandIcon(sub.id)"
+                      v-if="contextCommandIcon(sub.id)"
+                      class="size-3.5 shrink-0 text-muted"
+                    />
+                    <span class="truncate">{{ sub.label }}</span>
+                  </span>
+                  <AppShortcutText v-if="sub.shortcut">{{ sub.shortcut }}</AppShortcutText>
+                </template>
+              </ContextMenuItem>
+            </ContextMenuSubContent>
+          </ContextMenuPortal>
+        </ContextMenuSub>
+        <ContextMenuItem
+          v-else
+          v-test-id="item.testId ?? contextCommandTestId(item.id)"
+          :class="canvasMenuItemClass(item.label, cls)"
+          :disabled="item.disabled"
+          @select="item.action?.()"
+        >
+          <span class="flex min-w-0 flex-1 items-center gap-2">
+            <component
+              :is="contextCommandIcon(item.id)"
+              v-if="contextCommandIcon(item.id)"
+              class="size-3.5 shrink-0 text-muted"
+            />
+            <span class="truncate">{{ item.label }}</span>
+          </span>
+          <span
+            v-if="item.shortcut"
+            class="text-[11px]"
+            :class="canvasMenuShortcutClass(item.label)"
+            >{{ item.shortcut }}</span
+          >
+        </ContextMenuItem>
+      </template>
     </template>
   </ContextMenuContent>
 </template>

--- a/src/components/canvas/CanvasMenu.vue
+++ b/src/components/canvas/CanvasMenu.vue
@@ -8,6 +8,7 @@ import {
   ContextMenuSubContent,
   ContextMenuPortal
 } from 'reka-ui'
+import IconChevronRight from '~icons/lucide/chevron-right'
 import IconCombine from '~icons/lucide/combine'
 import IconCopyMinus from '~icons/lucide/copy-minus'
 import IconCopyX from '~icons/lucide/copy-x'
@@ -156,8 +157,8 @@ function contextCommandIcon(id: EditorCommandId | undefined): Component | undefi
         <ContextMenuSeparator v-if="item.separator" :class="cls.sep" />
         <ContextMenuSub v-else-if="item.sub">
           <ContextMenuSubTrigger v-test-id="item.testId" :class="cls.item">
-            <span>{{ item.label }}</span
-            ><span class="text-sm text-muted">›</span>
+            <span>{{ item.label }}</span>
+            <IconChevronRight class="size-3.5 text-muted" />
           </ContextMenuSubTrigger>
           <ContextMenuPortal>
             <ContextMenuSubContent :class="cls.submenu">

--- a/tests/engine/render/canvas/guides/redlines.test.ts
+++ b/tests/engine/render/canvas/guides/redlines.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test'
+
+import { SceneGraph } from '@open-pencil/scene-graph'
+
+import { computeGuideRedline } from '#core/canvas/guides/redlines'
+
+function setup() {
+  const graph = new SceneGraph()
+  const page = graph.getNode(graph.rootId)
+  if (!page) throw new Error('Expected page')
+  const frame = graph.createNode('FRAME', page.id, { x: 100, y: 100, width: 300, height: 200 })
+  graph.createNode('RECTANGLE', frame.id, { x: 50, y: 40, width: 80, height: 60 })
+  return { graph, pageId: page.id, frameId: frame.id }
+}
+
+describe('guide redlines', () => {
+  test('measures from a guide outside a top-level frame to its nearest edge', () => {
+    const { graph, pageId, frameId } = setup()
+    expect(computeGuideRedline(graph, pageId, frameId, 'x', 40)).toEqual({
+      segment: { axis: 'x', from: 40, to: 100, cross: 200, value: 60 },
+      targetId: frameId
+    })
+  })
+
+  test('measures from an intersecting guide to frame children', () => {
+    const { graph, pageId, frameId } = setup()
+    const redline = computeGuideRedline(graph, pageId, frameId, 'x', 120)
+    expect(redline?.segment).toMatchObject({ axis: 'x', from: 120, to: 150, value: 30 })
+  })
+
+  test('only accepts top-level selected frames', () => {
+    const { graph, pageId, frameId } = setup()
+    const nested = graph.createNode('FRAME', frameId)
+    expect(computeGuideRedline(graph, pageId, nested.id, 'x', 0)).toBeNull()
+  })
+})

--- a/tests/engine/vue/input/guides.test.ts
+++ b/tests/engine/vue/input/guides.test.ts
@@ -83,6 +83,34 @@ describe('guide canvas input', () => {
     ])
   })
 
+  test('keeps a selected top-level frame as owner over nested frame content', () => {
+    const { editor, input, getDrag } = setup()
+    const pageId = editor.state.currentPageId
+    const frame = editor.graph.createNode('FRAME', pageId, {
+      x: 100,
+      y: 100,
+      width: 300,
+      height: 200
+    })
+    const nested = editor.graph.createNode('FRAME', frame.id, {
+      x: 40,
+      y: 30,
+      width: 100,
+      height: 80
+    })
+    editor.graph.hitTestDeep = () => nested
+    input.tryStartFromRuler(100, 5, 100, 5)
+    const drag = getDrag()
+    if (drag?.type !== 'guide') throw new Error('Expected guide drag')
+
+    input.handleMove(drag, 200, 200, 200, 200, { frameId: frame.id, deep: false })
+    expect(drag.ownerId).toBe(frame.id)
+    expect(editor.state.guides.preview?.ownerId).toBe(frame.id)
+    input.finish(drag)
+    expect(editor.graph.getNode(frame.id)?.guides).toHaveLength(1)
+    expect(editor.graph.getNode(nested.id)?.guides).toEqual([])
+  })
+
   test('ruler hover takes precedence over an intersecting existing guide', () => {
     const { editor, input } = setup()
     editor.addGuide(editor.state.currentPageId, 'x', 100)

--- a/tests/engine/vue/input/guides.test.ts
+++ b/tests/engine/vue/input/guides.test.ts
@@ -12,7 +12,7 @@ function setup() {
   Object.assign(editor.state, { showRulers: true })
   let drag: DragState | null = null
   const input = createGuideInput({
-    canvasRef: ref<HTMLCanvasElement | null>(null),
+    canvasRef: ref({ clientWidth: 500, clientHeight: 500 } as HTMLCanvasElement),
     editor,
     canvasToLocal: (cx, cy) => ({ lx: cx, ly: cy }),
     setDrag: (next) => {
@@ -48,6 +48,39 @@ describe('guide canvas input', () => {
       axis: 'y',
       position: 40
     })
+  })
+
+  test('Option-drag duplicates an existing guide and preserves the source', () => {
+    const { editor, input, getDrag } = setup()
+    const pageId = editor.state.currentPageId
+    const sourceId = editor.addGuide(pageId, 'x', 40)
+    editor.undo.clear()
+
+    expect(input.tryStartExisting(40, 100, true)).toBe(true)
+    const drag = getDrag()
+    if (drag?.type !== 'guide') throw new Error('Expected guide drag')
+    input.handleMove(drag, 80, 100, 80, 100)
+    expect(editor.state.guides.preview?.source).toBeUndefined()
+    input.finish(drag)
+
+    const guides = editor.graph.getNode(pageId)?.guides ?? []
+    expect(guides).toHaveLength(2)
+    expect(guides).toContainEqual({ id: sourceId, axis: 'x', position: 40 })
+    expect(guides.some((guide) => guide.id !== sourceId && guide.position === 80)).toBe(true)
+  })
+
+  test('discarding an Option-drag on the ruler preserves the source guide', () => {
+    const { editor, input, getDrag } = setup()
+    const pageId = editor.state.currentPageId
+    const sourceId = editor.addGuide(pageId, 'x', 40)
+    input.tryStartExisting(40, 100, true)
+    const drag = getDrag()
+    if (drag?.type !== 'guide') throw new Error('Expected guide drag')
+    input.handleMove(drag, 5, 100, 5, 100)
+    input.finish(drag)
+    expect(editor.graph.getNode(pageId)?.guides).toEqual([
+      { id: sourceId, axis: 'x', position: 40 }
+    ])
   })
 
   test('ruler hover takes precedence over an intersecting existing guide', () => {

--- a/tests/engine/vue/input/guides.test.ts
+++ b/tests/engine/vue/input/guides.test.ts
@@ -4,7 +4,7 @@ import { ref } from 'vue'
 
 import { createEditor } from '@open-pencil/core/editor'
 
-import { createGuideInput } from '#vue/canvas/guides/input'
+import { createGuideInput, selectedTopLevelGuideFrameId } from '#vue/canvas/guides/input'
 import type { DragState } from '#vue/shared/input/types'
 
 function setup() {
@@ -14,7 +14,10 @@ function setup() {
   const input = createGuideInput({
     canvasRef: ref({ clientWidth: 500, clientHeight: 500 } as HTMLCanvasElement),
     editor,
-    canvasToLocal: (cx, cy) => ({ lx: cx, ly: cy }),
+    canvasToLocal: (cx, cy, scopeId) => {
+      const owner = editor.graph.getNode(scopeId)
+      return { lx: cx - (owner?.x ?? 0), ly: cy - (owner?.y ?? 0) }
+    },
     setDrag: (next) => {
       drag = next
     },
@@ -99,12 +102,19 @@ describe('guide canvas input', () => {
       height: 80
     })
     editor.graph.hitTestDeep = () => nested
+    editor.select([frame.id])
     input.tryStartFromRuler(100, 5, 100, 5)
     const drag = getDrag()
     if (drag?.type !== 'guide') throw new Error('Expected guide drag')
+    const selectedFrameId = selectedTopLevelGuideFrameId(editor)
+    expect(selectedFrameId).toBe(frame.id)
 
-    input.handleMove(drag, 200, 200, 200, 200, { frameId: frame.id, deep: false })
+    input.handleMove(drag, 200, 200, 200, 200, {
+      frameId: selectedFrameId ?? '',
+      deep: false
+    })
     expect(drag.ownerId).toBe(frame.id)
+    expect(drag.position).toBe(100)
     expect(editor.state.guides.preview?.ownerId).toBe(frame.id)
     input.finish(drag)
     expect(editor.graph.getNode(frame.id)?.guides).toHaveLength(1)


### PR DESCRIPTION
## Summary
- duplicate existing guides with Option/Alt-drag while preserving the source
- show active and selected guide coordinates in rulers and guide redlines against selected top-level frames
- add guide context-menu removal and share pointer drag threshold logic with layer duplication

## Validation
- `bun run check`
- focused guide, ruler measurement, and move-threshold engine tests
- `bun run test:dupes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate existing guides by holding Option/Alt while dragging.
  * Display guide coordinates in rulers and measurement redlines against frames or contents.
  * Select guides directly and remove them from the context menu.
* **Bug Fixes**
  * Improved guide dragging previews, scoping, and cleanup.
  * Prevented accidental guide removal when a duplication drag is canceled.
  * Added localized “Remove guide” menu labels across supported languages.
* **Documentation**
  * Added changelog entries describing the guide improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->