### PR TITLE
fix(ai): report zero cache tokens as observation unless cache_control was sent

### DIFF
--- a/src/app/ai/caching.ts
+++ b/src/app/ai/caching.ts
@@ -1,0 +1,13 @@
+import type { AIProviderID } from '@open-pencil/core/constants'
+
+export const ANTHROPIC_CACHE_CONTROL = {
+  anthropic: { cacheControl: { type: 'ephemeral' } }
+} as const
+
+export function supportsAnthropicCaching(providerID: AIProviderID, modelID: string): boolean {
+  return (
+    providerID === 'anthropic' ||
+    providerID === 'anthropic-compatible' ||
+    (providerID === 'openrouter' && modelID.startsWith('anthropic/'))
+  )
+}

--- a/src/app/ai/chat/transports.ts
+++ b/src/app/ai/chat/transports.ts
@@ -7,6 +7,7 @@ import { ref } from 'vue'
 import { ACP_AGENTS } from '@open-pencil/core/constants'
 import type { ACPAgentID, AIProviderID } from '@open-pencil/core/constants'
 
+import { ANTHROPIC_CACHE_CONTROL, supportsAnthropicCaching } from '@/app/ai/caching'
 import {
   classifyAIChatError,
   classifyAIChatFinish,
@@ -37,18 +38,6 @@ type ToolLoopTransportOptions = {
   effectiveModelID: string
   maxOutputTokens: number
   reasoningEffort: string
-}
-
-const ANTHROPIC_CACHE_CONTROL = {
-  anthropic: { cacheControl: { type: 'ephemeral' } }
-} as const
-
-function supportsAnthropicCaching(providerID: AIProviderID, modelID: string): boolean {
-  return (
-    providerID === 'anthropic' ||
-    providerID === 'anthropic-compatible' ||
-    (providerID === 'openrouter' && modelID.startsWith('anthropic/'))
-  )
 }
 
 function mergeProviderOptions(

--- a/src/app/ai/debug/index.ts
+++ b/src/app/ai/debug/index.ts
@@ -2,8 +2,10 @@ import type { UIMessage } from 'ai'
 
 import { buildDebugLog } from '@open-pencil/core/tools'
 import type { ToolDebugLog, ToolLogEntry } from '@open-pencil/core/tools'
+import type { AIProviderID } from '@open-pencil/core/constants'
 import type { JSONObject } from '@open-pencil/scene-graph/primitives'
 
+import { supportsAnthropicCaching } from '@/app/ai/caching'
 import type { AIChatFailure } from '@/app/ai/chat/failure'
 import { getStepUsages, getToolLogEntries } from '@/app/ai/tools'
 
@@ -18,7 +20,12 @@ export function safeFailureDetail(detail: string): string {
     : `${redacted.slice(0, MAX_FAILURE_DETAIL_LENGTH)}…`
 }
 
-export function formatTokenUsage(): string {
+export type CacheProviderContext = {
+  providerID: AIProviderID
+  modelID: string
+}
+
+export function formatTokenUsage(providerContext?: CacheProviderContext): string {
   const steps = getStepUsages()
   if (steps.length === 0) return '  (no usage data — provider may not report it)'
 
@@ -47,13 +54,21 @@ export function formatTokenUsage(): string {
   const cacheHitRate = totalInput > 0 ? ((totalCacheRead / totalInput) * 100).toFixed(1) : '0.0'
   const savedTokens = totalCacheRead > 0 ? totalCacheRead - Math.round(totalCacheRead * 0.1) : 0
 
+  const cacheControlSent =
+    providerContext && supportsAnthropicCaching(providerContext.providerID, providerContext.modelID)
+  const noCacheReported = totalCacheRead === 0 && totalCacheWrite === 0
+  let cacheWarning = ''
+  if (noCacheReported) {
+    cacheWarning = cacheControlSent
+      ? '⚠ NO CACHE TOKENS REPORTED — cache_control was sent, so caching may not be working'
+      : 'No cache tokens reported by this provider (it may not report them)'
+  }
+
   lines.unshift(
     `Total: in=${totalInput} out=${totalOutput} cache_read=${totalCacheRead} cache_write=${totalCacheWrite}`,
     `Cache hit rate: ${cacheHitRate}% (saved ~${savedTokens} uncached input tokens, 90% cost reduction on cached)`,
     `Steps: ${steps.length}`,
-    totalCacheRead === 0 && totalCacheWrite === 0
-      ? '⚠ NO CACHING DETECTED — system prompt + tools are re-processed every step'
-      : ''
+    cacheWarning
   )
 
   return lines.filter(Boolean).join('\n')
@@ -217,7 +232,11 @@ function formatMessageStats(messages: UIMessage[]): string {
   return lines.join('\n')
 }
 
-export function serializeChatLog(messages: UIMessage[], failure?: AIChatFailure | null): string {
+export function serializeChatLog(
+  messages: UIMessage[],
+  failure?: AIChatFailure | null,
+  providerContext?: CacheProviderContext
+): string {
   const sections: string[] = []
 
   const toolLog = getToolLogEntries()
@@ -230,7 +249,7 @@ export function serializeChatLog(messages: UIMessage[], failure?: AIChatFailure 
   sections.push('')
 
   sections.push('=== TOKEN USAGE & CACHING ===')
-  sections.push(formatTokenUsage())
+  sections.push(formatTokenUsage(providerContext))
   sections.push('')
 
   sections.push('=== DIAGNOSTICS ===')
@@ -291,7 +310,11 @@ export function serializeChatLog(messages: UIMessage[], failure?: AIChatFailure 
   return sections.join('\n\n')
 }
 
-export function copyChatLog(messages: UIMessage[], failure?: AIChatFailure | null): Promise<void> {
-  const text = serializeChatLog(messages, failure)
+export function copyChatLog(
+  messages: UIMessage[],
+  failure?: AIChatFailure | null,
+  providerContext?: CacheProviderContext
+): Promise<void> {
+  const text = serializeChatLog(messages, failure, providerContext)
   return navigator.clipboard.writeText(text)
 }

--- a/src/components/ChatPanel.vue
+++ b/src/components/ChatPanel.vue
@@ -41,7 +41,8 @@ import type { JSONObject } from '@open-pencil/scene-graph/primitives'
 
 const IS_DEV = import.meta.env.DEV
 
-const { isConfigured, ensureChat, resetChat, chatFailure, clearChatFailure } = useAIChat()
+const { isConfigured, ensureChat, resetChat, chatFailure, clearChatFailure, providerID, modelID } =
+  useAIChat()
 const { copy } = useClipboard()
 const { dialogs } = useI18n()
 const notifications = useNotificationMessages()
@@ -225,7 +226,10 @@ function handleStop() {
 }
 
 async function handleCopyDebug() {
-  await copyChatLog(messages.value, chatFailure.value)
+  await copyChatLog(messages.value, chatFailure.value, {
+    providerID: providerID.value,
+    modelID: modelID.value
+  })
   debugCopied.value = true
 }
 

--- a/tests/engine/app/ai/debug-log.test.ts
+++ b/tests/engine/app/ai/debug-log.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, test } from 'bun:test'
+import { beforeEach, describe, expect, test } from 'bun:test'
 
 import type { UIMessage } from 'ai'
 
 import { safeFailureDetail, serializeChatLog } from '@/app/ai/debug'
 import { setActiveEditorStore } from '@/app/editor/active-store'
 import { createEditorStore } from '@/app/editor/session'
+import { clearToolLogEntries, recordStepUsage } from '@/app/ai/tools'
 
 const messages: UIMessage[] = [
   { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Create a card' }] }
@@ -12,6 +13,17 @@ const messages: UIMessage[] = [
 
 describe('AI debug log', () => {
   setActiveEditorStore(createEditorStore())
+
+  beforeEach(() => {
+    clearToolLogEntries()
+    recordStepUsage({
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      timestamp: 0
+    })
+  })
 
   test('records request-level failures', () => {
     const log = serializeChatLog(messages, {
@@ -33,5 +45,17 @@ describe('AI debug log', () => {
 
   test('reports when no request failure was recorded', () => {
     expect(serializeChatLog(messages)).toContain('=== ERRORS ===\n\n  (none recorded)')
+  })
+
+  test('reports zero cache tokens as an observation for providers without cache_control', () => {
+    const log = serializeChatLog(messages, null, { providerID: 'openai', modelID: 'gpt-4o' })
+    expect(log).toContain('No cache tokens reported by this provider (it may not report them)')
+    expect(log).not.toContain('NO CACHE TOKENS REPORTED')
+  })
+
+  test('warns when an Anthropic-family provider sends cache_control but reports zero tokens', () => {
+    const log = serializeChatLog(messages, null, { providerID: 'anthropic', modelID: 'claude-3-5' })
+    expect(log).toContain('⚠ NO CACHE TOKENS REPORTED — cache_control was sent')
+    expect(log).not.toContain('No cache tokens reported by this provider')
   })
 })


### PR DESCRIPTION
## Why

Fixes #453. The AI debug panel claimed `NO CACHING DETECTED — system prompt + tools are re-processed every step` whenever the per-step cache counters were zero. Zero counters only mean the provider *reported* no cache tokens — for OpenAI-compatible providers prefix caching happens server-side with nothing for the client to enable, so the counters are expected to be zero regardless. The message read as a diagnosis of broken caching and produced a confident wrong conclusion (it nearly got filed as "the largest cost item in every log").

## What users will see

Copying the AI debug log no longer claims caching is broken for providers that never report cache telemetry. The zero-cache line now states the observation:

- **Non-Anthropic providers** (OpenAI-compatible, Google, etc.): `No cache tokens reported by this provider (it may not report them)`
- **Anthropic-family providers** (anthropic, anthropic-compatible, openrouter `anthropic/*`) — where `cache_control: ephemeral` is actually sent: the stronger `⚠ NO CACHE TOKENS REPORTED — cache_control was sent, so caching may not be working` remains, because there zero counters genuinely indicate caching isn't working.

## Surface area

- [x] UI — AI chat debug log copy output (`src/app/ai/debug`, `ChatPanel.vue`)
- [ ] Keyboard shortcut / CLI / API / Extension / i18n / dependency / behavior
- Behavior of the copied debug-log text is the change itself; no runtime feature behavior changes.

## Validation

- Extracted `supportsAnthropicCaching` into `src/app/ai/caching.ts`, shared by `transports.ts` (behavior unchanged) and the debug formatter.
- `bun test tests/engine/app/ai/debug-log.test.ts` → 5 pass (2 new cases: openai → observation, anthropic → warning).
- `tsgo --noEmit`, `vue-tsc --noEmit`, `bun run lint` → clean (only pre-existing max-lines warnings unrelated to this change).

## AI assistance

Claude (Anthropic) was used to help draft the implementation and the PR description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Anthropic prompt caching configuration across supported Anthropic-compatible models.
  * Chat debug logs now include provider and model context for clearer troubleshooting.
  * Token usage reports distinguish unavailable cache metrics from providers that do not report them.

* **Bug Fixes**
  * Improved cache-token reporting, including clearer informational messages and warnings for Anthropic caching scenarios.

* **Tests**
  * Expanded coverage for provider-specific cache-token reporting and reset handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->