### PR TITLE
fix(chat): treat absent MCP isError as success

### DIFF
--- a/src/components/chat/ChatMessage.vue
+++ b/src/components/chat/ChatMessage.vue
@@ -42,7 +42,22 @@ function hasErrorOutput(part: ToolPart): boolean {
   )
 }
 
+function mcpResultState(part: ToolPart): 'done' | 'error' | undefined {
+  if (
+    part.output === null ||
+    typeof part.output !== 'object' ||
+    !('content' in part.output) ||
+    !Array.isArray(part.output.content)
+  ) {
+    return undefined
+  }
+
+  return 'isError' in part.output && part.output.isError === true ? 'error' : 'done'
+}
+
 function toolState(part: ToolPart): 'pending' | 'done' | 'error' {
+  const mcpState = mcpResultState(part)
+  if (mcpState !== undefined) return mcpState
   if (part.state === 'output-error' || hasErrorOutput(part)) return 'error'
   if (part.state === 'output-available') return 'done'
   return 'pending'

--- a/src/components/chat/ChatMessage.vue
+++ b/src/components/chat/ChatMessage.vue
@@ -10,8 +10,9 @@ import {
   imageAttachmentsForMessage,
   visibleUserMessageText
 } from '@/app/ai/attachment/image/presentation'
-import { resolvedAppTheme } from '@/app/shell/theme'
 import ImageAttachment from '@/components/chat/attachment/image/ImageAttachment.vue'
+import { resolvedAppTheme } from '@/app/shell/theme'
+import { classifyToolState } from './tool-state'
 
 import type { UIDataTypes, UIMessage, UIMessagePart, UITools } from 'ai'
 
@@ -42,25 +43,12 @@ function hasErrorOutput(part: ToolPart): boolean {
   )
 }
 
-function mcpResultState(part: ToolPart): 'done' | 'error' | undefined {
-  if (
-    part.output === null ||
-    typeof part.output !== 'object' ||
-    !('content' in part.output) ||
-    !Array.isArray(part.output.content)
-  ) {
-    return undefined
-  }
-
-  return 'isError' in part.output && part.output.isError === true ? 'error' : 'done'
-}
-
 function toolState(part: ToolPart): 'pending' | 'done' | 'error' {
-  const mcpState = mcpResultState(part)
-  if (mcpState !== undefined) return mcpState
-  if (part.state === 'output-error' || hasErrorOutput(part)) return 'error'
-  if (part.state === 'output-available') return 'done'
-  return 'pending'
+  return classifyToolState({
+    toolName: getToolName(part),
+    state: part.state,
+    output: part.output
+  })
 }
 
 function partKey(part: UIMessagePart<UIDataTypes, UITools>, index: number): string {

--- a/src/components/chat/tool-state.ts
+++ b/src/components/chat/tool-state.ts
@@ -1,0 +1,35 @@
+export type ToolDisplayState = 'pending' | 'done' | 'error'
+
+export type ToolStateInput = {
+  toolName: string
+  state: string
+  output?: unknown
+}
+
+export function isMCPToolName(toolName: string): boolean {
+  return toolName.startsWith('mcp__')
+}
+
+function hasErrorOutput(output: unknown): boolean {
+  return typeof output === 'object' && output !== null && 'error' in output
+}
+
+export function classifyToolState({ toolName, state, output }: ToolStateInput): ToolDisplayState {
+  if (state === 'output-error' || (state === 'output-available' && hasErrorOutput(output))) {
+    return 'error'
+  }
+
+  if (
+    isMCPToolName(toolName) &&
+    state === 'output-available' &&
+    typeof output === 'object' &&
+    output !== null &&
+    'content' in output &&
+    Array.isArray(output.content)
+  ) {
+    return 'isError' in output && output.isError === true ? 'error' : 'done'
+  }
+
+  if (state === 'output-available') return 'done'
+  return 'pending'
+}

--- a/tests/engine/app/chat/tool-state.test.ts
+++ b/tests/engine/app/chat/tool-state.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test'
+
+import { classifyToolState, isMCPToolName } from '@/components/chat/tool-state'
+
+describe('classifyToolState', () => {
+  test('recognizes MCP tools by their names', () => {
+    expect(isMCPToolName('mcp__server__search')).toBe(true)
+    expect(isMCPToolName('get_nodes')).toBe(false)
+  })
+
+  test('treats omitted and false MCP isError as success', () => {
+    expect(
+      classifyToolState({
+        toolName: 'mcp__server__search',
+        state: 'output-available',
+        output: { content: [{ type: 'text', text: 'ok' }] }
+      })
+    ).toBe('done')
+    expect(
+      classifyToolState({
+        toolName: 'mcp__server__search',
+        state: 'output-available',
+        output: { content: [], isError: false }
+      })
+    ).toBe('done')
+  })
+
+  test('treats true MCP isError as an error', () => {
+    expect(
+      classifyToolState({
+        toolName: 'mcp__server__search',
+        state: 'output-available',
+        output: { content: [], isError: true }
+      })
+    ).toBe('error')
+  })
+
+  test('does not classify non-MCP content objects as MCP results', () => {
+    expect(
+      classifyToolState({
+        toolName: 'get_nodes',
+        state: 'output-available',
+        output: { content: [] }
+      })
+    ).toBe('done')
+  })
+
+  test('preserves generic error precedence', () => {
+    expect(
+      classifyToolState({
+        toolName: 'mcp__server__search',
+        state: 'output-available',
+        output: { content: [], error: 'failed' }
+      })
+    ).toBe('error')
+    expect(
+      classifyToolState({
+        toolName: 'mcp__server__search',
+        state: 'output-error',
+        output: { content: [] }
+      })
+    ).toBe('error')
+  })
+})


### PR DESCRIPTION
## Summary

Treat MCP tool results as errors only when `isError === true` in the OpenPencil chat UI.

## Changes

- Recognize MCP tool outputs by their `content` array.
- Render MCP results with missing `isError` as completed, matching MCP semantics.
- Render MCP results with `isError: false` as completed.
- Render MCP results with `isError: true` as errors.
- Preserve the existing error handling for non-MCP tool outputs and transport failures.

## Context

The MCP specification defines `isError` as optional and treats an omitted value as `false`. The chat UI was relying on the generic tool state and could display successful MCP calls as errors when the field was absent.

## Validation

- 32 MCP tests passed.
- `bun run lint` passed.
- `bunx tsgo --noEmit` passed.
- `bun --filter @open-pencil/mcp build` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message status handling for tool results.
  * Tool outputs are now more accurately identified as pending, completed, or errored.
  * Structured tool results with content arrays now display the correct status.
  * Explicit errors take priority, ensuring failed operations are clearly shown even when other result details are present.

* **Tests**
  * Added coverage for tool-result status classification, including successful and failed structured responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->