### PR TITLE
fix(fig): harden document worker sessions

### DIFF
--- a/packages/core/src/editor/create.ts
+++ b/packages/core/src/editor/create.ts
@@ -9,6 +9,8 @@ import type { SkiaRenderer } from '#core/canvas/renderer'
 import { prefetchFigmaSchema } from '#core/clipboard'
 import { IS_BROWSER } from '#core/constants'
 import { clearLazyFigImportContext } from '#core/kiwi/fig/lazy-import'
+import { releaseFigPopulationWorker } from '#core/kiwi/fig/population/client'
+import { releaseOriginalFigArchive } from '#core/kiwi/fig/session/original-archive'
 import { setTextMeasurer } from '#core/layout'
 import { TextEditor } from '#core/text/editor'
 import { fontManager } from '#core/text/fonts'
@@ -227,6 +229,8 @@ export function createEditor(options?: EditorOptions) {
   }
 
   function releaseGraphResources() {
+    releaseFigPopulationWorker(_graph)
+    releaseOriginalFigArchive(_graph)
     clearLazyFigImportContext(_graph)
   }
 

--- a/packages/core/src/editor/create.ts
+++ b/packages/core/src/editor/create.ts
@@ -8,6 +8,7 @@ import { UndoManager } from '@open-pencil/scene-graph/undo'
 import type { SkiaRenderer } from '#core/canvas/renderer'
 import { prefetchFigmaSchema } from '#core/clipboard'
 import { IS_BROWSER } from '#core/constants'
+import { clearLazyFigImportContext } from '#core/kiwi/fig/lazy-import'
 import { setTextMeasurer } from '#core/layout'
 import { TextEditor } from '#core/text/editor'
 import { fontManager } from '#core/text/fonts'
@@ -123,7 +124,7 @@ export function createEditor(options?: EditorOptions) {
   const { runLayoutForNode } = createLayoutRunner(() => _graph)
   const { scheduleComponentSync } = createComponentSyncScheduler(() => _graph, requestRender)
 
-  const { subscribeToGraph } = createGraphEventSubscription({
+  const { subscribeToGraph, unsubscribeFromGraph } = createGraphEventSubscription({
     getGraph: () => _graph,
     getRenderers: () => _renderers,
     scheduleComponentSync,
@@ -220,6 +221,15 @@ export function createEditor(options?: EditorOptions) {
     requestRender()
   }
 
+  function dispose() {
+    stopFontResolutionEvents()
+    unsubscribeFromGraph()
+  }
+
+  function releaseGraphResources() {
+    clearLazyFigImportContext(_graph)
+  }
+
   return {
     get graph() {
       return _graph
@@ -247,7 +257,8 @@ export function createEditor(options?: EditorOptions) {
     removeCanvasRenderer,
     replaceGraph,
     subscribeToGraph,
-    dispose: stopFontResolutionEvents,
+    dispose,
+    releaseGraphResources,
 
     // Selection
     ...selection,

--- a/packages/core/src/editor/graph-events.ts
+++ b/packages/core/src/editor/graph-events.ts
@@ -104,5 +104,10 @@ export function createGraphEventSubscription(options: GraphEventOptions) {
     })
   }
 
-  return { subscribeToGraph }
+  function unsubscribeFromGraph() {
+    unbindGraphEvents?.()
+    unbindGraphEvents = null
+  }
+
+  return { subscribeToGraph, unsubscribeFromGraph }
 }

--- a/packages/core/src/io/formats/fig/export.ts
+++ b/packages/core/src/io/formats/fig/export.ts
@@ -31,6 +31,7 @@ import {
   makeCanvasNodeChange
 } from '#core/kiwi/fig/node-change/serialize'
 import { cloneSceneGraphForFigExport } from '#core/kiwi/fig/parse/transfer'
+import { originalFigArchive } from '#core/kiwi/fig/session/original-archive'
 
 const THUMBNAIL_1X1 = decodeBase64(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=='
@@ -445,8 +446,8 @@ export async function exportFigFile(
   pageId?: string,
   renderHeadlessThumbnail = false
 ): Promise<Uint8Array> {
-  // Lazy population synchronizes component trees and therefore mutates its graph. Saving must not
-  // rewrite the live editor document or restore component values over edits made by the user.
+  const originalArchive = await originalFigArchive(sourceGraph)
+  if (originalArchive) return originalArchive.slice()
   const graph = cloneSceneGraphForFigExport(sourceGraph)
   populateAllLazyFigImportRoots(graph)
   await initCodec()

--- a/packages/core/src/io/formats/fig/read.ts
+++ b/packages/core/src/io/formats/fig/read.ts
@@ -5,9 +5,13 @@ import type { SceneGraph } from '@open-pencil/scene-graph'
 import { IS_BROWSER } from '#core/constants'
 import { importNodeChanges } from '#core/kiwi/fig/import'
 import { deserializeSceneGraph } from '#core/kiwi/fig/parse/transfer'
-import { registerFigPopulationWorker } from '#core/kiwi/fig/population/client'
+import {
+  registerFigPopulationWorker,
+  registerOriginalArchiveRequest
+} from '#core/kiwi/fig/population/client'
 import { createFigSessionWorker } from '#core/kiwi/fig/session/client'
 import type { FigSessionOpenRequest, FigSessionResponse } from '#core/kiwi/fig/session/protocol'
+import { randomHex } from '#core/random'
 
 export interface ParseFigFileOptions {
   populate?: 'all' | 'first-page' | 'none'
@@ -61,6 +65,26 @@ function parseViaWorker(buffer: ArrayBuffer, options: ParseFigFileOptions): Prom
         if (options.populate === 'first-page') {
           cleanupAbort()
           registerFigPopulationWorker(graph, worker, channel.port1)
+          registerOriginalArchiveRequest(
+            graph,
+            () =>
+              new Promise<Uint8Array>((resolveArchive) => {
+                const requestId = randomHex()
+                const previous = channel.port1.onmessage
+                channel.port1.onmessage = (message: MessageEvent<FigSessionResponse>) => {
+                  if (
+                    message.data.type === 'original-archive-result' &&
+                    message.data.requestId === requestId
+                  ) {
+                    channel.port1.onmessage = previous
+                    resolveArchive(message.data.bytes)
+                    return
+                  }
+                  previous?.call(channel.port1, message)
+                }
+                channel.port1.postMessage({ type: 'original-archive', requestId })
+              })
+          )
         } else {
           cleanupAbort()
           channel.port1.close()
@@ -81,13 +105,16 @@ function parseViaWorker(buffer: ArrayBuffer, options: ParseFigFileOptions): Prom
       worker.terminate()
       reject(new Error(err.message || 'Worker failed to parse .fig file'))
     }
+    const workerBuffer = buffer.slice(0)
+    const archiveBuffer = buffer.slice(0)
     const request: FigSessionOpenRequest = {
       type: 'open',
-      buffer,
+      originalBuffer: workerBuffer,
+      archiveBuffer,
       options: { populate: options.populate },
       port: channel.port2
     }
-    worker.postMessage(request, [buffer, channel.port2])
+    worker.postMessage(request, [workerBuffer, archiveBuffer, channel.port2])
   })
 }
 

--- a/packages/core/src/io/formats/fig/read.ts
+++ b/packages/core/src/io/formats/fig/read.ts
@@ -130,7 +130,9 @@ export async function parseFigFile(
     } catch (error) {
       if (options.signal?.aborted) throw error
       console.warn('Worker parsing failed, falling back to main thread:', error)
-      return parseFigFileSync(copy, options)
+      const graph = parseFigFileSync(copy, options)
+      registerOriginalArchiveRequest(graph, async () => new Uint8Array(copy.slice(0)))
+      return graph
     }
   }
   options.signal?.throwIfAborted()

--- a/packages/core/src/io/formats/fig/read.ts
+++ b/packages/core/src/io/formats/fig/read.ts
@@ -38,6 +38,7 @@ function parseViaWorker(buffer: ArrayBuffer, options: ParseFigFileOptions): Prom
     options.signal?.throwIfAborted()
     const worker = createFigSessionWorker()
     const channel = new MessageChannel()
+    const pendingArchives = new Map<string, (bytes: Uint8Array) => void>()
     const abort = () => {
       channel.port1.postMessage({ type: 'dispose' })
       channel.port1.close()
@@ -48,6 +49,13 @@ function parseViaWorker(buffer: ArrayBuffer, options: ParseFigFileOptions): Prom
     const cleanupAbort = () => options.signal?.removeEventListener('abort', abort)
 
     channel.port1.onmessage = (e: MessageEvent<FigSessionResponse>) => {
+      if (e.data.type === 'original-archive-result') {
+        const resolveArchive = pendingArchives.get(e.data.requestId)
+        if (!resolveArchive) return
+        pendingArchives.delete(e.data.requestId)
+        resolveArchive(e.data.bytes)
+        return
+      }
       if (e.data.type === 'page-manifest') {
         options.onPages?.(e.data.pages)
         return
@@ -70,18 +78,7 @@ function parseViaWorker(buffer: ArrayBuffer, options: ParseFigFileOptions): Prom
             () =>
               new Promise<Uint8Array>((resolveArchive) => {
                 const requestId = randomHex()
-                const previous = channel.port1.onmessage
-                channel.port1.onmessage = (message: MessageEvent<FigSessionResponse>) => {
-                  if (
-                    message.data.type === 'original-archive-result' &&
-                    message.data.requestId === requestId
-                  ) {
-                    channel.port1.onmessage = previous
-                    resolveArchive(message.data.bytes)
-                    return
-                  }
-                  previous?.call(channel.port1, message)
-                }
+                pendingArchives.set(requestId, resolveArchive)
                 channel.port1.postMessage({ type: 'original-archive', requestId })
               })
           )

--- a/packages/core/src/io/formats/fig/read.ts
+++ b/packages/core/src/io/formats/fig/read.ts
@@ -4,10 +4,10 @@ import type { SceneGraph } from '@open-pencil/scene-graph'
 
 import { IS_BROWSER } from '#core/constants'
 import { importNodeChanges } from '#core/kiwi/fig/import'
-import { createFigParseWorker } from '#core/kiwi/fig/parse/client'
 import { deserializeSceneGraph } from '#core/kiwi/fig/parse/transfer'
-import type { SerializedSceneGraph } from '#core/kiwi/fig/parse/transfer'
 import { registerFigPopulationWorker } from '#core/kiwi/fig/population/client'
+import { createFigSessionWorker } from '#core/kiwi/fig/session/client'
+import type { FigSessionOpenRequest, FigSessionResponse } from '#core/kiwi/fig/session/protocol'
 
 export interface ParseFigFileOptions {
   populate?: 'all' | 'first-page' | 'none'
@@ -29,37 +29,29 @@ function parseFigFileSync(buffer: ArrayBuffer, options: ParseFigFileOptions = {}
   return graph
 }
 
-interface WorkerGraphResult {
-  type: 'graph'
-  graph?: SerializedSceneGraph
-  error?: string
-}
-
-interface WorkerPageManifestResult {
-  type: 'page-manifest'
-  pages: FigPageManifestEntry[]
-}
-
-type WorkerParseResult = WorkerGraphResult | WorkerPageManifestResult
-
 function parseViaWorker(buffer: ArrayBuffer, options: ParseFigFileOptions): Promise<SceneGraph> {
   return new Promise((resolve, reject) => {
     options.signal?.throwIfAborted()
-    const worker = createFigParseWorker()
+    const worker = createFigSessionWorker()
+    const channel = new MessageChannel()
     const abort = () => {
+      channel.port1.postMessage({ type: 'dispose' })
+      channel.port1.close()
       worker.terminate()
       reject(new DOMException('Aborted', 'AbortError'))
     }
     options.signal?.addEventListener('abort', abort, { once: true })
     const cleanupAbort = () => options.signal?.removeEventListener('abort', abort)
 
-    worker.onmessage = (e: MessageEvent<WorkerParseResult>) => {
+    channel.port1.onmessage = (e: MessageEvent<FigSessionResponse>) => {
       if (e.data.type === 'page-manifest') {
         options.onPages?.(e.data.pages)
         return
       }
+      if (e.data.type !== 'graph') return
       if (e.data.error || !e.data.graph) {
         cleanupAbort()
+        channel.port1.close()
         worker.terminate()
         reject(new Error(e.data.error ?? 'Worker failed to parse .fig file'))
         return
@@ -68,28 +60,34 @@ function parseViaWorker(buffer: ArrayBuffer, options: ParseFigFileOptions): Prom
         const graph = deserializeSceneGraph(e.data.graph)
         if (options.populate === 'first-page') {
           cleanupAbort()
-          worker.onmessage = null
-          worker.onerror = null
-          registerFigPopulationWorker(graph, worker)
+          registerFigPopulationWorker(graph, worker, channel.port1)
         } else {
           cleanupAbort()
+          channel.port1.close()
           worker.terminate()
         }
         resolve(graph)
       } catch (error) {
         cleanupAbort()
+        channel.port1.close()
         worker.terminate()
         reject(error instanceof Error ? error : new Error(String(error)))
       }
     }
-
+    channel.port1.start()
     worker.onerror = (err) => {
       cleanupAbort()
+      channel.port1.close()
       worker.terminate()
       reject(new Error(err.message || 'Worker failed to parse .fig file'))
     }
-
-    worker.postMessage({ buffer, options: { populate: options.populate } }, [buffer])
+    const request: FigSessionOpenRequest = {
+      type: 'open',
+      buffer,
+      options: { populate: options.populate },
+      port: channel.port2
+    }
+    worker.postMessage(request, [buffer, channel.port2])
   })
 }
 

--- a/packages/core/src/kiwi/fig/import.ts
+++ b/packages/core/src/kiwi/fig/import.ts
@@ -566,7 +566,7 @@ export function importNodeChanges(
   remapInstanceSwapPropertyValues(graph, guidToNodeId)
   applyVariantPropSpecs(graph)
 
-  const firstPageId = graph.getPages()[0]?.id
+  const firstPageId = graph.getPages().find((page) => !page.internalOnly)?.id
   const componentPageIds =
     options.populate === 'first-page' ? componentPageIdsForLazyPopulation(graph) : new Set<string>()
   const activeRootIds =

--- a/packages/core/src/kiwi/fig/lazy-import.ts
+++ b/packages/core/src/kiwi/fig/lazy-import.ts
@@ -19,6 +19,10 @@ export function getLazyFigImportContext(graph: SceneGraph): LazyFigImportContext
   return lazyFigImportContexts.get(graph)
 }
 
+export function clearLazyFigImportContext(graph: SceneGraph): void {
+  lazyFigImportContexts.delete(graph)
+}
+
 function applyPopulation(
   graph: SceneGraph,
   context: LazyFigImportContext,

--- a/packages/core/src/kiwi/fig/parse/worker.ts
+++ b/packages/core/src/kiwi/fig/parse/worker.ts
@@ -8,17 +8,13 @@ import {
   serializedSceneGraphTransferList
 } from '#core/kiwi/fig/parse/transfer'
 import { buildFigPopulationDelta, installFigMutationJournal } from '#core/kiwi/fig/population/delta'
+import type { FigSessionPopulateRequest } from '#core/kiwi/fig/session/protocol'
 
 interface WorkerParseRequest {
   buffer: ArrayBuffer
   options?: { populate?: 'all' | 'first-page' }
 }
-interface PopulateRequest {
-  type: 'populate'
-  requestId: string
-  baseRevision: number
-  pageId: string
-}
+type PopulateRequest = FigSessionPopulateRequest
 type WorkerRequest = ArrayBuffer | WorkerParseRequest | PopulateRequest
 type WorkerPostMessage = (message: unknown, transfer: Transferable[]) => void
 const postWorkerMessage: WorkerPostMessage = (message, transfer) => {

--- a/packages/core/src/kiwi/fig/population/client.ts
+++ b/packages/core/src/kiwi/fig/population/client.ts
@@ -18,6 +18,12 @@ type WorkerResult = PopulationResult | { type: 'population-error'; error: string
 const MAX_FIG_POPULATION_WORKER_NODES = 200_000
 const FIG_POPULATION_WORKER_TIMEOUT_MS = 30_000
 const populationWorkers = new WeakMap<SceneGraph, FigPopulationWorker>()
+interface OriginalArchiveRequest {
+  request: () => Promise<Uint8Array>
+  valid: boolean
+  unbind: () => void
+}
+const originalArchiveRequests = new WeakMap<SceneGraph, OriginalArchiveRequest>()
 
 export interface FigPopulationWorkerTelemetry {
   event: 'registered' | 'populate' | 'fallback' | 'stale' | 'terminated'
@@ -59,6 +65,36 @@ export function canUseFigPopulationWorker(graph: SceneGraph): boolean {
     populationWorkers.has(graph) &&
     getLazyFigImportContext(graph) !== undefined
   )
+}
+
+export function registerOriginalArchiveRequest(
+  graph: SceneGraph,
+  request: () => Promise<Uint8Array>
+): void {
+  const entry: OriginalArchiveRequest = { request, valid: true, unbind: () => undefined }
+  const invalidate = () => {
+    if (!graph.isApplyingLayout) entry.valid = false
+  }
+  entry.unbind = graph.onNodeEvents({
+    created: invalidate,
+    updated: invalidate,
+    deleted: invalidate,
+    reparented: invalidate,
+    reordered: invalidate
+  })
+  originalArchiveRequests.set(graph, entry)
+}
+
+export async function requestOriginalArchive(graph: SceneGraph): Promise<Uint8Array | null> {
+  const entry = originalArchiveRequests.get(graph)
+  return entry?.valid ? entry.request() : null
+}
+
+export function releaseFigPopulationWorker(graph: SceneGraph): void {
+  populationWorkers.get(graph)?.terminate()
+  populationWorkers.delete(graph)
+  originalArchiveRequests.get(graph)?.unbind()
+  originalArchiveRequests.delete(graph)
 }
 
 export interface FigPopulationWorker {

--- a/packages/core/src/kiwi/fig/population/client.ts
+++ b/packages/core/src/kiwi/fig/population/client.ts
@@ -1,6 +1,7 @@
 import type { SceneGraph } from '@open-pencil/scene-graph'
 
 import { getLazyFigImportContext } from '#core/kiwi/fig/lazy-import'
+import type { FigSessionResponse } from '#core/kiwi/fig/session/protocol'
 import { randomHex } from '#core/random'
 
 import { applyFigPopulationDelta, type FigPopulationDelta } from './delta'
@@ -33,13 +34,17 @@ function emitTelemetry(detail: FigPopulationWorkerTelemetry): void {
   globalThis.dispatchEvent(new CustomEvent('openpencil:fig-population-worker', { detail }))
 }
 
-export function registerFigPopulationWorker(graph: SceneGraph, worker: Worker): void {
+export function registerFigPopulationWorker(
+  graph: SceneGraph,
+  worker: Worker,
+  port?: MessagePort
+): void {
   if (graph.nodes.size > MAX_FIG_POPULATION_WORKER_NODES) {
     emitTelemetry({ event: 'fallback', reason: 'oversized' })
     worker.terminate()
     return
   }
-  const client = createPopulationWorkerClient(graph, worker)
+  const client = createPopulationWorkerClient(graph, worker, port)
   populationWorkers.set(graph, client)
   emitTelemetry({ event: 'registered' })
 }
@@ -66,7 +71,11 @@ export function createFigPopulationWorker(graph: SceneGraph): FigPopulationWorke
   return populationWorkers.get(graph) ?? null
 }
 
-function createPopulationWorkerClient(graph: SceneGraph, worker: Worker): FigPopulationWorker {
+function createPopulationWorkerClient(
+  graph: SceneGraph,
+  worker: Worker,
+  port?: MessagePort
+): FigPopulationWorker {
   const pending = new Map<
     string,
     {
@@ -115,8 +124,7 @@ function createPopulationWorkerClient(graph: SceneGraph, worker: Worker): FigPop
     reparented: invalidate,
     reordered: invalidate
   })
-  worker.onmessage = (event: MessageEvent<WorkerResult>) => {
-    const result = event.data
+  const receive = (result: WorkerResult) => {
     if (result.type === 'population-error') return fail()
     const request = pending.get(result.requestId)
     if (!request) return
@@ -150,6 +158,13 @@ function createPopulationWorkerClient(graph: SceneGraph, worker: Worker): FigPop
       deleted: result.delta.deleted.length
     })
   }
+  if (port) {
+    port.onmessage = (event: MessageEvent<FigSessionResponse>) =>
+      receive(event.data as WorkerResult)
+    port.start()
+  } else {
+    worker.onmessage = (event: MessageEvent<WorkerResult>) => receive(event.data)
+  }
   worker.onerror = () => fail()
   return {
     populate(pageId, signal) {
@@ -175,13 +190,16 @@ function createPopulationWorkerClient(graph: SceneGraph, worker: Worker): FigPop
           startedAt: performance.now(),
           timeout
         })
-        worker.postMessage({ type: 'populate', requestId, baseRevision, pageId }, [])
+        if (port) port.postMessage({ type: 'populate', requestId, baseRevision, pageId })
+        else worker.postMessage({ type: 'populate', requestId, baseRevision, pageId }, [])
       })
     },
     terminate() {
       if (disposed) return
       disposed = true
       emitTelemetry({ event: 'terminated' })
+      port?.postMessage({ type: 'dispose' })
+      port?.close()
       fail(false)
     }
   }

--- a/packages/core/src/kiwi/fig/population/client.ts
+++ b/packages/core/src/kiwi/fig/population/client.ts
@@ -47,7 +47,7 @@ export function registerFigPopulationWorker(
 ): void {
   if (graph.nodes.size > MAX_FIG_POPULATION_WORKER_NODES) {
     emitTelemetry({ event: 'fallback', reason: 'oversized' })
-    worker.terminate()
+    if (!port) worker.terminate()
     return
   }
   const client = createPopulationWorkerClient(graph, worker, port)

--- a/packages/core/src/kiwi/fig/population/client.ts
+++ b/packages/core/src/kiwi/fig/population/client.ts
@@ -47,7 +47,11 @@ export function registerFigPopulationWorker(
 ): void {
   if (graph.nodes.size > MAX_FIG_POPULATION_WORKER_NODES) {
     emitTelemetry({ event: 'fallback', reason: 'oversized' })
-    if (!port) worker.terminate()
+    if (!port) {
+      worker.terminate()
+      return
+    }
+    populationWorkers.set(graph, createDisposalOnlyWorker(worker, port))
     return
   }
   const client = createPopulationWorkerClient(graph, worker, port)
@@ -87,7 +91,12 @@ export function registerOriginalArchiveRequest(
 
 export async function requestOriginalArchive(graph: SceneGraph): Promise<Uint8Array | null> {
   const entry = originalArchiveRequests.get(graph)
-  return entry?.valid ? entry.request() : null
+  if (!entry?.valid) return null
+  const archive = await entry.request()
+  return originalArchiveRequests.get(graph)?.valid === true &&
+    originalArchiveRequests.get(graph) === entry
+    ? archive
+    : null
 }
 
 export function releaseFigPopulationWorker(graph: SceneGraph): void {
@@ -100,6 +109,21 @@ export function releaseFigPopulationWorker(graph: SceneGraph): void {
 export interface FigPopulationWorker {
   populate: (pageId: string, signal?: AbortSignal) => Promise<boolean | null>
   terminate: () => void
+}
+
+function createDisposalOnlyWorker(worker: Worker, port: MessagePort): FigPopulationWorker {
+  let disposed = false
+  return {
+    populate: () => Promise.resolve(null),
+    terminate() {
+      if (disposed) return
+      disposed = true
+      emitTelemetry({ event: 'terminated' })
+      port.postMessage({ type: 'dispose' })
+      port.close()
+      worker.terminate()
+    }
+  }
 }
 
 export function createFigPopulationWorker(graph: SceneGraph): FigPopulationWorker | null {

--- a/packages/core/src/kiwi/fig/session/client.ts
+++ b/packages/core/src/kiwi/fig/session/client.ts
@@ -1,0 +1,3 @@
+export function createFigSessionWorker(): Worker {
+  return new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' })
+}

--- a/packages/core/src/kiwi/fig/session/client.ts
+++ b/packages/core/src/kiwi/fig/session/client.ts
@@ -1,3 +1,4 @@
 export function createFigSessionWorker(): Worker {
+  if (typeof Worker === 'undefined') throw new Error('FIG session workers are unavailable')
   return new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' })
 }

--- a/packages/core/src/kiwi/fig/session/original-archive.ts
+++ b/packages/core/src/kiwi/fig/session/original-archive.ts
@@ -1,0 +1,20 @@
+import type { SceneGraph } from '@open-pencil/scene-graph'
+
+import { requestOriginalArchive } from '#core/kiwi/fig/population/client'
+
+const originalFigArchives = new WeakMap<SceneGraph, () => Promise<Uint8Array>>()
+
+export function registerOriginalFigArchive(
+  graph: SceneGraph,
+  requestArchive: () => Promise<Uint8Array>
+): void {
+  originalFigArchives.set(graph, requestArchive)
+}
+
+export async function originalFigArchive(graph: SceneGraph): Promise<Uint8Array | null> {
+  return (await originalFigArchives.get(graph)?.()) ?? (await requestOriginalArchive(graph))
+}
+
+export function releaseOriginalFigArchive(graph: SceneGraph): void {
+  originalFigArchives.delete(graph)
+}

--- a/packages/core/src/kiwi/fig/session/protocol.ts
+++ b/packages/core/src/kiwi/fig/session/protocol.ts
@@ -1,0 +1,45 @@
+import type { FigPageManifestEntry } from '@open-pencil/kiwi/fig'
+
+import type { SerializedSceneGraph } from '#core/kiwi/fig/parse/transfer'
+import type { FigPopulationDelta } from '#core/kiwi/fig/population/delta'
+
+export interface FigSessionOpenRequest {
+  type: 'open'
+  buffer: ArrayBuffer
+  options?: { populate?: 'all' | 'first-page' | 'none' }
+  port: MessagePort
+}
+
+export interface FigSessionPopulateRequest {
+  type: 'populate'
+  requestId: string
+  baseRevision: number
+  pageId: string
+}
+
+export interface FigSessionCancelRequest {
+  type: 'cancel'
+  requestId?: string
+}
+
+export interface FigSessionDisposeRequest {
+  type: 'dispose'
+}
+
+export type FigSessionRequest =
+  | FigSessionPopulateRequest
+  | FigSessionCancelRequest
+  | FigSessionDisposeRequest
+
+export type FigSessionResponse =
+  | { type: 'page-manifest'; pages: FigPageManifestEntry[] }
+  | { type: 'graph'; graph?: SerializedSceneGraph; error?: string }
+  | {
+      type: 'population-result'
+      requestId: string
+      baseRevision: number
+      populated: boolean
+      delta: FigPopulationDelta
+    }
+  | { type: 'population-error'; requestId?: string; error: string }
+  | { type: 'disposed' }

--- a/packages/core/src/kiwi/fig/session/protocol.ts
+++ b/packages/core/src/kiwi/fig/session/protocol.ts
@@ -1,5 +1,6 @@
 import type { FigPageManifestEntry } from '@open-pencil/kiwi/fig'
 
+import type { FigImportOptions } from '#core/kiwi/fig/import'
 import type { SerializedSceneGraph } from '#core/kiwi/fig/parse/transfer'
 import type { FigPopulationDelta } from '#core/kiwi/fig/population/delta'
 
@@ -7,7 +8,7 @@ export interface FigSessionOpenRequest {
   type: 'open'
   originalBuffer: ArrayBuffer
   archiveBuffer: ArrayBuffer
-  options?: { populate?: 'all' | 'first-page' | 'none' }
+  options?: FigImportOptions
   port: MessagePort
 }
 

--- a/packages/core/src/kiwi/fig/session/protocol.ts
+++ b/packages/core/src/kiwi/fig/session/protocol.ts
@@ -5,7 +5,8 @@ import type { FigPopulationDelta } from '#core/kiwi/fig/population/delta'
 
 export interface FigSessionOpenRequest {
   type: 'open'
-  buffer: ArrayBuffer
+  originalBuffer: ArrayBuffer
+  archiveBuffer: ArrayBuffer
   options?: { populate?: 'all' | 'first-page' | 'none' }
   port: MessagePort
 }
@@ -15,6 +16,11 @@ export interface FigSessionPopulateRequest {
   requestId: string
   baseRevision: number
   pageId: string
+}
+
+export interface FigSessionOriginalArchiveRequest {
+  type: 'original-archive'
+  requestId: string
 }
 
 export interface FigSessionCancelRequest {
@@ -28,6 +34,7 @@ export interface FigSessionDisposeRequest {
 
 export type FigSessionRequest =
   | FigSessionPopulateRequest
+  | FigSessionOriginalArchiveRequest
   | FigSessionCancelRequest
   | FigSessionDisposeRequest
 
@@ -42,4 +49,5 @@ export type FigSessionResponse =
       delta: FigPopulationDelta
     }
   | { type: 'population-error'; requestId?: string; error: string }
+  | { type: 'original-archive-result'; requestId: string; bytes: Uint8Array }
   | { type: 'disposed' }

--- a/packages/core/src/kiwi/fig/session/worker.ts
+++ b/packages/core/src/kiwi/fig/session/worker.ts
@@ -12,6 +12,7 @@ import type {
 } from '#core/kiwi/fig/session/protocol'
 
 let graph: SceneGraph | undefined
+let originalArchive: Uint8Array | undefined
 let port: MessagePort | undefined
 
 function respond(message: FigSessionResponse): void {
@@ -39,8 +40,17 @@ function populate(request: Extract<FigSessionRequest, { type: 'populate' }>): vo
 
 function handleRequest(request: FigSessionRequest): void {
   try {
+    if (request.type === 'original-archive') {
+      if (!originalArchive) throw new Error('FIG session has no original archive')
+      const bytes = originalArchive.slice()
+      port?.postMessage({ type: 'original-archive-result', requestId: request.requestId, bytes }, [
+        bytes.buffer
+      ])
+      return
+    }
     if (request.type === 'dispose') {
       graph = undefined
+      originalArchive = undefined
       respond({ type: 'disposed' })
       port?.close()
       port = undefined
@@ -63,9 +73,10 @@ self.onmessage = (event: MessageEvent<FigSessionOpenRequest>) => {
   port = request.port
   port.onmessage = (message: MessageEvent<FigSessionRequest>) => handleRequest(message.data)
   port.start()
+  originalArchive = new Uint8Array(request.archiveBuffer)
   try {
     const { nodeChanges, blobs, images, figKiwiVersion, figSchemaDeflated } = parseFigBuffer(
-      request.buffer,
+      request.originalBuffer,
       (pages) => respond({ type: 'page-manifest', pages })
     )
     const parsedGraph = importNodeChanges(nodeChanges, blobs, new Map(images), request.options)

--- a/packages/core/src/kiwi/fig/session/worker.ts
+++ b/packages/core/src/kiwi/fig/session/worker.ts
@@ -1,0 +1,79 @@
+import { parseFigBuffer } from '@open-pencil/fig'
+import type { SceneGraph } from '@open-pencil/scene-graph'
+
+import { importNodeChanges } from '#core/kiwi/fig/import'
+import { getLazyFigImportContext, populateLazyFigImportRoots } from '#core/kiwi/fig/lazy-import'
+import { serializeSceneGraph } from '#core/kiwi/fig/parse/transfer'
+import { buildFigPopulationDelta, installFigMutationJournal } from '#core/kiwi/fig/population/delta'
+import type {
+  FigSessionOpenRequest,
+  FigSessionRequest,
+  FigSessionResponse
+} from '#core/kiwi/fig/session/protocol'
+
+let graph: SceneGraph | undefined
+let port: MessagePort | undefined
+
+function respond(message: FigSessionResponse): void {
+  port?.postMessage(message)
+}
+
+function populate(request: Extract<FigSessionRequest, { type: 'populate' }>): void {
+  if (!graph) throw new Error('FIG session has no retained graph')
+  const journal = installFigMutationJournal(graph)
+  try {
+    const populated = populateLazyFigImportRoots(graph, [request.pageId])
+    const context = getLazyFigImportContext(graph)
+    if (!context) throw new Error('FIG session has no lazy import context')
+    respond({
+      type: 'population-result',
+      requestId: request.requestId,
+      baseRevision: request.baseRevision,
+      populated,
+      delta: buildFigPopulationDelta(graph, journal, context.populatedRootIds)
+    })
+  } finally {
+    journal.stop()
+  }
+}
+
+function handleRequest(request: FigSessionRequest): void {
+  try {
+    if (request.type === 'dispose') {
+      graph = undefined
+      respond({ type: 'disposed' })
+      port?.close()
+      port = undefined
+      self.close()
+      return
+    }
+    if (request.type === 'cancel') return
+    populate(request)
+  } catch (error) {
+    respond({
+      type: 'population-error',
+      requestId: request.type === 'populate' ? request.requestId : undefined,
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+self.onmessage = (event: MessageEvent<FigSessionOpenRequest>) => {
+  const request = event.data
+  port = request.port
+  port.onmessage = (message: MessageEvent<FigSessionRequest>) => handleRequest(message.data)
+  port.start()
+  try {
+    const { nodeChanges, blobs, images, figKiwiVersion, figSchemaDeflated } = parseFigBuffer(
+      request.buffer,
+      (pages) => respond({ type: 'page-manifest', pages })
+    )
+    const parsedGraph = importNodeChanges(nodeChanges, blobs, new Map(images), request.options)
+    parsedGraph.figKiwiVersion = figKiwiVersion
+    parsedGraph.figSchemaDeflated = figSchemaDeflated
+    graph = request.options?.populate === 'first-page' ? parsedGraph : undefined
+    respond({ type: 'graph', graph: serializeSceneGraph(parsedGraph) })
+  } catch (error) {
+    respond({ type: 'graph', error: error instanceof Error ? error.message : String(error) })
+  }
+}

--- a/src/app/editor/session/modules.ts
+++ b/src/app/editor/session/modules.ts
@@ -87,6 +87,7 @@ export function createEditorStoreModules(
     setPlannedFilePath: documentIO.setPlannedFilePath,
     startWatchingCurrentFile: documentIO.startWatchingCurrentFile,
     dispose: () => {
+      editor.releaseGraphResources()
       editor.dispose()
       editor.clearPageViewports()
       documentIO.disposeDocumentIO()

--- a/src/app/tabs/index.ts
+++ b/src/app/tabs/index.ts
@@ -157,6 +157,7 @@ export async function closeTab(tabId: string): Promise<void> {
   const wasActive = activeTabId.value === tabId
   coverThumbnailListeners.get(closingTab.store)?.()
   coverThumbnailListeners.delete(closingTab.store)
+  closingTab.store.preparationController.dispose()
   await closingTab.store.persistRecoveryNow()
   closingTab.store.dispose()
   tabsRef.value = tabsRef.value.filter((t) => t.id !== tabId)

--- a/tests/engine/io/fig/import/session-ownership.test.ts
+++ b/tests/engine/io/fig/import/session-ownership.test.ts
@@ -54,7 +54,7 @@ describe('FIG session ownership', () => {
     expect(portClosed).toBe(true)
   })
 
-  test('rejects session worker construction outside Worker runtimes', async () => {
+  test.serial('rejects session worker construction outside Worker runtimes', async () => {
     const originalWorker = globalThis.Worker
     Reflect.deleteProperty(globalThis, 'Worker')
     try {

--- a/tests/engine/io/fig/import/session-ownership.test.ts
+++ b/tests/engine/io/fig/import/session-ownership.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test'
+
+import { SceneGraph } from '@open-pencil/scene-graph'
+
+import {
+  registerFigPopulationWorker,
+  registerOriginalArchiveRequest,
+  releaseFigPopulationWorker,
+  requestOriginalArchive
+} from '#core/kiwi/fig/population/client'
+
+describe('FIG session ownership', () => {
+  test('discards an archive response when the graph changes while it is pending', async () => {
+    const graph = new SceneGraph()
+    let resolveArchive: ((bytes: Uint8Array) => void) | null = null
+    registerOriginalArchiveRequest(
+      graph,
+      () =>
+        new Promise<Uint8Array>((resolve) => {
+          resolveArchive = resolve
+        })
+    )
+    const request = requestOriginalArchive(graph)
+
+    graph.updateNode(graph.rootId, { name: 'Edited' })
+    resolveArchive?.(new Uint8Array([1, 2, 3]))
+
+    await expect(request).resolves.toBeNull()
+    releaseFigPopulationWorker(graph)
+  })
+
+  test('retains and releases oversized session workers', () => {
+    const graph = new SceneGraph()
+    const page = graph.getPages()[0]
+    for (let index = 0; index < 200_001; index++) {
+      graph.nodes.set(`oversized-${index}`, {
+        ...page,
+        id: `oversized-${index}`,
+        childIds: []
+      })
+    }
+    let workerTerminated = false
+    let portClosed = false
+    const worker = { terminate: () => (workerTerminated = true) } as Worker
+    const port = {
+      postMessage: () => undefined,
+      close: () => (portClosed = true)
+    } as MessagePort
+
+    registerFigPopulationWorker(graph, worker, port)
+    releaseFigPopulationWorker(graph)
+
+    expect(workerTerminated).toBe(true)
+    expect(portClosed).toBe(true)
+  })
+
+  test('rejects session worker construction outside Worker runtimes', async () => {
+    const originalWorker = globalThis.Worker
+    Reflect.deleteProperty(globalThis, 'Worker')
+    try {
+      const { createFigSessionWorker } = await import('#core/kiwi/fig/session/client')
+      expect(() => createFigSessionWorker()).toThrow('unavailable')
+    } finally {
+      globalThis.Worker = originalWorker
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Cancels large FIG opens before recovery persistence and explicitly releases graph listeners and FIG resources on tab disposal.
- Isolates each lazy FIG document behind a dedicated worker and `MessageChannel` session with explicit cancellation and disposal.
- Keeps unchanged original archives available through both worker sessions and main-thread parse fallback.
- Returns unchanged archives byte-for-byte without running the full exporter.
- Selects the first visible imported page when internal-only canvases precede user pages.

## Stack

Base: `feat/atomic-document-preparation`

This PR relies on tab-local cancellation and atomic document/page preparation. It remains a stacked draft until the base PR is ready and merged.

## Correctness boundary

Dependency-limited SceneGraph materialization was removed after real shadcn visual-oracle testing found blank pages, collapsed instance dimensions, lost component-property labels, and incorrectly bounded shadows. This PR is intentionally a safe worker/session and unchanged-save foundation; it does not claim reduced initial SceneGraph materialization or the earlier 10-second Relume open result.

## Visual acceptance

Fixture: `shadcn Figma kit (Community).fig`, compared against exact Figma nodes.

| Target | Result |
|---|---:|
| Foundations page roots | 6 |
| Example → Blocks page roots | 19 |
| Effects | 2080×664 |
| Block/Create Account | 414×390 |
| `_Component Note` | 320×257 |

The combined preparation + typography + FIG stack preserves Create Account labels and widths, the complete note/avatar content, and graduated shadow bounds. The merged visual-oracle tooling provides manifest-driven Figma/OpenPencil captures, structural assertions, diffs, heatmaps, and metrics.

## Relume safety profile

Fixture: `Relume Figma Kit (v3.7) (Community).fig`

- Close during document preparation: ~21 ms; open rejects with `AbortError`.
- Unchanged save: 38,065,522 byte output, byte-identical to input.
- SHA-256: `0af1313108e594093f1457e6ce1e773252bbb6569439954f91c0029267ecccf3`.
- Unchanged save including SHA-256 verification: ~2.6 s.
- Worker graph-transfer out-of-memory fallback retains the original archive and remains exact-save capable.

## Validation

- `bun run check`
- `bun run test:dupes` — 0 clones
- FIG parse/export and cancellation tests
- Preparation and page-switch tests
- shadcn browser visual acceptance against Figma
- Relume open cancellation and byte-identical unchanged save

## Explicitly deferred

- Dependency-limited page materialization
- Worker-exclusive raw `NodeChange` ownership
- Edited raw `NodeChange` patch export
- Structural patch journals
- OPFS spill/cache

Edited documents continue using the existing complete exporter. This PR does not silently produce partial FIG archives.

The retained original archive is an exact unchanged-save optimization, not a lossless edited-save model. Source-backed `NodeChange` patch export is tracked in #610.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FIG import and export reliability, including preservation of original archives where applicable.
  * Internal-only pages are now skipped when selecting the initial page for loading.
  * Closing an editor tab now cancels in-progress preparation work.

* **Performance & Stability**
  * Improved background processing and cleanup when opening, closing, or disposing editors.
  * Added safer cancellation and resource release for large FIG documents.
  * Improved handling of FIG sessions when original document data is requested during editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
