### PR TITLE
perf(automation): scope post-mutation layout recompute to affected nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Defer JSX generation and syntax highlighting until the Code panel is active, keeping large canvas selections responsive. (#500)
 - Index Figma clipboard children once during import instead of rescanning every pasted node, keeping large flat pastes linear. (#500)
 - Reduce peak memory during `.fig` export by sharing immutable binary resources with the isolated export graph.
+- Scope the MCP/automation bridge's post-mutation layout recompute to the affected node(s) and their ancestors instead of the entire current page, preventing large documents from stalling automation calls past the RPC timeout.
 
 ### Fixed
 

--- a/packages/core/src/editor/create.ts
+++ b/packages/core/src/editor/create.ts
@@ -229,6 +229,7 @@ export function createEditor(options?: EditorOptions) {
     },
     undo,
     state,
+    runLayoutForNode,
 
     // Graph reads
     ...graphReads,

--- a/src/app/automation/bridge/tool-handlers.ts
+++ b/src/app/automation/bridge/tool-handlers.ts
@@ -4,6 +4,7 @@ import { computeAllLayouts } from '@open-pencil/core/layout'
 import { ALL_TOOLS, registerComponentCatalog } from '@open-pencil/core/tools'
 import type { JSONObject } from '@open-pencil/scene-graph/primitives'
 
+import { captureParentIds, collectLayoutScopeIds } from '@/app/automation/bridge/tool-handlers.utils'
 import type { AutomationTarget } from '@/app/automation/bridge/target'
 import { ensureGraphFonts } from '@/app/editor/fonts'
 import { useLibraryService } from '@/app/libraries'
@@ -23,7 +24,7 @@ export function createAutomationToolHandler(makeFigma: FigmaFactory) {
       y: toolArgs.y as number | undefined
     })
     await ensureGraphFonts(store.graph, [result.id], store.renderer)
-    computeAllLayouts(store.graph, target.pageId)
+    store.runLayoutForNode(result.id)
     store.requestRender()
     store.flashNodes([result.id])
     return {
@@ -48,14 +49,25 @@ export function createAutomationToolHandler(makeFigma: FigmaFactory) {
     libraryService.bindEditor(store)
     registerComponentCatalog(store.graph, libraryService)
     const figma = makeFigma(store, target.pageId)
+    const priorParentIds = def.mutates ? captureParentIds(store.graph, toolArgs) : []
     const result = await def.execute(figma, toolArgs)
 
     if (def.mutates) {
       const pageNode = store.graph.getNode(figma.currentPageId)
       if (pageNode) await ensureGraphFonts(store.graph, pageNode.childIds, store.renderer)
-      computeAllLayouts(store.graph, figma.currentPageId)
+      const resultIds = extractNodeIds(result)
+      const scopeIds = collectLayoutScopeIds(toolArgs, priorParentIds, resultIds)
+      if (scopeIds.length > 0) {
+        for (const id of scopeIds) store.runLayoutForNode(id)
+      } else {
+        // No recognizable node-id argument (e.g. batch_update's JSON-encoded
+        // operations, or arrange with no ids meaning "all top-level
+        // children") — fall back to the unscoped recompute rather than risk
+        // leaving an affected frame stale.
+        computeAllLayouts(store.graph, figma.currentPageId)
+      }
       store.requestRender()
-      store.flashNodes(extractNodeIds(result))
+      store.flashNodes(resultIds)
     }
     return { ok: true, result }
   }

--- a/src/app/automation/bridge/tool-handlers.utils.ts
+++ b/src/app/automation/bridge/tool-handlers.utils.ts
@@ -1,0 +1,53 @@
+import type { SceneGraph } from '@open-pencil/scene-graph'
+
+/**
+ * Argument keys that conventionally name a target canvas node across the
+ * MCP tool registry (single id, list of ids, or the variable-binding tools'
+ * `node_id`). Used to scope the post-mutation layout recompute to just the
+ * affected subtree(s) instead of the whole page.
+ */
+const NODE_ID_ARG_KEYS = ['id', 'node_id'] as const
+const NODE_ID_LIST_ARG_KEY = 'ids'
+
+function readArgNodeIds(args: Record<string, unknown>): string[] {
+  const ids: string[] = []
+  for (const key of NODE_ID_ARG_KEYS) {
+    const value = args[key]
+    if (typeof value === 'string') ids.push(value)
+  }
+  const list = args[NODE_ID_LIST_ARG_KEY]
+  if (Array.isArray(list)) {
+    for (const id of list) if (typeof id === 'string') ids.push(id)
+  }
+  return ids
+}
+
+/**
+ * Snapshots the parent of each node a tool call targets, before the call
+ * runs. A tool can delete, merge, or reparent its target nodes, leaving
+ * nothing at that id to walk up from afterward — the old parent is what
+ * still needs its layout (e.g. HUG sizing) recomputed in that case.
+ */
+export function captureParentIds(graph: SceneGraph, args: Record<string, unknown>): string[] {
+  const parentIds: string[] = []
+  for (const id of readArgNodeIds(args)) {
+    const parentId = graph.getNode(id)?.parentId
+    if (parentId) parentIds.push(parentId)
+  }
+  return parentIds
+}
+
+/**
+ * Node ids whose layout subtree should be recomputed after a mutating tool
+ * call, combining the call's own targets, their pre-call parents (see
+ * captureParentIds), and any ids the tool reports in its result (e.g. newly
+ * created nodes). Deduplicated; ids that no longer exist are harmless — the
+ * caller's per-id recompute already no-ops on a missing node.
+ */
+export function collectLayoutScopeIds(
+  args: Record<string, unknown>,
+  priorParentIds: string[],
+  resultIds: string[]
+): string[] {
+  return [...new Set([...readArgNodeIds(args), ...priorParentIds, ...resultIds])]
+}


### PR DESCRIPTION
### Summary

MCP/automation clients occasionally see the bridge's RPC calls time out (`RPC timeout (20s)` in `packages/mcp/src/browser-rpc.ts`), then recover on their own a moment later with no process restart. Traced this to `src/app/automation/bridge/tool-handlers.ts`: every mutating tool call ends with `computeAllLayouts(store.graph, figma.currentPageId)` — an unscoped recompute of *every* auto-layout frame on the entire current page, regardless of how small the actual edit was. On a page with real content (a component library's "Components" page, for example), this cost scales with total page complexity per tool call, not with the size of the edit, and can occasionally run long enough on the browser's main thread to blow past the bridge's timeout. Nothing crashes — the browser is just still finishing that pass — which is exactly why it "self-heals."

### What changed

- The interactive editor already solves this for its own actions via `runLayoutForNode` in `packages/core/src/editor/layout-runner.ts`: recompute just the mutated node's subtree, then walk up its ancestor chain recomputing any auto-layout ancestor. That helper existed on the internal editor context but wasn't part of the public `Editor`/`EditorStore` return value, so the automation bridge had no way to use it — exposed it (`packages/core/src/editor/create.ts`).
- `tool-handlers.ts` now scopes its post-mutation recompute using `runLayoutForNode` instead of `computeAllLayouts` over the whole page. Candidate node ids come from (new file `tool-handlers.utils.ts`):
  - the tool call's own `id`/`ids`/`node_id` arguments (covers the large majority of mutating tools),
  - each of those ids' *pre-call* parent (captured before `execute` runs, since a tool can delete, merge, or reparent its target — leaving nothing at that id to walk up from afterward, while the old parent still needs to reflow),
  - the ids a tool reports in its result (e.g. a newly created node — walking its ancestors naturally reflows whatever parent it landed in).
- If none of those produce a candidate (e.g. `batch_update`'s JSON-encoded `operations` string, or `arrange` called with no `ids`, which means "all top-level children" — genuinely page-wide), it falls back to the previous unscoped `computeAllLayouts`, so no case is left under-recomputed.
- `handleToolRender` (the `render` tool) had the same unscoped call; replaced with `store.runLayoutForNode(result.id)` directly, since it always has exactly the new tree's root id.

### AI assistance

Models: Claude Sonnet 5 (Claude Code). Root-caused by tracing the MCP bridge's actual RPC path end-to-end (`packages/mcp/src/browser-rpc.ts` → `src/app/automation/bridge/*`) after observing the 20s-timeout behavior described by a user; verified live against a running desktop app instance covering single-id, creation, deletion, and multi-id (`combine_as_variants`) mutation paths before opening this PR.

### Validation

- [x] `bun run check` — ran the individual steps this change touches directly (`lint`, `tsgo --noEmit`, `check:vue`, `build:packages`, `test:dupes`) clean; did not run the full composite `check` script since several unrelated steps (`check:secrets`, `check:audit`) fail identically on a pristine `origin/master` checkout in this sandbox.
- [x] `bun test tests/engine/figma tests/engine/editor`: 359/359 pass (covers the `Editor`/`create.ts` change). `bun test tests/engine/mcp tests/engine/tools`: same 13 pre-existing failures as pristine `origin/master` in this sandbox (a live local MCP server was already bound to the port the test suite needs — an environment collision, not a regression).
- [x] Tests added or updated, or not needed because: `src/app/**` (the desktop/browser app layer this change lives in) has no existing unit-test harness — it's covered only by Playwright E2E, which has no automation-bridge coverage today either. Rather than invent new test infrastructure for one file, verified behavior live against a running OpenPencil instance instead: (1) a single-id `set_layout` padding change on a HUG frame resized correctly, (2) creating a child into a HUG parent grew the parent, (3) deleting that child shrank the parent back down (exercises the pre-captured-parent path), (4) `combine_as_variants` followed by `set_layout` on a variant child resized correctly (the multi-id + result-id paths). A follow-up PR could add a lightweight test harness for `src/app/automation/bridge` if maintainers want it as a condition of merge.
- [x] CHANGELOG.md updated (Unreleased → Performance).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved automation and MCP layout updates by recalculating only affected canvas nodes and their ancestors.
  * Reduced unnecessary full-page layout recomputation after targeted changes.
  * Preserved full-page recalculation when affected nodes cannot be identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->