### PR TITLE
fix(clipboard): harden rich clipboard fallbacks

### DIFF
--- a/src/app/editor/clipboard/paste-to-replace.ts
+++ b/src/app/editor/clipboard/paste-to-replace.ts
@@ -10,12 +10,14 @@ async function readClipboardHTML() {
   if (isTauri()) {
     try {
       const text = await readTauriClipboardText()
-      if (text && isDesignClipboardHTML(text)) return text
+      if (isDesignClipboardHTML(text ?? '')) return text
+      const memory = getInMemoryClipboardHTML(text ?? '')
+      return memory && isDesignClipboardHTML(memory) ? memory : null
     } catch (error) {
       console.warn('Tauri clipboard read failed', error)
+      const memory = getInMemoryClipboardHTML()
+      return memory && isDesignClipboardHTML(memory) ? memory : null
     }
-    const memory = getInMemoryClipboardHTML()
-    return memory && isDesignClipboardHTML(memory) ? memory : null
   }
 
   if (

--- a/src/app/editor/clipboard/system/browser.ts
+++ b/src/app/editor/clipboard/system/browser.ts
@@ -4,7 +4,11 @@ import type { Vector } from '@open-pencil/scene-graph/primitives'
 
 import type { EditorStore } from '@/app/editor/active-store'
 import { isDesignClipboardHTML } from '@/app/editor/clipboard/html'
-import { getInMemoryClipboardHTML, setInMemoryClipboardHTML } from '@/app/editor/clipboard/memory'
+import {
+  clearInMemoryClipboardHTML,
+  getInMemoryClipboardHTML,
+  setInMemoryClipboardHTML
+} from '@/app/editor/clipboard/memory'
 import { createClipboardTransfer } from '@/app/editor/clipboard/system/transfer'
 import type {
   BrowserClipboardIO,
@@ -83,6 +87,7 @@ async function copySelection(store: EditorStore, io: BrowserClipboardIO): Promis
     }
     if (!payload.html && !payload.plainText) return false
     if (payload.html) setInMemoryClipboardHTML(payload.html, payload.plainText)
+    else clearInMemoryClipboardHTML()
 
     return await io.write(payload)
   } catch (error) {

--- a/src/app/editor/clipboard/system/tauri.ts
+++ b/src/app/editor/clipboard/system/tauri.ts
@@ -2,7 +2,11 @@ import type { Vector } from '@open-pencil/scene-graph/primitives'
 
 import type { EditorStore } from '@/app/editor/active-store'
 import { isDesignClipboardHTML } from '@/app/editor/clipboard/html'
-import { getInMemoryClipboardHTML, setInMemoryClipboardHTML } from '@/app/editor/clipboard/memory'
+import {
+  clearInMemoryClipboardHTML,
+  getInMemoryClipboardHTML,
+  setInMemoryClipboardHTML
+} from '@/app/editor/clipboard/memory'
 import { createClipboardTransfer } from '@/app/editor/clipboard/system/transfer'
 import type { SystemClipboard } from '@/app/editor/clipboard/system/types'
 import {
@@ -25,6 +29,7 @@ async function copySelection(store: EditorStore): Promise<boolean> {
       setInMemoryClipboardHTML(html, plainText)
     } else {
       await writeTauriClipboardText(plainText)
+      clearInMemoryClipboardHTML()
     }
     return true
   } catch (error) {

--- a/src/app/shell/keyboard/clipboard.ts
+++ b/src/app/shell/keyboard/clipboard.ts
@@ -27,6 +27,13 @@ export async function copyAndDeleteSelection(
   }
 }
 
+function selectionMatches(store: EditorStore, selectedIds: Set<string>): boolean {
+  return (
+    selectedIds.size === store.state.selectedIds.size &&
+    [...selectedIds].every((id) => store.state.selectedIds.has(id))
+  )
+}
+
 export function bindEditorClipboard(store: EditorStore) {
   useEventListener(window, 'copy', (e: ClipboardEvent) => {
     if (isEditing(e) || hasDocumentTextSelection()) return
@@ -42,8 +49,9 @@ export function bindEditorClipboard(store: EditorStore) {
     if (isEditing(e)) return
     e.preventDefault()
     if (isTauri()) {
+      const selectedIds = new Set(store.state.selectedIds)
       void tauriSystemClipboard.copy(store).then((copied) => {
-        if (copied) store.deleteSelected()
+        if (copied && selectionMatches(store, selectedIds)) store.deleteSelected()
         return undefined
       })
       return


### PR DESCRIPTION
## Summary

- Require complete OpenPencil and Figma clipboard markers with linear scans
- Distinguish unavailable clipboard reads from successful non-HTML reads
- Bind cached Tauri rich HTML to its matching plain-text fallback
- Preserve nodes when selection changes during an asynchronous cut
- Reduce the clipboard adapter public surface and share payload types

## Validation

- `bun run lint:structure`
- `bunx tsgo --noEmit`
- `bun tools/type-shapes/src/index.ts`
- `bun test tests/engine/app/clipboard/html.test.ts tests/engine/app/clipboard/memory.test.ts tests/engine/app/clipboard/keyboard.test.ts`
- `bunx playwright test tests/e2e/clipboard/browser-rich-copy.spec.ts --project=openpencil`
- `bun run test:dupes`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added system clipboard support for copying and pasting design content in browser and desktop environments.
  - Preserves design formatting when supported and falls back to cached clipboard content when necessary.
  - Added safer handling for clipboard failures and unsupported content.

- **Bug Fixes**
  - Cut operations now delete selected content only after a successful copy and unchanged selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->