### PR TITLE
fix(fig): open legacy raw fig-kiwi files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 
 ### Fixed
 
+- Open legacy raw `.fig` files that store the Kiwi document and thumbnail without a ZIP wrapper. (#582)
 - Preserve a frame's auto-layout HUG sizing mode when converting it into a component with `create_component`, so later padding changes still resize the component as expected.
 - Run `openpencil import` on Node so the npm-installed CLI no longer fails with `Bun is not defined`. (#575)
 - Isolate browser-development MCP servers behind worktree-aware Portless WebSocket routes and per-runtime socket/discovery paths, preventing concurrent worktrees from competing for port 7600 or the global MCP socket.

--- a/packages/fig/src/archive.ts
+++ b/packages/fig/src/archive.ts
@@ -2,8 +2,10 @@ import { unzipSync, zipSync, type Unzipped, type Zippable } from 'fflate'
 
 import type { FigPageManifestEntry } from '@open-pencil/kiwi/fig'
 import type { NodeChange } from '@open-pencil/kiwi/fig/codec'
-import { buildFigKiwi } from '@open-pencil/kiwi/fig/container'
+import { buildFigKiwi, parseFigKiwiChunks } from '@open-pencil/kiwi/fig/container'
 import { decodeFigKiwiCanvas } from '@open-pencil/kiwi/fig/parse'
+
+import { hasPNGSignature } from './thumbnail'
 
 export interface FigImageEntry {
   name: string
@@ -51,12 +53,27 @@ function isCanonicalCanvasEntry(name: string): boolean {
   return name === 'canvas.fig' || name === 'canvas'
 }
 
-/** Parse a complete zipped `.fig` file into its Figma protocol payload and binary resources. */
+function parseRawFigKiwi(
+  bytes: Uint8Array,
+  onPages?: (pages: FigPageManifestEntry[]) => void
+): FigParseResult | null {
+  const chunks = parseFigKiwiChunks(bytes)
+  if (!chunks) return null
+
+  const decoded = decodeFigKiwiCanvas(bytes, onPages)
+  const thumbnailPNG = chunks.slice(2).find(hasPNGSignature) ?? null
+  return { ...decoded, images: [], thumbnailPNG, metaJSON: null }
+}
+
+/** Parse a complete zipped or legacy raw `.fig` file into its protocol payload and resources. */
 export function parseFigBuffer(
   buffer: ArrayBuffer,
   onPages?: (pages: FigPageManifestEntry[]) => void
 ): FigParseResult {
   const bytes = new Uint8Array(buffer)
+  const raw = parseRawFigKiwi(bytes, onPages)
+  if (raw) return raw
+
   const canvasArchive = unzipSync(bytes, { filter: ({ name }) => isCanonicalCanvasEntry(name) })
   let canvasData = findCanvasData(canvasArchive)
   let archive: Unzipped

--- a/packages/fig/src/thumbnail.ts
+++ b/packages/fig/src/thumbnail.ts
@@ -45,7 +45,7 @@ function boundedLimit(value: number | undefined, fallback: number): number {
   return Number.isFinite(value) && value && value > 0 ? value : fallback
 }
 
-function hasPNGSignature(bytes: Uint8Array): boolean {
+export function hasPNGSignature(bytes: Uint8Array): boolean {
   return PNG_SIGNATURE.every((byte, index) => bytes[index] === byte)
 }
 

--- a/packages/fig/tests/index.test.ts
+++ b/packages/fig/tests/index.test.ts
@@ -18,6 +18,16 @@ import {
   writeFigContainer
 } from '../src/index'
 
+const PNG_SIGNATURE = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+function appendChunk(container: Uint8Array, chunk: Uint8Array): Uint8Array {
+  const bytes = new Uint8Array(container.byteLength + 4 + chunk.byteLength)
+  bytes.set(container)
+  new DataView(bytes.buffer).setUint32(container.byteLength, chunk.byteLength, true)
+  bytes.set(chunk, container.byteLength + 4)
+  return bytes
+}
+
 describe('@open-pencil/fig package API', () => {
   beforeAll(async () => {
     await initCodec()
@@ -66,6 +76,34 @@ describe('@open-pencil/fig package API', () => {
     expect(parsed.images).toEqual([['hash', new Uint8Array([9, 8, 7])]])
     expect(parsed.thumbnailPNG).toEqual(thumbnailPNG)
     expect(parsed.metaJSON).toBe(metaJSON)
+  })
+
+  it('parses legacy raw fig-kiwi files and preserves their thumbnail chunk', () => {
+    const container = writeFigContainer(
+      {
+        schemaDeflated: deflateSync(getSchemaBytes()),
+        dataRaw: encodeMessage(
+          createNodeChangesMessage(0, 0, [
+            {
+              guid: { sessionID: 0, localID: 0 },
+              type: 'DOCUMENT',
+              phase: 'CREATED',
+              name: 'Document'
+            }
+          ])
+        )
+      },
+      { version: 1 }
+    )
+    const thumbnailPNG = new Uint8Array([...PNG_SIGNATURE, 1, 2, 3])
+    const bytes = appendChunk(container, thumbnailPNG)
+    const parsed = parseFigBuffer(bytes.buffer as ArrayBuffer)
+
+    expect(parsed.nodeChanges).toHaveLength(1)
+    expect(parsed.figKiwiVersion).toBe(1)
+    expect(parsed.images).toEqual([])
+    expect(parsed.thumbnailPNG).toEqual(thumbnailPNG)
+    expect(parsed.metaJSON).toBeNull()
   })
 
   it('rejects invalid fig-kiwi containers', () => {


### PR DESCRIPTION
### Summary

Open legacy raw/unwrapped `.fig` files that contain a `fig-kiwi` container directly instead of a ZIP archive.

Two real-world examples from the BC Government Design System repository reproduce the issue:

- https://github.com/bcgov/figma/blob/master/versions/bcgov_2020-06-15.fig
- https://github.com/bcgov/figma/blob/master/versions/bcgov_v2_2020-06-18.fig

Both are version 1 containers with schema, document, and PNG thumbnail chunks. They previously failed with `invalid zip data`.

Fixes #582.

### What changed

- Detect a raw `fig-kiwi` container before attempting ZIP extraction.
- Decode the existing document payload and preserve a trailing PNG thumbnail chunk.
- Return empty archive-only resources for raw files.
- Add a synthetic regression test and update the changelog.

### AI assistance

Models: OpenAI Codex (GPT-5)

### Validation

- [x] `bun run check`
- [x] Tests added and updated: `bun --filter @open-pencil/fig test` (54 passed).
- [x] Both public files above decode successfully (85 and 111 node changes; 9,216-byte and 8,364-byte thumbnails preserved).
- [x] `CHANGELOG.md` updated.

Additional baseline notes:

- `bun run test:unit`: 2,866 passed, 1 skipped, and 3 unrelated failures. The same failures reproduce on a clean `origin/master`: one path-text font-gate assertion and two `gold-preview` component-property GUID round-trip assertions.
- `bun run test`: currently stops during collection because Playwright includes the WebdriverIO specs under `tests/e2e/native` (`describe is not defined`). A non-native browser run reached 75 passing tests before unrelated existing visual and Tauri-mock failures; it was then stopped.
