### PR TITLE
fix(fig): tolerate incomplete component property assignments

### DIFF
--- a/packages/fig/src/instance-overrides/component-props/apply.ts
+++ b/packages/fig/src/instance-overrides/component-props/apply.ts
@@ -62,7 +62,10 @@ function applySwapProp(
   const swapId =
     propTextCharacters(val) ?? (val.guidValue ? guidToString(val.guidValue) : undefined)
   const newCompId = swapId ? ctx.guidToNodeId.get(swapId) : undefined
-  if (!newCompId) return
+  const currentCompId = ctx.graph.getNode(childId)?.componentId
+  if (currentCompId && getComponentRoot(ctx, currentCompId) === getComponentRoot(ctx, newCompId)) {
+    return
+  }
   applyPatchAndMark(
     ctx,
     childId,

--- a/packages/fig/src/instance-overrides/component-props/apply.ts
+++ b/packages/fig/src/instance-overrides/component-props/apply.ts
@@ -62,6 +62,7 @@ function applySwapProp(
   const swapId =
     propTextCharacters(val) ?? (val.guidValue ? guidToString(val.guidValue) : undefined)
   const newCompId = swapId ? ctx.guidToNodeId.get(swapId) : undefined
+  if (!newCompId) return
   const currentCompId = ctx.graph.getNode(childId)?.componentId
   if (currentCompId && getComponentRoot(ctx, currentCompId) === getComponentRoot(ctx, newCompId)) {
     return

--- a/packages/fig/src/instance-overrides/component-props/values.ts
+++ b/packages/fig/src/instance-overrides/component-props/values.ts
@@ -17,7 +17,8 @@ export function propTextCharacters(value: ComponentPropValue): string | undefine
   return value.textValue?.characters ?? value.textDataValue?.characters
 }
 
-function isEmptyPropValue(v: ComponentPropValue): boolean {
+function isEmptyPropValue(v: ComponentPropValue | undefined): boolean {
+  if (!v) return true
   return (
     v.boolValue === undefined &&
     v.textValue === undefined &&
@@ -31,8 +32,9 @@ function resolveAssignmentValue(
   assignment: ComponentPropAssignment,
   key: string,
   resolveDefaults: boolean
-): ComponentPropValue {
-  if (!isEmptyPropValue(assignment.value)) return assignment.value
+): ComponentPropValue | undefined {
+  const value = assignment.value
+  if (value && !isEmptyPropValue(value)) return value
 
   const variableValue = assignment.varValue?.value
   if (variableValue?.symbolIdValue?.guid) return { guidValue: variableValue.symbolIdValue.guid }
@@ -53,7 +55,8 @@ export function assignmentsToValueMap(
   for (const assignment of assignments) {
     if (!assignment.defID) continue
     const key = guidToString(assignment.defID)
-    valueByDef.set(key, resolveAssignmentValue(ctx, assignment, key, resolveDefaults))
+    const value = resolveAssignmentValue(ctx, assignment, key, resolveDefaults)
+    if (value) valueByDef.set(key, value)
   }
   return valueByDef
 }

--- a/packages/fig/src/instance-overrides/types.ts
+++ b/packages/fig/src/instance-overrides/types.ts
@@ -38,7 +38,7 @@ export type ComponentPropValue = {
 
 export interface ComponentPropAssignment {
   defID?: GUID
-  value: ComponentPropValue
+  value?: ComponentPropValue
   varValue?: {
     value?: {
       boolValue?: boolean


### PR DESCRIPTION
Fixes #613

### Summary

- Tolerate Figma component-property assignments whose value field is absent.
- Ignore unresolved empty assignments instead of crashing during `.fig` import.
- Skip no-op instance swaps when the target resolves to the instance's current component root, preventing recursive repopulation.

### Validation

- `@open-pencil/fig` instance-override tests: 30 passed.
- Structure lint passed.
- `git diff --check` passed.

The fix is intentionally limited to the import override pass; no package release is being prepared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved component swap handling to avoid unnecessary swaps when the requested component is already applied.
  - Corrected handling of missing or empty component property values.
  - Prevented empty assignments from overwriting existing property values.
  - Improved consistency when applying component properties, helping preserve existing values when no replacement is provided.
  - Ensured component updates are applied only when an actual change is needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->