### PR TITLE
fix(text): preserve committed WebView input

### DIFF
--- a/packages/vue/src/canvas/text-edit/editing.ts
+++ b/packages/vue/src/canvas/text-edit/editing.ts
@@ -88,7 +88,7 @@ export function createTextCompositionHandlers({
     resetBlink()
   }
 
-  function onInput() {
+  function onInput(event: InputEvent) {
     const el = textareaRef.value
     if (!el) return
 
@@ -97,7 +97,7 @@ export function createTextCompositionHandlers({
       return
     }
 
-    const text = el.value
+    const text = el.value || event.data || ''
     if (!text) return
     if (
       skipCommittedInput &&


### PR DESCRIPTION
Fixes #607

## Summary

- Preserve committed text when WebKit clears the hidden textarea before the input handler runs.
- Keep normal textarea input handling unchanged when the value is available.

## Validation

- `bun test tests/engine/text/editor.test.ts`
- `bun run build:native-test`
- `git diff --check`

Native WebDriver execution is currently blocked by the local Tauri harness startup, before the text-editing test reaches the fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text editing to correctly process committed input when the editor’s text area is empty.
  * Enhanced handling of input events for more reliable text entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->