### PR TITLE
feat(fig): record source-backed graph edits

### DIFF
--- a/packages/fig/src/index.ts
+++ b/packages/fig/src/index.ts
@@ -18,6 +18,8 @@ export {
   staleFigmaRawFields
 } from './source-metadata'
 
+export * from './source-session/journal'
+
 import {
   FIG_KIWI_DEFAULT_VERSION,
   buildFigKiwi,

--- a/packages/fig/src/source-session/journal.ts
+++ b/packages/fig/src/source-session/journal.ts
@@ -1,0 +1,90 @@
+import type { SceneGraph, SceneNode } from '@open-pencil/scene-graph'
+
+export type FigSourceEdit =
+  | { type: 'set-property'; sourceId: string; fields: Partial<SceneNode> }
+  | { type: 'create-node'; nodeId: string; parentSourceId: string | null; index: number }
+  | { type: 'delete-node'; sourceId: string }
+  | {
+      type: 'reparent-node'
+      sourceId: string
+      parentSourceId: string | null
+      index: number
+    }
+  | { type: 'reorder-node'; sourceId: string; parentSourceId: string | null; index: number }
+
+export interface FigSourceEditJournal {
+  readonly edits: readonly FigSourceEdit[]
+  stop(): void
+}
+
+function sourceId(node: SceneNode | undefined): string | null {
+  return node?.source.id ?? null
+}
+
+function sourceIdsAtStart(graph: SceneGraph): Map<string, string> {
+  return new Map(
+    [...graph.getAllNodes()].flatMap((node) => {
+      const id = sourceId(node)
+      return id ? [[node.id, id] as [string, string]] : []
+    })
+  )
+}
+
+function childIndex(graph: SceneGraph, nodeId: string, parentId: string | null): number {
+  if (!parentId) return -1
+  return graph.getNode(parentId)?.childIds.indexOf(nodeId) ?? -1
+}
+
+export function installFigSourceEditJournal(graph: SceneGraph): FigSourceEditJournal {
+  const edits: FigSourceEdit[] = []
+  const sourceIds = sourceIdsAtStart(graph)
+
+  const stopCreated = graph.onNodeEvents({
+    created: (node) => {
+      edits.push({
+        type: 'create-node',
+        nodeId: node.id,
+        parentSourceId: sourceId(graph.getNode(node.parentId ?? '')),
+        index: childIndex(graph, node.id, node.parentId)
+      })
+    },
+    updated: (id, fields) => {
+      const node = graph.getNode(id)
+      const idFromSource = sourceIds.get(id) ?? sourceId(node)
+      if (idFromSource) edits.push({ type: 'set-property', sourceId: idFromSource, fields })
+    },
+    deleted: (id) => {
+      edits.push({ type: 'delete-node', sourceId: sourceIds.get(id) ?? id })
+    },
+    reparented: (id, _oldParentId, newParentId) => {
+      const node = graph.getNode(id)
+      const idFromSource = sourceId(node)
+      if (idFromSource) {
+        edits.push({
+          type: 'reparent-node',
+          sourceId: sourceIds.get(id) ?? idFromSource,
+          parentSourceId: sourceIds.get(newParentId) ?? sourceId(graph.getNode(newParentId)),
+          index: childIndex(graph, id, newParentId)
+        })
+      }
+    },
+    reordered: (id, parentId, index) => {
+      const node = graph.getNode(id)
+      const idFromSource = sourceIds.get(id) ?? sourceId(node)
+      if (idFromSource) {
+        edits.push({
+          type: 'reorder-node',
+          sourceId: sourceIds.get(id) ?? idFromSource,
+          parentSourceId: sourceIds.get(parentId) ?? sourceId(graph.getNode(parentId)),
+          index
+        })
+      }
+    }
+  })
+  return {
+    edits,
+    stop() {
+      stopCreated()
+    }
+  }
+}

--- a/packages/fig/tests/source-session-journal.test.ts
+++ b/packages/fig/tests/source-session-journal.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test'
+
+import { SceneGraph } from '@open-pencil/scene-graph'
+
+import { installFigSourceEditJournal } from '../src/source-session/journal'
+
+describe('FIG source edit journal', () => {
+  test('records source-backed property and structural edits', () => {
+    const graph = new SceneGraph()
+    const page = graph.getPages()[0]
+    const first = graph.createNode('FRAME', page.id, { name: 'First' })
+    const second = graph.createNode('FRAME', page.id, { name: 'Second' })
+    first.source.id = 'source-first'
+    second.source.id = 'source-second'
+
+    const journal = installFigSourceEditJournal(graph)
+    graph.updateNode(first.id, { name: 'Updated' })
+    graph.reorderChild(first.id, page.id, 1)
+    graph.reparentNode(second.id, first.id)
+    journal.stop()
+
+    expect(journal.edits).toContainEqual({
+      type: 'set-property',
+      sourceId: 'source-first',
+      fields: expect.objectContaining({ name: 'Updated' })
+    })
+    expect(journal.edits).toContainEqual({
+      type: 'reorder-node',
+      sourceId: 'source-first',
+      parentSourceId: null,
+      index: 1
+    })
+    expect(journal.edits).toContainEqual({
+      type: 'reparent-node',
+      sourceId: 'source-second',
+      parentSourceId: 'source-first',
+      index: 0
+    })
+  })
+
+  test('records created and deleted source nodes', () => {
+    const graph = new SceneGraph()
+    const page = graph.getPages()[0]
+    const parent = graph.createNode('FRAME', page.id, { name: 'Parent' })
+    parent.source.id = 'source-parent'
+    const journal = installFigSourceEditJournal(graph)
+    const child = graph.createNode('RECTANGLE', parent.id, { name: 'Child' })
+    child.source.id = 'source-child'
+    graph.deleteNode(child.id)
+    journal.stop()
+
+    expect(journal.edits).toContainEqual(
+      expect.objectContaining({ type: 'create-node', nodeId: child.id })
+    )
+    expect(journal.edits).toContainEqual({ type: 'delete-node', sourceId: child.id })
+  })
+})


### PR DESCRIPTION
## Summary

- Add a format-neutral source-edit journal for FIG-backed SceneGraph documents.
- Record source-backed property, creation, deletion, reparenting, and reorder edits.
- Preserve source identities for nodes that are removed after import.
- Add focused tests for the journal contract.

This is the first incremental slice toward source-backed FIG patch export tracked in #610. It records the edit vocabulary without changing export behavior yet.

## Validation

- `bun run build:packages`
- `bun run lint:structure`
- `bun run check:arch`
- `bun run test:dupes`
- `bun test packages/fig/tests/source-session-journal.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a source-edit journal that records property changes, node creation and deletion, reparenting, and reordering.
  * Exposed the journaling API through the package’s public interface.
  * Recorded edits include source identifiers and child positions where applicable.

* **Tests**
  * Added coverage for property and structural source-edit tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->