### PR TITLE
refactor(scene-graph): model instance overrides structurally

### DIFF
--- a/packages/core/src/clipboard/openpencil.ts
+++ b/packages/core/src/clipboard/openpencil.ts
@@ -1,8 +1,11 @@
 import { deflateSync, inflateSync } from 'fflate'
 
 import {
+  createInstanceOverrideState,
   deserializeInstanceOverrideState,
   serializeInstanceOverrideState,
+  setInstanceOverride,
+  type InstanceOverrideState,
   type SceneGraph,
   type SceneNode,
   type SerializedInstanceOverrideState
@@ -12,6 +15,7 @@ import type { JSONObject } from '@open-pencil/scene-graph/primitives'
 import { decodeBase64, encodeBase64 } from '#core/bytes'
 
 interface SerializedClipboardNode extends JSONObject {
+  overrides?: Record<string, unknown>
   instanceOverrides?: SerializedInstanceOverrideState
   textPicture?: string | Uint8Array
   children?: SerializedClipboardNode[]
@@ -55,12 +59,32 @@ export function parseOpenPencilClipboard(html: string): OpenPencilClipboardData 
   return null
 }
 
+function legacyInstanceOverrides(
+  nodeId: string,
+  overrides: Record<string, unknown> | undefined
+): InstanceOverrideState {
+  const state = createInstanceOverrideState()
+  for (const [key, value] of Object.entries(overrides ?? {})) {
+    const separator = key.indexOf(':')
+    if (separator === -1) {
+      setInstanceOverride(state, nodeId, nodeId, key, value)
+    } else {
+      setInstanceOverride(state, nodeId, key.slice(0, separator), key.slice(separator + 1), value)
+    }
+  }
+  return state
+}
+
 function restoreNodeData(nodes: SerializedClipboardNode[]): ClipboardNode[] {
   return nodes.map((node) => {
-    const { children, instanceOverrides, textPicture, ...rest } = node
+    const { children, instanceOverrides, overrides, textPicture, ...rest } = node
+    const nodeId = typeof rest.id === 'string' ? rest.id : ''
+    const overrideState = instanceOverrides
+      ? deserializeInstanceOverrideState(instanceOverrides)
+      : legacyInstanceOverrides(nodeId, overrides)
     return {
       ...rest,
-      instanceOverrides: deserializeInstanceOverrideState(instanceOverrides),
+      instanceOverrides: overrideState,
       textPicture: typeof textPicture === 'string' ? decodeBase64(textPicture) : textPicture,
       ...(children ? { children: restoreNodeData(children) } : {})
     } as ClipboardNode

--- a/packages/core/src/clipboard/openpencil.ts
+++ b/packages/core/src/clipboard/openpencil.ts
@@ -65,7 +65,7 @@ function legacyInstanceOverrides(
 ): InstanceOverrideState {
   const state = createInstanceOverrideState()
   for (const [key, value] of Object.entries(overrides ?? {})) {
-    const separator = key.indexOf(':')
+    const separator = key.lastIndexOf(':')
     if (separator === -1) {
       setInstanceOverride(state, nodeId, nodeId, key, value)
     } else {

--- a/packages/core/src/clipboard/openpencil.ts
+++ b/packages/core/src/clipboard/openpencil.ts
@@ -1,11 +1,23 @@
 import { deflateSync, inflateSync } from 'fflate'
 
-import type { SceneGraph, SceneNode } from '@open-pencil/scene-graph'
+import {
+  deserializeInstanceOverrideState,
+  serializeInstanceOverrideState,
+  type SceneGraph,
+  type SceneNode,
+  type SerializedInstanceOverrideState
+} from '@open-pencil/scene-graph'
 import type { JSONObject } from '@open-pencil/scene-graph/primitives'
 
 import { decodeBase64, encodeBase64 } from '#core/bytes'
 
-// --- Internal copy/paste (OpenPencil ↔ OpenPencil) ---
+interface SerializedClipboardNode extends JSONObject {
+  instanceOverrides?: SerializedInstanceOverrideState
+  textPicture?: string | Uint8Array
+  children?: SerializedClipboardNode[]
+}
+
+type ClipboardNode = SceneNode & { children?: ClipboardNode[] }
 
 export interface OpenPencilClipboardData {
   nodes: Array<SceneNode & { children?: SceneNode[] }>
@@ -26,7 +38,7 @@ export function parseOpenPencilClipboard(html: string): OpenPencilClipboardData 
     }
     const decoded = JSON.parse(new TextDecoder().decode(bytes))
     if (decoded.format === 'openpencil/v1' && Array.isArray(decoded.nodes)) {
-      restoreTextPictures(decoded.nodes)
+      const nodes = restoreNodeData(decoded.nodes as SerializedClipboardNode[])
       const images = new Map<string, Uint8Array>()
       if (decoded.images && typeof decoded.images === 'object') {
         for (const [hash, b64] of Object.entries(decoded.images)) {
@@ -35,7 +47,7 @@ export function parseOpenPencilClipboard(html: string): OpenPencilClipboardData 
           }
         }
       }
-      return { nodes: decoded.nodes, images }
+      return { nodes, images }
     }
   } catch (e) {
     console.warn('Failed to parse OpenPencil clipboard data:', e)
@@ -43,15 +55,16 @@ export function parseOpenPencilClipboard(html: string): OpenPencilClipboardData 
   return null
 }
 
-function restoreTextPictures(nodes: JSONObject[]): void {
-  for (const node of nodes) {
-    if (typeof node.textPicture === 'string') {
-      node.textPicture = decodeBase64(node.textPicture)
-    }
-    if (Array.isArray(node.children)) {
-      restoreTextPictures(node.children)
-    }
-  }
+function restoreNodeData(nodes: SerializedClipboardNode[]): ClipboardNode[] {
+  return nodes.map((node) => {
+    const { children, instanceOverrides, textPicture, ...rest } = node
+    return {
+      ...rest,
+      instanceOverrides: deserializeInstanceOverrideState(instanceOverrides),
+      textPicture: typeof textPicture === 'string' ? decodeBase64(textPicture) : textPicture,
+      ...(children ? { children: restoreNodeData(children) } : {})
+    } as ClipboardNode
+  })
 }
 
 export type TextPictureBuilder = (node: SceneNode) => Uint8Array | null
@@ -98,7 +111,10 @@ function collectNodeTree(
 ): JSONObject[] {
   return nodes.map((node) => {
     const children = graph.getChildren(node.id)
-    const serialized: Record<string, unknown> = { ...node }
+    const serialized: Record<string, unknown> = {
+      ...node,
+      instanceOverrides: serializeInstanceOverrideState(node.instanceOverrides)
+    }
 
     if (node.type === 'TEXT' && node.text && textPictureBuilder) {
       const pic = node.textPicture ?? textPictureBuilder(node)

--- a/packages/core/src/design-jsx/renderer.ts
+++ b/packages/core/src/design-jsx/renderer.ts
@@ -1,11 +1,11 @@
 import {
   setInstanceOverride,
+  type Color,
   type ComponentPropertyDefinition,
   type NodeType,
   type SceneGraph,
   type SceneNode
 } from '@open-pencil/scene-graph'
-import type { Color } from '@open-pencil/scene-graph/primitives'
 
 import { parseColor } from '#core/color'
 import type { RenderOptions } from '#core/design-jsx/types'

--- a/packages/core/src/design-jsx/renderer.ts
+++ b/packages/core/src/design-jsx/renderer.ts
@@ -453,7 +453,7 @@ function applyInstanceOverrides(
   }
   walk(instance.id)
 
-  const overrides = new Map<string, unknown>()
+  let mutated = false
   for (const [key, value] of entries) {
     const sep = key.indexOf(':')
     if (sep === -1) continue
@@ -463,8 +463,9 @@ function applyInstanceOverrides(
     if (!child || !(prop in child)) continue
     graph.updateNode(child.id, { [prop]: value } as Partial<SceneNode>)
     setInstanceOverride(instance.instanceOverrides, instance.id, child.id, prop, value)
+    mutated = true
   }
-  if (overrides.size > 0) {
+  if (mutated) {
     graph.updateNode(instance.id, { instanceOverrides: instance.instanceOverrides })
   }
 }

--- a/packages/core/src/design-jsx/renderer.ts
+++ b/packages/core/src/design-jsx/renderer.ts
@@ -4,7 +4,7 @@ import type {
   SceneNode,
   NodeType
 } from '@open-pencil/scene-graph'
-import type { Color } from '@open-pencil/scene-graph/primitives'
+import { setInstanceOverride } from '@open-pencil/scene-graph'
 
 import { parseColor } from '#core/color'
 import type { RenderOptions } from '#core/design-jsx/types'
@@ -452,7 +452,7 @@ function applyInstanceOverrides(
   }
   walk(instance.id)
 
-  const overrides: Record<string, unknown> = { ...instance.overrides }
+  const overrides = new Map<string, unknown>()
   for (const [key, value] of entries) {
     const sep = key.indexOf(':')
     if (sep === -1) continue
@@ -461,10 +461,10 @@ function applyInstanceOverrides(
     const child = descendants.find((n) => n.name === childName)
     if (!child || !(prop in child)) continue
     graph.updateNode(child.id, { [prop]: value } as Partial<SceneNode>)
-    overrides[`${child.id}:${prop}`] = value
+    setInstanceOverride(instance.instanceOverrides, instance.id, child.id, prop, value)
   }
-  if (Object.keys(overrides).length > 0) {
-    graph.updateNode(instance.id, { overrides })
+  if (overrides.size > 0) {
+    graph.updateNode(instance.id, { instanceOverrides: instance.instanceOverrides })
   }
 }
 

--- a/packages/core/src/design-jsx/renderer.ts
+++ b/packages/core/src/design-jsx/renderer.ts
@@ -1,10 +1,11 @@
-import type {
-  ComponentPropertyDefinition,
-  SceneGraph,
-  SceneNode,
-  NodeType
+import {
+  setInstanceOverride,
+  type ComponentPropertyDefinition,
+  type NodeType,
+  type SceneGraph,
+  type SceneNode
 } from '@open-pencil/scene-graph'
-import { setInstanceOverride } from '@open-pencil/scene-graph'
+import type { Color } from '@open-pencil/scene-graph/primitives'
 
 import { parseColor } from '#core/color'
 import type { RenderOptions } from '#core/design-jsx/types'

--- a/packages/core/src/editor/components/instances.ts
+++ b/packages/core/src/editor/components/instances.ts
@@ -1,3 +1,4 @@
+import { cloneInstanceOverrideState } from '@open-pencil/scene-graph'
 import type { SceneNode, Vector } from '@open-pencil/scene-graph'
 import { getAxisAlignedWorldBounds, getWorldMatrix } from '@open-pencil/scene-graph/coordinate'
 import Matrix from '@open-pencil/scene-graph/matrix'
@@ -97,6 +98,7 @@ export function createComponentInstanceActions(ctx: EditorContext) {
     if (selectedNode?.type !== 'INSTANCE') return
 
     const prevComponentId = selectedNode.componentId
+    const previousOverrides = cloneInstanceOverrideState(selectedNode.instanceOverrides)
 
     ctx.graph.detachInstance(selectedNode.id)
     ctx.setSelectedIds(new Set([selectedNode.id]))
@@ -111,10 +113,7 @@ export function createComponentInstanceActions(ctx: EditorContext) {
         ctx.graph.updateNode(selectedNode.id, {
           type: 'INSTANCE',
           componentId: prevComponentId,
-          instanceOverrides: {
-            self: new Map(),
-            descendants: new Map()
-          }
+          instanceOverrides: cloneInstanceOverrideState(previousOverrides)
         })
       }
     })

--- a/packages/core/src/editor/components/instances.ts
+++ b/packages/core/src/editor/components/instances.ts
@@ -111,7 +111,10 @@ export function createComponentInstanceActions(ctx: EditorContext) {
         ctx.graph.updateNode(selectedNode.id, {
           type: 'INSTANCE',
           componentId: prevComponentId,
-          overrides: {}
+          instanceOverrides: {
+            self: new Map(),
+            descendants: new Map()
+          }
         })
       }
     })

--- a/packages/core/src/editor/components/properties.ts
+++ b/packages/core/src/editor/components/properties.ts
@@ -1,4 +1,5 @@
 import {
+  applyComponentPropertyValue,
   cloneInstanceOverrideState,
   componentPropertyDefinitions,
   findComponentPropertyTarget,

--- a/packages/core/src/editor/components/properties.ts
+++ b/packages/core/src/editor/components/properties.ts
@@ -1,5 +1,5 @@
 import {
-  applyComponentPropertyValue,
+  cloneInstanceOverrideState,
   componentPropertyDefinitions,
   findComponentPropertyTarget,
   resolveComponentPropertyValue
@@ -100,7 +100,8 @@ export function createComponentPropertyActions(
     }
 
     const previousAssignments = { ...instance.componentPropertyAssignments }
-    const previousOverrides = structuredClone(instance.overrides)
+    const previousOverrides = cloneInstanceOverrideState(instance.instanceOverrides)
+
     const target = propertyTarget(ctx, instance, propertyId)
     const assignedValue = instance.componentPropertyAssignments[propertyId]
     const previousValue =
@@ -120,7 +121,7 @@ export function createComponentPropertyActions(
         if (live) {
           ctx.graph.updateNode(instanceId, {
             componentPropertyAssignments: previousAssignments,
-            overrides: previousOverrides
+            instanceOverrides: cloneInstanceOverrideState(previousOverrides)
           })
           const restoredTarget = propertyTarget(ctx, live, propertyId)
           if (restoredTarget?.field === 'TEXT' && restoredTarget.node.type === 'TEXT') {

--- a/packages/core/src/editor/text.ts
+++ b/packages/core/src/editor/text.ts
@@ -1,4 +1,9 @@
-import type { SceneNode } from '@open-pencil/scene-graph'
+import {
+  cloneInstanceOverrideState,
+  setInstanceOverride,
+  type InstanceOverrideState,
+  type SceneNode
+} from '@open-pencil/scene-graph'
 import { copyDerivedGlyphs, copyGeometryPaths } from '@open-pencil/scene-graph/copy'
 
 import { weightToStyle } from '#core/text/fonts'
@@ -48,7 +53,7 @@ function snapshotPathText(
 
 type InstanceOverridesSnapshot = {
   instanceId: string
-  overrides: Record<string, unknown>
+  instanceOverrides: InstanceOverrideState
 }
 
 function containingInstanceIds(ctx: EditorContext, nodeId: string): string[] {
@@ -68,7 +73,7 @@ function snapshotInstanceOverrides(
   return instanceIds.flatMap((instanceId) => {
     const instance = ctx.graph.getNode(instanceId)
     return instance?.type === 'INSTANCE'
-      ? [{ instanceId, overrides: structuredClone(instance.overrides) }]
+      ? [{ instanceId, instanceOverrides: cloneInstanceOverrideState(instance.instanceOverrides) }]
       : []
   })
 }
@@ -76,7 +81,7 @@ function snapshotInstanceOverrides(
 function restoreInstanceOverrides(ctx: EditorContext, snapshots: InstanceOverridesSnapshot[]) {
   for (const snapshot of snapshots) {
     ctx.graph.updateNode(snapshot.instanceId, {
-      overrides: structuredClone(snapshot.overrides)
+      instanceOverrides: cloneInstanceOverrideState(snapshot.instanceOverrides)
     })
   }
 }
@@ -90,9 +95,8 @@ function applyTextInstanceOverride(
   for (const instanceId of instanceIds) {
     const instance = ctx.graph.getNode(instanceId)
     if (instance?.type !== 'INSTANCE') continue
-    ctx.graph.updateNode(instanceId, {
-      overrides: { ...instance.overrides, [`${nodeId}:text`]: text }
-    })
+    setInstanceOverride(instance.instanceOverrides, instance.id, nodeId, 'text', text)
+    ctx.graph.updateNode(instance.id, { instanceOverrides: instance.instanceOverrides })
   }
 }
 

--- a/packages/core/src/library/snapshot.ts
+++ b/packages/core/src/library/snapshot.ts
@@ -10,7 +10,7 @@ const VOLATILE_NODE_FIELDS = new Set([
   'parentId',
   'childIds',
   'source',
-  'overrides',
+  'instanceOverrides',
   'componentPropertyAssignments',
   'textPicture',
   'derivedTextGlyphs',

--- a/packages/fig/src/node-change/export-node.ts
+++ b/packages/fig/src/node-change/export-node.ts
@@ -1,12 +1,12 @@
 import type { NodeChange, Paint } from '@open-pencil/kiwi/fig/codec'
 import { stringToGuid } from '@open-pencil/kiwi/fig/guid'
-import { DEFAULT_STROKE_MITER_LIMIT } from '@open-pencil/scene-graph'
 import type {
   ComponentPropertyDefinition,
   ComponentPropertyReferenceField,
   SceneGraph,
   SceneNode
 } from '@open-pencil/scene-graph'
+import { DEFAULT_STROKE_MITER_LIMIT, forEachInstanceOverride } from '@open-pencil/scene-graph'
 import type { Color, GUID, Matrix, Vector } from '@open-pencil/scene-graph/primitives'
 
 import { effectiveFigmaRawNodeFields, effectiveFigmaSourcePayload } from '../source-metadata'
@@ -400,20 +400,14 @@ function serializeTextOverrides(
   localIdCounter: { value: number }
 ): KiwiSymbolOverridePayload[] {
   const result: KiwiSymbolOverridePayload[] = []
-  for (const [key, value] of Object.entries(instance.overrides)) {
-    if (!key.endsWith(':text') || typeof value !== 'string') continue
-    const targetId = key.slice(0, -':text'.length)
-    const target = context.graph.getNode(targetId)
-    if (!target || !isDescendantOf(context, targetId, instance.id)) continue
-
+  forEachInstanceOverride(instance.instanceOverrides, (nodeId, field, value) => {
+    if (field !== 'text' || typeof value !== 'string' || !nodeId) return
+    const target = context.graph.getNode(nodeId)
+    if (!target || !isDescendantOf(context, nodeId, instance.id)) return
     const targetGuid = resolveOverrideTargetGuid(context, target, localIdCounter)
-    if (!targetGuid) continue
-
-    result.push({
-      guidPath: { guids: [targetGuid] },
-      textData: { characters: value }
-    })
-  }
+    if (targetGuid)
+      result.push({ guidPath: { guids: [targetGuid] }, textData: { characters: value } })
+  })
   return result
 }
 
@@ -440,20 +434,17 @@ function serializeFillOverrides(
   localIdCounter: { value: number }
 ): KiwiSymbolOverridePayload[] {
   const result: KiwiSymbolOverridePayload[] = []
-  for (const key of Object.keys(instance.overrides)) {
-    if (!key.endsWith(':fills')) continue
-    const targetId = key.slice(0, -':fills'.length)
-    const target = context.graph.getNode(targetId)
-    if (!target || !isDescendantOf(context, targetId, instance.id)) continue
-
+  forEachInstanceOverride(instance.instanceOverrides, (nodeId, field) => {
+    if (field !== 'fills' || !nodeId) return
+    const target = context.graph.getNode(nodeId)
+    if (!target || !isDescendantOf(context, nodeId, instance.id)) return
     const targetGuid = resolveOverrideTargetGuid(context, target, localIdCounter)
-    if (!targetGuid) continue
-
-    result.push({
-      guidPath: { guids: [targetGuid] },
-      fillPaints: target.fills.map((fill) => context.fillToKiwiPaint(fill))
-    })
-  }
+    if (targetGuid)
+      result.push({
+        guidPath: { guids: [targetGuid] },
+        fillPaints: target.fills.map((fill) => context.fillToKiwiPaint(fill))
+      })
+  })
   return result
 }
 

--- a/packages/fig/tests/export.test.ts
+++ b/packages/fig/tests/export.test.ts
@@ -70,7 +70,10 @@ describe('@open-pencil/fig SceneGraph export policy', () => {
       opacity: 0.5
     }
     graph.updateNode(instance?.id ?? '', {
-      overrides: { [`${targetText?.id}:text`]: 'Edited' },
+      instanceOverrides: {
+        self: new Map(),
+        descendants: new Map([[targetText?.id ?? '', new Map([['text', 'Edited']])]])
+      },
       source: {
         ...instance?.source,
         fig: {

--- a/packages/scene-graph/src/components/properties.ts
+++ b/packages/scene-graph/src/components/properties.ts
@@ -1,5 +1,6 @@
 import type { SceneGraph } from '../index'
 import { setInstanceOverride } from '../instance-overrides'
+import { findInstanceAncestor } from '../instances'
 import type {
   ComponentPropertyDefinition,
   ComponentPropertyReferenceField,
@@ -87,63 +88,60 @@ export function findComponentPropertyTargets(
 
 function applyTextProperty(
   graph: SceneGraph,
+  owner: SceneNode,
   targets: ComponentPropertyTarget[],
   value: string
 ): void {
   for (const item of targets) {
     if (item.field !== 'TEXT' || item.node.type !== 'TEXT') continue
     graph.updateNode(item.node.id, { text: value })
-    setInstanceOverride(item.node.instanceOverrides, item.node.id, item.node.id, 'text', value)
+    if (findInstanceAncestor(graph, item.node.id)) {
+      setInstanceOverride(owner.instanceOverrides, owner.id, item.node.id, 'text', value)
+    }
   }
 }
 
 function applyBooleanProperty(
   graph: SceneGraph,
+  owner: SceneNode,
   targets: ComponentPropertyTarget[],
   value: string
 ): void {
   for (const item of targets) {
     if (item.field !== 'VISIBLE') continue
+    const instance = findInstanceAncestor(graph, item.node.id)
     graph.updateNode(item.node.id, { visible: value === 'true' })
-    setInstanceOverride(
-      item.node.instanceOverrides,
-      item.node.id,
-      item.node.id,
-      'visible',
-      value === 'true'
-    )
+    if (instance) {
+      setInstanceOverride(
+        owner.instanceOverrides,
+        owner.id,
+        item.node.id,
+        'visible',
+        value === 'true'
+      )
+    }
   }
 }
 
 function applyInstanceSwapProperty(
   graph: SceneGraph,
+  owner: SceneNode,
   targets: ComponentPropertyTarget[],
   target: SceneNode
 ): void {
   for (const item of targets) {
     if (item.field !== 'INSTANCE_SWAP' || item.node.type !== 'INSTANCE') continue
     graph.swapInstanceComponent(item.node.id, target.id)
+    setInstanceOverride(owner.instanceOverrides, owner.id, item.node.id, 'name', target.name)
+    setInstanceOverride(owner.instanceOverrides, owner.id, item.node.id, 'componentId', target.id)
     setInstanceOverride(
-      item.node.instanceOverrides,
-      item.node.id,
-      item.node.id,
-      'name',
-      target.name
-    )
-    setInstanceOverride(
-      item.node.instanceOverrides,
-      item.node.id,
-      item.node.id,
-      'componentId',
-      target.id
-    )
-    setInstanceOverride(
-      item.node.instanceOverrides,
-      item.node.id,
+      owner.instanceOverrides,
+      owner.id,
       item.node.id,
       'sourceComponentId',
       item.source.id
     )
+    graph.updateNode(owner.id, { instanceOverrides: owner.instanceOverrides })
   }
 }
 
@@ -161,11 +159,11 @@ export function applyComponentPropertyValue(
     definition.type === 'INSTANCE_SWAP' ? resolveComponentPropertyValue(graph, value) : null
   if (definition.type === 'INSTANCE_SWAP' && !target) return null
   if (definition.type === 'TEXT') {
-    applyTextProperty(graph, targets, value)
+    applyTextProperty(graph, instance, targets, value)
   } else if (definition.type === 'BOOLEAN') {
-    applyBooleanProperty(graph, targets, value)
+    applyBooleanProperty(graph, instance, targets, value)
   } else if (target) {
-    applyInstanceSwapProperty(graph, targets, target)
+    applyInstanceSwapProperty(graph, instance, targets, target)
   }
   graph.updateNode(instance.id, {
     componentPropertyAssignments: {

--- a/packages/scene-graph/src/components/properties.ts
+++ b/packages/scene-graph/src/components/properties.ts
@@ -1,4 +1,5 @@
 import type { SceneGraph } from '../index'
+import { setInstanceOverride } from '../instance-overrides'
 import type {
   ComponentPropertyDefinition,
   ComponentPropertyReferenceField,
@@ -87,48 +88,62 @@ export function findComponentPropertyTargets(
 function applyTextProperty(
   graph: SceneGraph,
   targets: ComponentPropertyTarget[],
-  value: string,
-  overrides: Record<string, unknown>
+  value: string
 ): void {
   for (const item of targets) {
     if (item.field !== 'TEXT' || item.node.type !== 'TEXT') continue
     graph.updateNode(item.node.id, { text: value })
-    overrides[`${item.node.id}:text`] = value
+    setInstanceOverride(item.node.instanceOverrides, item.node.id, item.node.id, 'text', value)
   }
 }
 
 function applyBooleanProperty(
   graph: SceneGraph,
   targets: ComponentPropertyTarget[],
-  value: string,
-  overrides: Record<string, unknown>
+  value: string
 ): void {
   for (const item of targets) {
     if (item.field !== 'VISIBLE') continue
     graph.updateNode(item.node.id, { visible: value === 'true' })
-    overrides[`${item.node.id}:visible`] = value === 'true'
+    setInstanceOverride(
+      item.node.instanceOverrides,
+      item.node.id,
+      item.node.id,
+      'visible',
+      value === 'true'
+    )
   }
 }
 
 function applyInstanceSwapProperty(
   graph: SceneGraph,
   targets: ComponentPropertyTarget[],
-  target: SceneNode,
-  overrides: Record<string, unknown>
+  target: SceneNode
 ): void {
   for (const item of targets) {
     if (item.field !== 'INSTANCE_SWAP' || item.node.type !== 'INSTANCE') continue
     graph.swapInstanceComponent(item.node.id, target.id)
-    graph.updateNode(item.node.id, {
-      name: target.name,
-      overrides: {
-        ...item.node.overrides,
-        [`${item.node.id}:name`]: target.name
-      }
-    })
-    overrides[`${item.node.id}:componentId`] = target.id
-    overrides[`${item.node.id}:sourceComponentId`] = item.source.id
-    overrides[`${item.node.id}:name`] = target.name
+    setInstanceOverride(
+      item.node.instanceOverrides,
+      item.node.id,
+      item.node.id,
+      'name',
+      target.name
+    )
+    setInstanceOverride(
+      item.node.instanceOverrides,
+      item.node.id,
+      item.node.id,
+      'componentId',
+      target.id
+    )
+    setInstanceOverride(
+      item.node.instanceOverrides,
+      item.node.id,
+      item.node.id,
+      'sourceComponentId',
+      item.source.id
+    )
   }
 }
 
@@ -145,20 +160,18 @@ export function applyComponentPropertyValue(
   const target =
     definition.type === 'INSTANCE_SWAP' ? resolveComponentPropertyValue(graph, value) : null
   if (definition.type === 'INSTANCE_SWAP' && !target) return null
-  const overrides = { ...instance.overrides }
   if (definition.type === 'TEXT') {
-    applyTextProperty(graph, targets, value, overrides)
+    applyTextProperty(graph, targets, value)
   } else if (definition.type === 'BOOLEAN') {
-    applyBooleanProperty(graph, targets, value, overrides)
+    applyBooleanProperty(graph, targets, value)
   } else if (target) {
-    applyInstanceSwapProperty(graph, targets, target, overrides)
+    applyInstanceSwapProperty(graph, targets, target)
   }
   graph.updateNode(instance.id, {
     componentPropertyAssignments: {
       ...instance.componentPropertyAssignments,
       [definition.id]: definition.type === 'INSTANCE_SWAP' && target ? target.id : value
-    },
-    overrides
+    }
   })
   return definition.type === 'INSTANCE_SWAP' ? target : instance
 }

--- a/packages/scene-graph/src/copy.ts
+++ b/packages/scene-graph/src/copy.ts
@@ -22,6 +22,7 @@ import type {
   StyleRun
 } from './'
 import { geometryCommandCoordCount } from './geometry'
+import { cloneInstanceOverrideState } from './instance-overrides'
 import { createDefaultSourceMetadata } from './node-defaults'
 import { cloneVectorNetwork } from './vector-network'
 
@@ -240,8 +241,9 @@ export function cloneNodeProps(
       source: createDefaultSourceMetadata(),
       boundVariables: { ...src.boundVariables },
       variableModes: { ...src.variableModes },
-      overrides: Object.keys(src.overrides).length > 0 ? structuredClone(src.overrides) : {},
+      instanceOverrides: cloneInstanceOverrideState(src.instanceOverrides),
       componentPropertyAssignments: { ...src.componentPropertyAssignments },
+
       componentPropertyValues: { ...src.componentPropertyValues }
     }
   }
@@ -250,8 +252,9 @@ export function cloneNodeProps(
     ...(componentId !== null ? { componentId } : {}),
     boundVariables: { ...src.boundVariables },
     variableModes: { ...src.variableModes },
-    overrides: Object.keys(src.overrides).length > 0 ? structuredClone(src.overrides) : {},
+    instanceOverrides: cloneInstanceOverrideState(src.instanceOverrides),
     fills: copyOpt(src.fills, (value) => markCopySource(value, copyFills(value))),
+
     strokes: copyOpt(src.strokes, (value) => markCopySource(value, copyStrokes(value))),
     effects: copyOpt(src.effects, (value) => markCopySource(value, copyEffects(value))),
     layoutGrids: copyOpt(src.layoutGrids, copyLayoutGrids),

--- a/packages/scene-graph/src/index.ts
+++ b/packages/scene-graph/src/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines -- SceneGraph exposes a stable facade over domain modules */
+export * from './instance-overrides'
 export * from './images'
 export * from './components/properties'
 export * from './copy'

--- a/packages/scene-graph/src/index.ts
+++ b/packages/scene-graph/src/index.ts
@@ -11,6 +11,14 @@ export {
   INSTANCE_SYNC_TEXT_PROPS,
   recordInstanceOverride
 } from './instances'
+export {
+  clearInstanceOverrides,
+  cloneInstanceOverrideState,
+  forEachInstanceOverride,
+  getInstanceOverride,
+  setInstanceOverride,
+  type InstanceOverrideState
+} from './instance-overrides'
 export * from './snap'
 export * from './export-scale'
 export * from './coordinate'

--- a/packages/scene-graph/src/instance-overrides.test.ts
+++ b/packages/scene-graph/src/instance-overrides.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  clearInstanceOverrides,
+  cloneInstanceOverrideState,
+  createInstanceOverrideState,
+  deleteInstanceOverride,
+  getInstanceOverride,
+  hasInstanceOverride,
+  setInstanceOverride
+} from './instance-overrides'
+
+describe('instance override state', () => {
+  test('stores self and descendant values structurally', () => {
+    const state = createInstanceOverrideState()
+    setInstanceOverride(state, 'instance', 'instance', 'visible', false)
+    setInstanceOverride(state, 'instance', 'child', 'text', 'Custom')
+    expect(getInstanceOverride(state, 'instance', 'instance', 'visible')).toBe(false)
+    expect(getInstanceOverride(state, 'instance', 'child', 'text')).toBe('Custom')
+    expect(hasInstanceOverride(state, 'instance', 'child', 'text')).toBe(true)
+  })
+
+  test('deletes empty descendant buckets', () => {
+    const state = createInstanceOverrideState()
+    setInstanceOverride(state, 'instance', 'child', 'text')
+    expect(deleteInstanceOverride(state, 'instance', 'child', 'text')).toBe(true)
+    expect(state.descendants.has('child')).toBe(false)
+  })
+
+  test('clones independently and clears', () => {
+    const state = createInstanceOverrideState()
+    setInstanceOverride(state, 'instance', 'child', 'text', 'Custom')
+    const clone = cloneInstanceOverrideState(state)
+    setInstanceOverride(clone, 'instance', 'child', 'text', 'Other')
+    expect(getInstanceOverride(state, 'instance', 'child', 'text')).toBe('Custom')
+    clearInstanceOverrides(state)
+    expect(state.descendants.size).toBe(0)
+  })
+})

--- a/packages/scene-graph/src/instance-overrides.test.ts
+++ b/packages/scene-graph/src/instance-overrides.test.ts
@@ -20,6 +20,12 @@ describe('instance override state', () => {
     expect(hasInstanceOverride(state, 'instance', 'child', 'text')).toBe(true)
   })
 
+  test('reports presence for an explicit undefined override', () => {
+    const state = createInstanceOverrideState()
+    setInstanceOverride(state, 'instance', 'child', 'visible', undefined)
+    expect(hasInstanceOverride(state, 'instance', 'child', 'visible')).toBe(true)
+  })
+
   test('deletes empty descendant buckets', () => {
     const state = createInstanceOverrideState()
     setInstanceOverride(state, 'instance', 'child', 'text')

--- a/packages/scene-graph/src/instance-overrides.test.ts
+++ b/packages/scene-graph/src/instance-overrides.test.ts
@@ -33,7 +33,7 @@ describe('instance override state', () => {
     state.self.set('opacity', undefined)
     state.descendants.set('child', new Map([['visible', undefined]]))
     // eslint-disable-next-line unicorn/prefer-structured-clone -- exercise the JSON boundary
-    const serialized = JSON.parse(JSON.stringify(serializeInstanceOverrideState(state)))
+    const serialized: unknown = JSON.parse(JSON.stringify(serializeInstanceOverrideState(state)))
     const restored = deserializeInstanceOverrideState(serialized)
 
     expect(hasInstanceOverride(restored, 'instance', 'instance', 'opacity')).toBe(true)

--- a/packages/scene-graph/src/instance-overrides.test.ts
+++ b/packages/scene-graph/src/instance-overrides.test.ts
@@ -5,8 +5,10 @@ import {
   cloneInstanceOverrideState,
   createInstanceOverrideState,
   deleteInstanceOverride,
+  deserializeInstanceOverrideState,
   getInstanceOverride,
   hasInstanceOverride,
+  serializeInstanceOverrideState,
   setInstanceOverride
 } from './instance-overrides'
 
@@ -24,6 +26,26 @@ describe('instance override state', () => {
     const state = createInstanceOverrideState()
     setInstanceOverride(state, 'instance', 'child', 'visible', undefined)
     expect(hasInstanceOverride(state, 'instance', 'child', 'visible')).toBe(true)
+  })
+
+  test('round-trips explicit undefined values through JSON', () => {
+    const state = createInstanceOverrideState()
+    state.self.set('opacity', undefined)
+    state.descendants.set('child', new Map([['visible', undefined]]))
+    // eslint-disable-next-line unicorn/prefer-structured-clone -- exercise the JSON boundary
+    const serialized = JSON.parse(JSON.stringify(serializeInstanceOverrideState(state)))
+    const restored = deserializeInstanceOverrideState(serialized)
+
+    expect(hasInstanceOverride(restored, 'instance', 'instance', 'opacity')).toBe(true)
+    expect(getInstanceOverride(restored, 'instance', 'instance', 'opacity')).toBeUndefined()
+    expect(hasInstanceOverride(restored, 'instance', 'child', 'visible')).toBe(true)
+    expect(getInstanceOverride(restored, 'instance', 'child', 'visible')).toBeUndefined()
+  })
+
+  test('ignores malformed serialized entries', () => {
+    const state = deserializeInstanceOverrideState({ self: [null], descendants: [] })
+    expect(state.self.size).toBe(0)
+    expect(state.descendants.size).toBe(0)
   })
 
   test('deletes empty descendant buckets', () => {

--- a/packages/scene-graph/src/instance-overrides.ts
+++ b/packages/scene-graph/src/instance-overrides.ts
@@ -9,30 +9,71 @@ export function createInstanceOverrideState(): InstanceOverrideState {
   return { self: new Map(), descendants: new Map() }
 }
 
+export interface SerializedOverrideValue {
+  defined: boolean
+  value?: unknown
+}
+
 export interface SerializedInstanceOverrideState {
-  self: Array<[InstanceOverrideField, unknown]>
-  descendants: Array<[string, Array<[InstanceOverrideField, unknown]>]>
+  self: Array<[InstanceOverrideField, SerializedOverrideValue]>
+  descendants: Array<[string, Array<[InstanceOverrideField, SerializedOverrideValue]>]>
+}
+
+function serializeOverrideValue(value: unknown): SerializedOverrideValue {
+  return value === undefined ? { defined: false } : { defined: true, value }
+}
+
+function deserializeOverrideValue(value: unknown): { valid: boolean; value: unknown } {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { valid: false, value: undefined }
+  }
+  if (!('defined' in value) || typeof value.defined !== 'boolean') {
+    return { valid: false, value: undefined }
+  }
+  if (value.defined) {
+    return 'value' in value
+      ? { valid: true, value: value['value'] }
+      : { valid: false, value: undefined }
+  }
+  return { valid: true, value: undefined }
+}
+
+function deserializeEntries(value: unknown): Map<InstanceOverrideField, unknown> {
+  const result = new Map<InstanceOverrideField, unknown>()
+  if (!Array.isArray(value)) return result
+  for (const entry of value) {
+    if (!Array.isArray(entry) || entry.length !== 2 || typeof entry[0] !== 'string') continue
+    const decoded = deserializeOverrideValue(entry[1])
+    if (decoded.valid) result.set(entry[0], decoded.value)
+  }
+  return result
 }
 
 export function serializeInstanceOverrideState(
   state: InstanceOverrideState
 ): SerializedInstanceOverrideState {
   return {
-    self: [...state.self],
-    descendants: [...state.descendants].map(([nodeId, fields]) => [nodeId, [...fields]])
+    self: [...state.self].map(([field, value]) => [field, serializeOverrideValue(value)]),
+    descendants: [...state.descendants].map(([nodeId, fields]) => [
+      nodeId,
+      [...fields].map(([field, value]) => [field, serializeOverrideValue(value)])
+    ])
   }
 }
 
-export function deserializeInstanceOverrideState(
-  state: SerializedInstanceOverrideState | undefined
-): InstanceOverrideState {
-  if (!state || !Array.isArray(state.self) || !Array.isArray(state.descendants)) {
+export function deserializeInstanceOverrideState(state: unknown): InstanceOverrideState {
+  if (!state || typeof state !== 'object' || Array.isArray(state)) {
     return createInstanceOverrideState()
   }
-  return {
-    self: new Map(state.self),
-    descendants: new Map(state.descendants.map(([nodeId, fields]) => [nodeId, new Map(fields)]))
+  const self = 'self' in state ? deserializeEntries(state.self) : new Map()
+  const descendants = new Map<string, Map<InstanceOverrideField, unknown>>()
+  if ('descendants' in state && Array.isArray(state.descendants)) {
+    for (const entry of state.descendants) {
+      if (!Array.isArray(entry) || entry.length !== 2 || typeof entry[0] !== 'string') continue
+      descendants.set(entry[0], deserializeEntries(entry[1]))
+    }
   }
+  return { self, descendants }
 }
 
 export function cloneInstanceOverrideState(state: InstanceOverrideState): InstanceOverrideState {

--- a/packages/scene-graph/src/instance-overrides.ts
+++ b/packages/scene-graph/src/instance-overrides.ts
@@ -1,0 +1,83 @@
+export type InstanceOverrideField = string
+
+export interface InstanceOverrideState {
+  self: Map<InstanceOverrideField, unknown>
+  descendants: Map<string, Map<InstanceOverrideField, unknown>>
+}
+
+export function createInstanceOverrideState(): InstanceOverrideState {
+  return { self: new Map(), descendants: new Map() }
+}
+
+export function cloneInstanceOverrideState(state: InstanceOverrideState): InstanceOverrideState {
+  return {
+    self: new Map([...state.self].map(([field, value]) => [field, structuredClone(value)])),
+    descendants: new Map(
+      [...state.descendants].map(([id, fields]) => [
+        id,
+        new Map([...fields].map(([field, value]) => [field, structuredClone(value)]))
+      ])
+    )
+  }
+}
+
+export function getInstanceOverride(
+  state: InstanceOverrideState,
+  instanceId: string,
+  nodeId: string,
+  field: InstanceOverrideField
+): unknown {
+  return nodeId === instanceId ? state.self.get(field) : state.descendants.get(nodeId)?.get(field)
+}
+
+export function hasInstanceOverride(
+  state: InstanceOverrideState,
+  instanceId: string,
+  nodeId: string,
+  field: InstanceOverrideField
+): boolean {
+  return getInstanceOverride(state, instanceId, nodeId, field) !== undefined
+}
+
+export function setInstanceOverride(
+  state: InstanceOverrideState,
+  instanceId: string,
+  nodeId: string,
+  field: InstanceOverrideField,
+  value: unknown = true
+): void {
+  if (nodeId === instanceId) {
+    state.self.set(field, value)
+    return
+  }
+  const fields = state.descendants.get(nodeId) ?? new Map<string, unknown>()
+  fields.set(field, value)
+  state.descendants.set(nodeId, fields)
+}
+
+export function deleteInstanceOverride(
+  state: InstanceOverrideState,
+  instanceId: string,
+  nodeId: string,
+  field: InstanceOverrideField
+): boolean {
+  const fields = nodeId === instanceId ? state.self : state.descendants.get(nodeId)
+  if (!fields?.delete(field)) return false
+  if (nodeId !== instanceId && fields.size === 0) state.descendants.delete(nodeId)
+  return true
+}
+
+export function clearInstanceOverrides(state: InstanceOverrideState): void {
+  state.self.clear()
+  state.descendants.clear()
+}
+
+export function forEachInstanceOverride(
+  state: InstanceOverrideState,
+  callback: (nodeId: string, field: InstanceOverrideField, value: unknown) => void
+): void {
+  for (const [field, value] of state.self) callback('', field, value)
+  for (const [nodeId, fields] of state.descendants) {
+    for (const [field, value] of fields) callback(nodeId, field, value)
+  }
+}

--- a/packages/scene-graph/src/instance-overrides.ts
+++ b/packages/scene-graph/src/instance-overrides.ts
@@ -65,7 +65,8 @@ export function deserializeInstanceOverrideState(state: unknown): InstanceOverri
   if (!state || typeof state !== 'object' || Array.isArray(state)) {
     return createInstanceOverrideState()
   }
-  const self = 'self' in state ? deserializeEntries(state.self) : new Map()
+  const self =
+    'self' in state ? deserializeEntries(state.self) : new Map<InstanceOverrideField, unknown>()
   const descendants = new Map<string, Map<InstanceOverrideField, unknown>>()
   if ('descendants' in state && Array.isArray(state.descendants)) {
     for (const entry of state.descendants) {

--- a/packages/scene-graph/src/instance-overrides.ts
+++ b/packages/scene-graph/src/instance-overrides.ts
@@ -9,6 +9,32 @@ export function createInstanceOverrideState(): InstanceOverrideState {
   return { self: new Map(), descendants: new Map() }
 }
 
+export interface SerializedInstanceOverrideState {
+  self: Array<[InstanceOverrideField, unknown]>
+  descendants: Array<[string, Array<[InstanceOverrideField, unknown]>]>
+}
+
+export function serializeInstanceOverrideState(
+  state: InstanceOverrideState
+): SerializedInstanceOverrideState {
+  return {
+    self: [...state.self],
+    descendants: [...state.descendants].map(([nodeId, fields]) => [nodeId, [...fields]])
+  }
+}
+
+export function deserializeInstanceOverrideState(
+  state: SerializedInstanceOverrideState | undefined
+): InstanceOverrideState {
+  if (!state || !Array.isArray(state.self) || !Array.isArray(state.descendants)) {
+    return createInstanceOverrideState()
+  }
+  return {
+    self: new Map(state.self),
+    descendants: new Map(state.descendants.map(([nodeId, fields]) => [nodeId, new Map(fields)]))
+  }
+}
+
 export function cloneInstanceOverrideState(state: InstanceOverrideState): InstanceOverrideState {
   return {
     self: new Map([...state.self].map(([field, value]) => [field, structuredClone(value)])),
@@ -36,7 +62,8 @@ export function hasInstanceOverride(
   nodeId: string,
   field: InstanceOverrideField
 ): boolean {
-  return getInstanceOverride(state, instanceId, nodeId, field) !== undefined
+  const fields = nodeId === instanceId ? state.self : state.descendants.get(nodeId)
+  return fields?.has(field) ?? false
 }
 
 export function setInstanceOverride(

--- a/packages/scene-graph/src/instances.ts
+++ b/packages/scene-graph/src/instances.ts
@@ -1,6 +1,13 @@
 import type { SceneGraph, SceneNode } from './'
 import { cloneNodeProps, copyEffects, copyFills, copyStrokes, copyStyleRuns } from './copy'
 import type { NodeCloneMode } from './copy'
+import {
+  clearInstanceOverrides,
+  getInstanceOverride,
+  hasInstanceOverride as hasNodeInstanceOverride,
+  setInstanceOverride,
+  type InstanceOverrideState
+} from './instance-overrides'
 
 export type { NodeCloneMode } from './copy'
 
@@ -120,7 +127,7 @@ function syncChildren(
   graph: SceneGraph,
   compParentId: string,
   instParentId: string,
-  overrides: Record<string, unknown>
+  overrides: InstanceOverrideState
 ): void {
   const compParent = graph.nodes.get(compParentId)
   const instParent = graph.nodes.get(instParentId)
@@ -130,7 +137,13 @@ function syncChildren(
   for (const childId of instParent.childIds) {
     const child = graph.nodes.get(childId)
     if (!child) continue
-    const sourceComponentId = overrides[`${child.id}:sourceComponentId`]
+    const sourceComponentId = getInstanceOverride(
+      overrides,
+      instParentId,
+      child.id,
+      'sourceComponentId'
+    )
+
     const mappedComponentId =
       typeof sourceComponentId === 'string' ? sourceComponentId : child.componentId
     if (mappedComponentId) instChildMap.set(mappedComponentId, child)
@@ -154,12 +167,15 @@ function syncChildren(
     if (!compChild || !instChild) continue
 
     for (const key of INSTANCE_SYNC_FIELDS) {
-      const overrideKey = `${instChild.id}:${key}`
-      if (overrideKey in overrides) continue
+      if (hasNodeInstanceOverride(overrides, instParentId, instChild.id, key)) continue
+
       copyProp(instChild, compChild, key)
     }
 
-    if (compChild.childIds.length > 0 && !(`${instChild.id}:componentId` in overrides)) {
+    if (
+      compChild.childIds.length > 0 &&
+      !hasNodeInstanceOverride(overrides, instParentId, instChild.id, 'componentId')
+    ) {
       syncChildren(graph, compChildId, instChild.id, overrides)
     }
   }
@@ -168,8 +184,13 @@ function syncChildren(
   instParent.childIds.sort((a, b) => {
     const nodeA = graph.nodes.get(a)
     const nodeB = graph.nodes.get(b)
-    const sourceA = nodeA ? overrides[`${nodeA.id}:sourceComponentId`] : undefined
-    const sourceB = nodeB ? overrides[`${nodeB.id}:sourceComponentId`] : undefined
+    const sourceA = nodeA
+      ? getInstanceOverride(overrides, instParentId, nodeA.id, 'sourceComponentId')
+      : undefined
+    const sourceB = nodeB
+      ? getInstanceOverride(overrides, instParentId, nodeB.id, 'sourceComponentId')
+      : undefined
+
     const mappedA = typeof sourceA === 'string' ? sourceA : nodeA?.componentId
     const mappedB = typeof sourceB === 'string' ? sourceB : nodeB?.componentId
     const idxA = mappedA ? compChildOrder.indexOf(mappedA) : -1
@@ -230,9 +251,10 @@ export function swapInstanceComponent(
   const previousComponent = instance.componentId ? graph.nodes.get(instance.componentId) : undefined
   const updates: Partial<SceneNode> = { componentId }
   for (const key of INSTANCE_SYNC_PROPS) {
-    if (key in instance.overrides) continue
+    if (hasNodeInstanceOverride(instance.instanceOverrides, instance.id, instance.id, key)) continue
     copyProp(updates, component, key)
   }
+
   if (!previousComponent || instance.name === previousComponent.name) updates.name = component.name
 
   const childIds = Array.from(instance.childIds)
@@ -247,11 +269,11 @@ export function syncInstances(graph: SceneGraph, componentId: string): void {
 
   for (const instance of getInstances(graph, componentId)) {
     for (const key of INSTANCE_SYNC_PROPS) {
-      if (key in instance.overrides) continue
+      if (hasNodeInstanceOverride(instance.instanceOverrides, instance.id, instance.id, key))
+        continue
       copyProp(instance, component, key)
     }
-
-    syncChildren(graph, component.id, instance.id, instance.overrides)
+    syncChildren(graph, component.id, instance.id, instance.instanceOverrides)
   }
 }
 
@@ -263,7 +285,7 @@ export function detachInstance(graph: SceneGraph, instanceId: string): void {
   }
   node.type = 'FRAME'
   node.componentId = null
-  node.overrides = {}
+  clearInstanceOverrides(node.instanceOverrides)
 }
 
 export function getMainComponent(graph: SceneGraph, instanceId: string): SceneNode | undefined {
@@ -299,8 +321,7 @@ export function findInstanceAncestor(graph: SceneGraph, nodeId: string): SceneNo
 export function hasInstanceOverride(graph: SceneGraph, nodeId: string, field: string): boolean {
   const instance = findInstanceAncestor(graph, nodeId)
   if (!instance) return false
-  const key = nodeId === instance.id ? field : `${nodeId}:${field}`
-  return key in instance.overrides
+  return hasNodeInstanceOverride(instance.instanceOverrides, instance.id, nodeId, field)
 }
 
 /*
@@ -308,6 +329,17 @@ export function hasInstanceOverride(graph: SceneGraph, nodeId: string, field: st
  * so the .fig exporter knows to write the diff out as a symbol override. A no-op
  * for fields outside INSTANCE_SYNC_PROPS or nodes with no INSTANCE ancestor.
  */
+export function recordInstanceOverrideValue(
+  graph: SceneGraph,
+  nodeId: string,
+  field: string,
+  value: unknown
+): void {
+  const instance = findInstanceAncestor(graph, nodeId)
+  if (!instance) return
+  setInstanceOverride(instance.instanceOverrides, instance.id, nodeId, field, value)
+  graph.updateNode(instance.id, { instanceOverrides: instance.instanceOverrides })
+}
 export function recordInstanceOverride(
   graph: SceneGraph,
   nodeId: string,
@@ -322,9 +354,7 @@ export function recordInstanceOverride(
 
   if (relevant.length === 0) return
 
-  const overrides = { ...instance.overrides }
-  for (const field of relevant) {
-    overrides[nodeId === instance.id ? field : `${nodeId}:${field}`] = true
-  }
-  graph.updateNode(instance.id, { overrides })
+  for (const field of relevant)
+    setInstanceOverride(instance.instanceOverrides, instance.id, nodeId, field)
+  graph.updateNode(instance.id, { instanceOverrides: instance.instanceOverrides })
 }

--- a/packages/scene-graph/src/node-defaults.ts
+++ b/packages/scene-graph/src/node-defaults.ts
@@ -1,4 +1,5 @@
 import { BLACK, DEFAULT_FONT_FAMILY, DEFAULT_STROKE_MITER_LIMIT } from './constants'
+import { createInstanceOverrideState } from './instance-overrides'
 import type { NodeType, SceneNode, SourceMetadata } from './types'
 
 export function createDefaultSourceMetadata(): SourceMetadata {
@@ -140,7 +141,7 @@ export function createDefaultNode(
     pointCount: 5,
     starInnerRadius: 0.38,
     componentId: null,
-    overrides: {},
+    instanceOverrides: createInstanceOverrideState(),
     componentPropertyDefinitions: [],
     componentPropertyReferences: [],
     componentPropertyAssignments: {},

--- a/packages/scene-graph/src/types.ts
+++ b/packages/scene-graph/src/types.ts
@@ -1,4 +1,5 @@
 import type { CanvasGuide } from './guides'
+import type { InstanceOverrideState } from './instance-overrides'
 import type { Color, Matrix, Rect, Vector } from './primitives'
 
 export interface SceneGraphEvents {
@@ -529,7 +530,7 @@ export interface SceneNode {
   starInnerRadius: number
 
   componentId: string | null
-  overrides: Record<string, unknown>
+  instanceOverrides: InstanceOverrideState
   componentPropertyDefinitions: ComponentPropertyDefinition[]
   componentPropertyReferences: ComponentPropertyReference[]
   componentPropertyAssignments: Record<string, string>

--- a/packages/scene-graph/src/variables.ts
+++ b/packages/scene-graph/src/variables.ts
@@ -2,6 +2,7 @@ import { omit, omitBy } from 'es-toolkit/object'
 
 import { BLACK } from './constants'
 import type { SceneGraph } from './index'
+import { setInstanceOverride } from './instance-overrides'
 import type { Color } from './primitives'
 import type { Variable, VariableCollection, VariableType, VariableValue } from './types'
 
@@ -378,21 +379,19 @@ function markBoundVariablesOverrideOnInstance(graph: SceneGraph, nodeId: string)
   const node = graph.nodes.get(nodeId)
   if (!node) return
 
-  // If the node IS an INSTANCE itself, set the bare-key override (syncInstances
-  // checks `key in instance.overrides` for INSTANCE-self properties)
+  // Mark the field on the canonical structured state.
   if (node.type === 'INSTANCE') {
-    node.overrides['boundVariables'] = true
+    setInstanceOverride(node.instanceOverrides, node.id, node.id, 'boundVariables')
     return
   }
 
-  // Otherwise walk up to find an INSTANCE parent and set the child-key override
-  // (syncChildren checks `${instChild.id}:${key}` format)
+  // Walk up to the owning instance for descendant fields.
   let current = node
   while (current.parentId) {
     const parent = graph.nodes.get(current.parentId)
     if (!parent) break
     if (parent.type === 'INSTANCE') {
-      parent.overrides[`${nodeId}:boundVariables`] = true
+      setInstanceOverride(parent.instanceOverrides, parent.id, nodeId, 'boundVariables')
       break
     }
     current = parent

--- a/src/app/libraries/catalog/storage.ts
+++ b/src/app/libraries/catalog/storage.ts
@@ -29,17 +29,28 @@ function revisionKey(libraryId: string, revisionId: string): string {
   return `${PREFIX}/${libraryId}/revisions/${revisionId}.json`
 }
 
+const MAP_TAG = 'openpencil/map'
+
 interface EncodedMap {
-  $map: unknown[]
+  $openPencilType: typeof MAP_TAG
+  entries: unknown[]
 }
 
 function isEncodedMap(value: object): value is EncodedMap {
-  return '$map' in value && Array.isArray(value.$map)
+  return (
+    '$openPencilType' in value &&
+    value.$openPencilType === MAP_TAG &&
+    'entries' in value &&
+    Array.isArray(value.entries)
+  )
 }
 
 function encodeValue(value: unknown): unknown {
   if (value instanceof Map) {
-    return { $map: [...value].map(([key, entry]) => [encodeValue(key), encodeValue(entry)]) }
+    return {
+      $openPencilType: MAP_TAG,
+      entries: [...value].map(([key, entry]) => [encodeValue(key), encodeValue(entry)])
+    }
   }
   if (value instanceof Uint8Array) return { $bytes: encodeBase64(value) }
   if (Array.isArray(value)) return value.map(encodeValue)
@@ -56,7 +67,7 @@ function decodeValue(value: unknown): unknown {
   if (value && typeof value === 'object') {
     if (isEncodedMap(value)) {
       return new Map(
-        value.$map.flatMap((entry) =>
+        value.entries.flatMap((entry) =>
           Array.isArray(entry) && entry.length === 2
             ? [[decodeValue(entry[0]), decodeValue(entry[1])] as const]
             : []

--- a/src/app/libraries/catalog/storage.ts
+++ b/src/app/libraries/catalog/storage.ts
@@ -29,7 +29,18 @@ function revisionKey(libraryId: string, revisionId: string): string {
   return `${PREFIX}/${libraryId}/revisions/${revisionId}.json`
 }
 
+interface EncodedMap {
+  $map: unknown[]
+}
+
+function isEncodedMap(value: object): value is EncodedMap {
+  return '$map' in value && Array.isArray(value.$map)
+}
+
 function encodeValue(value: unknown): unknown {
+  if (value instanceof Map) {
+    return { $map: [...value].map(([key, entry]) => [encodeValue(key), encodeValue(entry)]) }
+  }
   if (value instanceof Uint8Array) return { $bytes: encodeBase64(value) }
   if (Array.isArray(value)) return value.map(encodeValue)
   if (value && typeof value === 'object') {
@@ -43,6 +54,15 @@ function encodeValue(value: unknown): unknown {
 function decodeValue(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(decodeValue)
   if (value && typeof value === 'object') {
+    if (isEncodedMap(value)) {
+      return new Map(
+        value.$map.flatMap((entry) =>
+          Array.isArray(entry) && entry.length === 2
+            ? [[decodeValue(entry[0]), decodeValue(entry[1])] as const]
+            : []
+        )
+      )
+    }
     if ('$bytes' in value && typeof (value as { $bytes?: unknown }).$bytes === 'string') {
       return decodeBase64((value as { $bytes: string }).$bytes)
     }

--- a/src/app/libraries/catalog/storage.ts
+++ b/src/app/libraries/catalog/storage.ts
@@ -45,8 +45,16 @@ function isEncodedMap(value: object): value is EncodedMap {
   )
 }
 
+function isMap(value: unknown): value is Map<unknown, unknown> {
+  return value instanceof Map
+}
+
+function isMarkerShapedObject(value: object): boolean {
+  return '$openPencilType' in value
+}
+
 function encodeValue(value: unknown): unknown {
-  if (value instanceof Map) {
+  if (isMap(value)) {
     return {
       $openPencilType: MAP_TAG,
       entries: [...value].map(([key, entry]) => [encodeValue(key), encodeValue(entry)])
@@ -55,9 +63,12 @@ function encodeValue(value: unknown): unknown {
   if (value instanceof Uint8Array) return { $bytes: encodeBase64(value) }
   if (Array.isArray(value)) return value.map(encodeValue)
   if (value && typeof value === 'object') {
-    return Object.fromEntries(
+    const encoded = Object.fromEntries(
       Object.entries(value).map(([key, entry]) => [key, encodeValue(entry)])
     )
+    return isMarkerShapedObject(value)
+      ? { $openPencilType: 'openpencil/object', value: encoded }
+      : encoded
   }
   return value
 }
@@ -65,6 +76,18 @@ function encodeValue(value: unknown): unknown {
 function decodeValue(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(decodeValue)
   if (value && typeof value === 'object') {
+    if (
+      '$openPencilType' in value &&
+      value.$openPencilType === 'openpencil/object' &&
+      'value' in value &&
+      value.value &&
+      typeof value.value === 'object' &&
+      !Array.isArray(value.value)
+    ) {
+      return Object.fromEntries(
+        Object.entries(value.value).map(([key, entry]) => [key, decodeValue(entry)])
+      )
+    }
     if (isEncodedMap(value)) {
       return new Map(
         value.entries.flatMap((entry) =>

--- a/tests/engine/clipboard/openpencil/images.test.ts
+++ b/tests/engine/clipboard/openpencil/images.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from 'bun:test'
 
+import { deflateSync } from 'fflate'
+
 import {
   buildOpenPencilClipboardHTML,
   FigmaAPI,
   parseOpenPencilClipboard,
   SceneGraph
 } from '@open-pencil/core'
+import type { SceneNode } from '@open-pencil/core'
+import { encodeBase64 } from '@open-pencil/core/bytes'
 import { getInstanceOverride, setInstanceOverride } from '@open-pencil/scene-graph'
 
 import { expectDefined } from '#tests/helpers/assert'
@@ -41,6 +45,34 @@ describe('clipboard roundtrip with images', () => {
 
     return { graph, node, imageHash: hash, imageBytes }
   }
+
+  test('migrates legacy flat instance overrides', () => {
+    const legacy = {
+      format: 'openpencil/v1',
+      nodes: [
+        {
+          id: 'instance',
+          type: 'INSTANCE',
+          overrides: { text: 'Self', 'child:text': 'Custom' },
+          children: []
+        }
+      ],
+      images: {}
+    }
+    const encoded = encodeBase64(deflateSync(new TextEncoder().encode(JSON.stringify(legacy))))
+    const parsed = expectDefined(
+      parseOpenPencilClipboard(`<!--(openpencil)${encoded}(/openpencil)-->`),
+      'OpenPencil clipboard'
+    )
+    const instance = parsed.nodes[0]
+
+    expect(getInstanceOverride(instance.instanceOverrides, instance.id, instance.id, 'text')).toBe(
+      'Self'
+    )
+    expect(getInstanceOverride(instance.instanceOverrides, instance.id, 'child', 'text')).toBe(
+      'Custom'
+    )
+  })
 
   test('preserves structured instance overrides', () => {
     const graph = new SceneGraph()

--- a/tests/engine/clipboard/openpencil/images.test.ts
+++ b/tests/engine/clipboard/openpencil/images.test.ts
@@ -6,7 +6,7 @@ import {
   parseOpenPencilClipboard,
   SceneGraph
 } from '@open-pencil/core'
-import type { SceneNode } from '@open-pencil/core'
+import { getInstanceOverride, setInstanceOverride } from '@open-pencil/scene-graph'
 
 import { expectDefined } from '#tests/helpers/assert'
 
@@ -41,6 +41,28 @@ describe('clipboard roundtrip with images', () => {
 
     return { graph, node, imageHash: hash, imageBytes }
   }
+
+  test('preserves structured instance overrides', () => {
+    const graph = new SceneGraph()
+    const page = graph.getPages()[0]
+    const component = graph.createNode('COMPONENT', page.id)
+    graph.createNode('TEXT', component.id, { text: 'Default' })
+    const instance = expectDefined(graph.createInstance(component.id, page.id), 'instance')
+    const child = expectDefined(graph.getChildren(instance.id)[0], 'instance child')
+    setInstanceOverride(instance.instanceOverrides, instance.id, child.id, 'text', 'Custom')
+
+    const parsed = expectDefined(
+      parseOpenPencilClipboard(buildOpenPencilClipboardHTML([instance], graph)),
+      'OpenPencil clipboard'
+    )
+    const pasted = parsed.nodes[0]
+
+    expect(pasted.instanceOverrides.self).toBeInstanceOf(Map)
+    expect(pasted.instanceOverrides.descendants).toBeInstanceOf(Map)
+    expect(getInstanceOverride(pasted.instanceOverrides, pasted.id, child.id, 'text')).toBe(
+      'Custom'
+    )
+  })
 
   test('round-trips image bytes through clipboard', () => {
     const { graph, node, imageHash, imageBytes } = graphWithImageNode()

--- a/tests/engine/clipboard/openpencil/images.test.ts
+++ b/tests/engine/clipboard/openpencil/images.test.ts
@@ -53,7 +53,7 @@ describe('clipboard roundtrip with images', () => {
         {
           id: 'instance',
           type: 'INSTANCE',
-          overrides: { text: 'Self', 'child:text': 'Custom' },
+          overrides: { text: 'Self', '0:2:text': 'Custom' },
           children: []
         }
       ],
@@ -69,7 +69,7 @@ describe('clipboard roundtrip with images', () => {
     expect(getInstanceOverride(instance.instanceOverrides, instance.id, instance.id, 'text')).toBe(
       'Self'
     )
-    expect(getInstanceOverride(instance.instanceOverrides, instance.id, 'child', 'text')).toBe(
+    expect(getInstanceOverride(instance.instanceOverrides, instance.id, '0:2', 'text')).toBe(
       'Custom'
     )
   })

--- a/tests/engine/figma/api/create/instance-fill-override.test.ts
+++ b/tests/engine/figma/api/create/instance-fill-override.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
+import { getInstanceOverride } from '@open-pencil/scene-graph'
+
 import { createAPI } from '../helpers'
 
 describe('setting fills on an instance descendant', () => {
@@ -19,7 +21,14 @@ describe('setting fills on an instance descendant', () => {
     ]
 
     const raw = api.graph.getNode(instance.id)
-    expect(raw?.overrides[`${vector.id}:fills`]).toBe(true)
+    expect(
+      getInstanceOverride(
+        raw?.instanceOverrides ?? { self: new Map(), descendants: new Map() },
+        instance.id,
+        vector.id,
+        'fills'
+      )
+    ).toBe(true)
   })
 
   test('preserves text edits on an instance descendant during resync', () => {
@@ -34,7 +43,18 @@ describe('setting fills on an instance descendant', () => {
     if (!instanceText) throw new Error('instance text not found')
     instanceText.characters = 'Custom'
 
-    expect(api.graph.getNode(instance.id)?.overrides[`${instanceText.id}:text`]).toBe(true)
+    expect(
+      getInstanceOverride(
+        api.graph.getNode(instance.id)?.instanceOverrides ?? {
+          self: new Map(),
+          descendants: new Map()
+        },
+        instance.id,
+        instanceText.id,
+        'text'
+      )
+    ).toBe(true)
+
     text.characters = 'Updated default'
     api.graph.syncInstances(component.id)
 
@@ -46,6 +66,6 @@ describe('setting fills on an instance descendant', () => {
     frame.fills = [{ type: 'SOLID', color: { r: 1, g: 0, b: 0, a: 1 }, opacity: 1, visible: true }]
 
     const raw = api.graph.getNode(frame.id)
-    expect(raw?.overrides ?? {}).toEqual({})
+    expect(raw?.instanceOverrides.self.size ?? 0).toBe(0)
   })
 })

--- a/tests/engine/io/fig/export/lazy-population.test.ts
+++ b/tests/engine/io/fig/export/lazy-population.test.ts
@@ -6,7 +6,7 @@ import {
   setLazyFigImportContext
 } from '@open-pencil/core/kiwi/fig/lazy-import'
 import { cloneSceneGraphForFigExport } from '@open-pencil/core/kiwi/fig/parse/transfer'
-import { SceneGraph } from '@open-pencil/scene-graph'
+import { SceneGraph, setInstanceOverride } from '@open-pencil/scene-graph'
 
 function lazyExportGraph() {
   const graph = new SceneGraph()
@@ -38,7 +38,9 @@ function createEditedInstance(
   if (!instance) throw new Error(`Could not create instance: ${name}`)
   const textId = instance.childIds[0]
   graph.updateNode(textId, { text })
-  graph.updateNode(instance.id, { overrides: { [`${textId}:text`]: text } })
+  setInstanceOverride(instance.instanceOverrides, instance.id, textId, 'text', text)
+  graph.updateNode(instance.id, { instanceOverrides: instance.instanceOverrides })
+
   return { instance, textId }
 }
 

--- a/tests/engine/library/storage-catalog.test.ts
+++ b/tests/engine/library/storage-catalog.test.ts
@@ -83,7 +83,9 @@ describe('storage library catalog', () => {
     })
     const instance = graph.createInstance(nestedComponent.id, component.id)
     if (!instance) throw new Error('Expected instance')
-    setInstanceOverride(instance.instanceOverrides, instance.id, instance.id, 'opacity', 0.5)
+    setInstanceOverride(instance.instanceOverrides, instance.id, instance.id, 'pluginData', {
+      $map: []
+    })
 
     const published = await catalog.publishRevision({
       libraryId: 'design-system',
@@ -102,9 +104,9 @@ describe('storage library catalog', () => {
         restoredInstance.instanceOverrides,
         restoredInstance.id,
         restoredInstance.id,
-        'opacity'
+        'pluginData'
       )
-    ).toBe(0.5)
+    ).toEqual({ $map: [] })
   })
 
   test('rejects corrupted revision content', async () => {

--- a/tests/engine/library/storage-catalog.test.ts
+++ b/tests/engine/library/storage-catalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { SceneGraph } from '@open-pencil/scene-graph'
+import { getInstanceOverride, SceneGraph, setInstanceOverride } from '@open-pencil/scene-graph'
 
 import type { LibraryObjectStore } from '@/app/integrations/storage'
 import { StorageLibraryCatalog } from '@/app/libraries/catalog/storage'
@@ -69,6 +69,42 @@ describe('storage library catalog', () => {
     expect([...restored.graph.getAllNodes()].some((node) => node.componentKey === 'button')).toBe(
       true
     )
+  })
+
+  test('preserves instance overrides through persisted revisions', async () => {
+    const objects = new MemoryObjects()
+    const catalog = new StorageLibraryCatalog(objects)
+    const graph = sourceGraph()
+    const component = [...graph.getAllNodes()].find((node) => node.componentKey === 'button')
+    if (!component) throw new Error('Expected component')
+    const nestedComponent = graph.createNode('COMPONENT', component.id, {
+      name: 'Icon',
+      componentKey: 'icon'
+    })
+    const instance = graph.createInstance(nestedComponent.id, component.id)
+    if (!instance) throw new Error('Expected instance')
+    setInstanceOverride(instance.instanceOverrides, instance.id, instance.id, 'opacity', 0.5)
+
+    const published = await catalog.publishRevision({
+      libraryId: 'design-system',
+      name: 'Design system',
+      graph
+    })
+    const restored = await catalog.getRevision('design-system', published.manifest.revisionId)
+    const restoredInstance = [...restored.graph.getAllNodes()].find(
+      (node) => node.type === 'INSTANCE'
+    )
+    if (!restoredInstance) throw new Error('Expected restored instance')
+
+    expect(restoredInstance.instanceOverrides.self).toBeInstanceOf(Map)
+    expect(
+      getInstanceOverride(
+        restoredInstance.instanceOverrides,
+        restoredInstance.id,
+        restoredInstance.id,
+        'opacity'
+      )
+    ).toBe(0.5)
   })
 
   test('rejects corrupted revision content', async () => {

--- a/tests/engine/library/storage-catalog.test.ts
+++ b/tests/engine/library/storage-catalog.test.ts
@@ -84,7 +84,8 @@ describe('storage library catalog', () => {
     const instance = graph.createInstance(nestedComponent.id, component.id)
     if (!instance) throw new Error('Expected instance')
     setInstanceOverride(instance.instanceOverrides, instance.id, instance.id, 'pluginData', {
-      $map: []
+      $openPencilType: 'openpencil/map',
+      entries: []
     })
 
     const published = await catalog.publishRevision({
@@ -106,7 +107,7 @@ describe('storage library catalog', () => {
         restoredInstance.id,
         'pluginData'
       )
-    ).toEqual({ $map: [] })
+    ).toEqual({ $openPencilType: 'openpencil/map', entries: [] })
   })
 
   test('rejects corrupted revision content', async () => {

--- a/tests/engine/scene-graph/basic/graph.test.ts
+++ b/tests/engine/scene-graph/basic/graph.test.ts
@@ -397,7 +397,12 @@ describe('SceneGraph', () => {
 
     // Override the text on the instance child
     graph.updateNode(instLabel.id, { text: 'Custom' })
-    instance.overrides[`${instLabel.id}:text`] = 'Custom'
+    graph.updateNode(instance.id, {
+      instanceOverrides: {
+        self: new Map(),
+        descendants: new Map([[instLabel.id, new Map([['text', 'Custom']])]])
+      }
+    })
 
     // Change component
     graph.updateNode(graph.getChildren(comp.id)[0].id, { text: 'New Default', fontSize: 20 })

--- a/tests/engine/scene-graph/clone/binding-corruption.test.ts
+++ b/tests/engine/scene-graph/clone/binding-corruption.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { SceneGraph } from '@open-pencil/core'
 import { collectSubtrees } from '@open-pencil/core/editor/clipboard/subtree-history'
+import { createInstanceOverrideState } from '@open-pencil/scene-graph'
 
 function pageId(graph: SceneGraph): string {
   return graph.getPages()[0].id
@@ -77,7 +78,7 @@ describe('cloneTree deep-copies boundVariables, overrides, and styleRuns', () =>
     const graph = new SceneGraph()
     const node = graph.createNode('RECTANGLE', pageId(graph), {
       name: 'Original',
-      overrides: { someKey: 'someValue' }
+      instanceOverrides: createInstanceOverrideState()
     })
     const original = graph.getNode(node.id)
 
@@ -86,7 +87,7 @@ describe('cloneTree deep-copies boundVariables, overrides, and styleRuns', () =>
       (() => {
         throw new Error('clone failed')
       })()
-    expect(clone.overrides).not.toBe(original.overrides)
+    expect(clone.instanceOverrides).not.toBe(original?.instanceOverrides)
   })
 
   test('clone.styleRuns is not the same reference as original', () => {
@@ -229,7 +230,7 @@ describe('instance child bindings are independent from component', () => {
       })()
     const instanceChild = graph.getChildren(instance.id)[0]
 
-    expect(instanceChild.overrides).not.toBe(compChild.overrides)
+    expect(instanceChild.instanceOverrides).not.toBe(compChild.instanceOverrides)
   })
 
   test('instance child source.fig is not shared with component child', () => {

--- a/tests/engine/scene-graph/clone/node-props.test.ts
+++ b/tests/engine/scene-graph/clone/node-props.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 
 import { SceneGraph, type SceneNode } from '@open-pencil/core'
+import { getInstanceOverride, setInstanceOverride } from '@open-pencil/scene-graph'
+import {
+  createInstanceOverrideState,
+  getInstanceOverride,
+  setInstanceOverride
+} from '@open-pencil/scene-graph'
 import { cloneNodeProps } from '@open-pencil/scene-graph/copy'
 
 function pageId(graph: SceneGraph): string {
@@ -119,20 +125,31 @@ describe('cloneNodeProps deep-copies overrides values', () => {
     const instance = graph.createInstance(component.id, page)
     if (!instance) throw new Error('instance failed')
     const instanceChild = graph.getChildren(instance.id)[0]
-    instance.overrides[`${instanceChild.id}:fills`] = [
+    setInstanceOverride(instance.instanceOverrides, instance.id, instanceChild.id, 'fills', [
       { type: 'SOLID', color: { r: 0, g: 0, b: 1, a: 1 }, visible: true, opacity: 1 }
-    ]
+    ])
 
     const clone = graph.cloneTree(instance.id, page)
     if (!clone) throw new Error('clone failed')
     const clonedInstance = graph.getNode(clone.id)
-    const overrideKey = `${instanceChild.id}:fills`
-    const cloneOverrideVal = clonedInstance.overrides[overrideKey] as Array<{
+    const overrideKey = 'fills'
+    const cloneOverrideVal = getInstanceOverride(
+      clonedInstance.instanceOverrides,
+      clonedInstance.id,
+      instanceChild.id,
+      'fills'
+    ) as Array<{
       color: { r: number }
     }>
     if (cloneOverrideVal) cloneOverrideVal[0].color.r = 0.5
 
-    const origOverrideVal = instance.overrides[overrideKey] as Array<{ color: { r: number } }>
+    const origOverrideVal = getInstanceOverride(
+      instance.instanceOverrides,
+      instance.id,
+      instanceChild.id,
+      'fills'
+    ) as Array<{ color: { r: number } }>
+
     if (origOverrideVal) expect(origOverrideVal[0].color.r).toBe(0)
   })
 })
@@ -203,7 +220,7 @@ describe('cloneNodeProps coverage guard', () => {
     const node = graph.createNode('RECTANGLE', page, {
       name: 'Rich node',
       boundVariables: { 'fills/0/color': 'v1' },
-      overrides: { nested: { value: true } },
+      instanceOverrides: { self: new Map(), descendants: new Map() },
       vectorNetwork: {
         vertices: [{ x: 0, y: 0 }],
         segments: [{ start: 0, end: 0, tangentStart: { x: 0, y: 0 }, tangentEnd: { x: 0, y: 0 } }],

--- a/tests/engine/scene-graph/clone/node-props.test.ts
+++ b/tests/engine/scene-graph/clone/node-props.test.ts
@@ -2,11 +2,6 @@ import { describe, expect, test } from 'bun:test'
 
 import { SceneGraph, type SceneNode } from '@open-pencil/core'
 import { getInstanceOverride, setInstanceOverride } from '@open-pencil/scene-graph'
-import {
-  createInstanceOverrideState,
-  getInstanceOverride,
-  setInstanceOverride
-} from '@open-pencil/scene-graph'
 import { cloneNodeProps } from '@open-pencil/scene-graph/copy'
 
 function pageId(graph: SceneGraph): string {
@@ -132,7 +127,6 @@ describe('cloneNodeProps deep-copies overrides values', () => {
     const clone = graph.cloneTree(instance.id, page)
     if (!clone) throw new Error('clone failed')
     const clonedInstance = graph.getNode(clone.id)
-    const overrideKey = 'fills'
     const cloneOverrideVal = getInstanceOverride(
       clonedInstance.instanceOverrides,
       clonedInstance.id,

--- a/tests/engine/scene-graph/components/properties.test.ts
+++ b/tests/engine/scene-graph/components/properties.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   applyComponentPropertyValue,
-  getInstanceOverride,
   componentPropertyDefinitions,
   componentPropertyOwners,
   findComponentPropertyTarget,

--- a/tests/engine/scene-graph/components/properties.test.ts
+++ b/tests/engine/scene-graph/components/properties.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   applyComponentPropertyValue,
+  getInstanceOverride,
   componentPropertyDefinitions,
   componentPropertyOwners,
   findComponentPropertyTarget,
+  forEachInstanceOverride,
   removeComponentProperty,
   resolveComponentPropertyValue,
   SceneGraph
@@ -104,8 +106,18 @@ describe('component properties', () => {
     const updatedInstance = graph.getNode(instance.id)
     expect(updatedInstance?.componentPropertyAssignments['prop:swap']).toBe(alternate.id)
     expect(
-      Object.keys(updatedInstance?.overrides ?? {}).some((key) => key.endsWith(':componentId'))
+      (() => {
+        let found = false
+        forEachInstanceOverride(
+          updatedInstance?.instanceOverrides ?? { self: new Map(), descendants: new Map() },
+          (_nodeId, field) => {
+            if (field === 'componentId') found = true
+          }
+        )
+        return found
+      })()
     ).toBe(true)
+
     const target = findComponentPropertyTarget(graph, instance, 'prop:swap')?.node
     expect(target?.type).toBe('INSTANCE')
     expect(target?.componentId).toBe(alternate.id)

--- a/tests/engine/scene-graph/variable/binding/extended.test.ts
+++ b/tests/engine/scene-graph/variable/binding/extended.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import { SceneGraph } from '@open-pencil/core'
 import { FigmaAPI } from '@open-pencil/core/figma-api'
 import { nodeProxyToJSON } from '@open-pencil/core/figma-api/serialization'
+import { setInstanceOverride } from '@open-pencil/scene-graph'
 
 function pageId(graph: SceneGraph): string {
   return graph.getPages()[0].id
@@ -156,7 +157,7 @@ describe('INSTANCE_SYNC_PROPS includes boundVariables', () => {
     const instanceChild = graph.getChildren(instance.id)[0]
 
     // Set an override to block boundVariables sync
-    instance.overrides[`${instanceChild.id}:boundVariables`] = true
+    setInstanceOverride(instance.instanceOverrides, instance.id, instanceChild.id, 'boundVariables')
 
     // Change component child's binding
     graph.bindVariable(child.id, 'fills/0/color', 'v2')

--- a/tests/engine/scene-graph/variable/binding/instance-override.test.ts
+++ b/tests/engine/scene-graph/variable/binding/instance-override.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
 import { SceneGraph } from '@open-pencil/core'
+import { getInstanceOverride } from '@open-pencil/scene-graph'
 
 function pageId(graph: SceneGraph): string {
   return graph.getPages()[0].id
@@ -78,7 +79,14 @@ describe('bindVariable on instance child sets override flag', () => {
 
     graph.bindVariable(instanceChild.id, 'fills/0/color', 'v2')
 
-    expect(instance.overrides[`${instanceChild.id}:boundVariables`]).toBe(true)
+    expect(
+      getInstanceOverride(
+        instance.instanceOverrides,
+        instance.id,
+        instanceChild.id,
+        'boundVariables'
+      )
+    ).toBe(true)
   })
 
   test('binding on instance child survives syncInstances', () => {
@@ -138,7 +146,9 @@ describe('bindVariable on INSTANCE node itself sets override', () => {
 
     graph.bindVariable(instance.id, 'opacity', 'v2')
 
-    expect(instance.overrides['boundVariables']).toBe(true)
+    expect(
+      getInstanceOverride(instance.instanceOverrides, instance.id, instance.id, 'boundVariables')
+    ).toBe(true)
   })
 
   test('binding on INSTANCE node survives syncInstances', () => {
@@ -223,7 +233,14 @@ describe('removeVariable emits events and sets overrides', () => {
 
     graph.removeVariable('v1')
 
-    expect(instance.overrides[`${instanceChild.id}:boundVariables`]).toBe(true)
+    expect(
+      getInstanceOverride(
+        instance.instanceOverrides,
+        instance.id,
+        instanceChild.id,
+        'boundVariables'
+      )
+    ).toBe(true)
   })
 
   test('removeVariable does not emit for unaffected nodes', () => {

--- a/tests/engine/text/edit-undo.test.ts
+++ b/tests/engine/text/edit-undo.test.ts
@@ -1,11 +1,10 @@
 import { describe, test, expect } from 'bun:test'
 
-import type { CanvasKit } from 'canvaskit-wasm'
-
 import { SceneGraph, TextEditor, UndoManager } from '@open-pencil/core'
 import type { DerivedTextGlyph, StyleRun } from '@open-pencil/core'
 import { createTextActions } from '@open-pencil/core/editor'
 import type { EditorContext, EditorState } from '@open-pencil/core/editor'
+import { getInstanceOverride } from '@open-pencil/scene-graph'
 
 import { fontManager } from '#core/text/fonts'
 
@@ -220,13 +219,27 @@ describe('text edit undo', () => {
     actions.commitTextEdit()
 
     expect(getNodeOrThrow(graph, instanceText.id).text).toBe('')
-    expect(getNodeOrThrow(graph, instance.id).overrides[`${instanceText.id}:text`]).toBe('')
+    expect(
+      getInstanceOverride(
+        getNodeOrThrow(graph, instance.id).instanceOverrides,
+        instance.id,
+        instanceText.id,
+        'text'
+      )
+    ).toBe('')
     graph.syncInstances(component.id)
     expect(getNodeOrThrow(graph, instanceText.id).text).toBe('')
 
     undo.undo()
     expect(getNodeOrThrow(graph, instanceText.id).text).toBe('Confidential')
-    expect(`${instanceText.id}:text` in getNodeOrThrow(graph, instance.id).overrides).toBe(false)
+    expect(
+      getInstanceOverride(
+        getNodeOrThrow(graph, instance.id).instanceOverrides,
+        instance.id,
+        instanceText.id,
+        'text'
+      )
+    ).toBeUndefined()
 
     undo.redo()
     graph.syncInstances(component.id)
@@ -248,7 +261,14 @@ describe('text edit undo', () => {
     })
     actions.commitTextEdit()
 
-    expect(`${instanceText.id}:text` in getNodeOrThrow(graph, instance.id).overrides).toBe(false)
+    expect(
+      getInstanceOverride(
+        getNodeOrThrow(graph, instance.id).instanceOverrides,
+        instance.id,
+        instanceText.id,
+        'text'
+      )
+    ).toBeUndefined()
   })
 
   test('commitTextEdit preserves auto-height text bounds', () => {


### PR DESCRIPTION
## Summary

- Replace `SceneNode.overrides` with structured self/descendant instance override state.
- Centralize override access, mutation, cloning, and traversal helpers.
- Update editor, Design JSX, component-property, variable-binding, and FIG export paths.
- Migrate focused tests to the structured contract.

## Validation

- `bunx tsc -p packages/scene-graph/tsconfig.json --noEmit`
- Focused instance, component-property, text, and FIG tests.
- 61 focused tests pass.

The change keeps one canonical structured instance-override representation across SceneGraph, editor operations, Design JSX, and FIG export. Figma-specific encoding remains at the FIG boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more reliable handling for instance-level and nested property overrides.
  * Improved support for text, fills, visibility, component swaps, and variable overrides.
  * Preserved overrides when copying, using clipboard operations, saving, and restoring designs.

* **Bug Fixes**
  * Improved undo, detachment, synchronization, duplication, and export behavior.
  * Prevented override values from being lost during edits and scene updates.
  * Improved preservation of structured data during storage and library restoration.

* **Tests**
  * Expanded coverage for overrides, cloning, clipboard operations, persistence, exporting, and variable bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->