### PR TITLE
feat: add searchable command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 ### Added
 
 - Add a searchable command palette for editor and application actions.
-
-### Added
-
 - Render triangle and line arrow stroke caps on lines and open vector paths, and choose them from the stroke cap picker.
 - Add a timestamp-faithful pan and zoom benchmark workflow with physical macOS trackpad recording, CDP and DOM replay, Chromium traces, frame-pacing and latency distributions, zoom-anchor drift and viewport-jump detection, retained-backing settlement metrics, and a documented native Instruments acceptance procedure.
 
@@ -557,6 +554,7 @@
 - Fix component property override resolution through clone chains.
 - Fix text/property overrides clobbered by second transitive sync.
 
+
 - Fix text rendering with wrong fonts on file open — all font weights (including default family) are now loaded before the first render.
 - Fix `weightToStyle` mapping: weight 400 now correctly maps to "Regular" instead of "Medium".
 - Fix detached ArrayBuffer crash when switching pages after saving — export worker now copies image buffers before transferring.
@@ -679,6 +677,7 @@
 - Centralize all color utilities in `packages/core/src/color.ts` — `colorToHex8`, `colorToCSSCompact`, `normalizeColor`, `colorDistance`; remove 5 duplicate implementations across the codebase.
 - Add `geometry.ts` with shared rotation math (`degToRad`, `radToDeg`, `rotatePoint`, `rotatedCorners`, `rotatedBBox`).
 - Extract `isArrayMixed()` helper for multi-selection property panels.
+
 
 - Add `motion-v` for declarative animations — used in mobile drawer (spring-animated height with pan gestures) and toolbar (layout-animated category switching with directional slide transitions).
 - Mobile drawer: replace `useSwipe` + manual rAF animation with `motion.div` `:animate` + `@pan`/`@panEnd`; always-on tab state (no more null `activeRibbonTab`); content stays rendered when closed.
@@ -830,14 +829,17 @@
 - Fix font picker dropdown truncating long font names.
 - Show explanation in font picker when Local Font Access API unavailable (Safari/Firefox).
 
+
 - Auto-populate GitHub Release notes from CHANGELOG.md via `ffurrer2/extract-release-notes@v2`.
 - Skip already-published npm versions on CI re-runs instead of failing.
 - Exclude non-app directories from Vite file watcher.
+
 
 - Extract shared color constants (`BLACK`, `TRANSPARENT`, `DEFAULT_SHADOW_COLOR`) — replaces 8 inline literals across core.
 - Extract shared `NodeContextMenuContent` component to avoid menu duplication.
 - Fix `@open-pencil/core` dep in MCP package: `workspace:*` for local dev (pnpm resolves at publish time).
 - Replace store thunks with a late-binding proxy.
+
 
 - Clipboard roundtrip tests: encode to Figma Kiwi binary → decode → verify.
 - 9 visual regression snapshot tests for effects rendering.
@@ -869,6 +871,7 @@
 
 - Import additional properties from Figma clipboard: `layoutAlignSelf`, `clipsContent`, `fontWeight`, `italic`, `letterSpacing`, `lineHeight`.
 - Convert `letterSpacing` PERCENT units to pixels based on font size.
+
 
 - 7 new clipboard import unit tests (14 total).
 
@@ -1009,10 +1012,12 @@ First public alpha. The editor is functional but not production-ready.
 - ScrubInput drag-to-change number controls.
 - Resizable side panels via reka-ui Splitter.
 
+
 - .fig file import via Kiwi binary codec (194 definitions, ~390 fields).
 - .fig file export with Kiwi encoding, Zstd compression, thumbnail generation.
 - Figma clipboard: copy/paste between OpenPencil and Figma.
 - Round-trip fidelity for supported node types.
+
 
 - Built-in AI chat in properties panel (⌘J).
 - Direct browser → OpenRouter communication, no backend.
@@ -1021,9 +1026,11 @@ First public alpha. The editor is functional but not production-ready.
 - Streaming markdown responses (vue-stream-markdown).
 - Tool call timeline with collapsible details.
 
+
 - JSX export of selected nodes with Tailwind-like shorthand props.
 - Syntax highlighting via Prism.js.
 - Copy to clipboard.
+
 
 - `info` — document stats, node types, fonts.
 - `tree` — visual node tree.
@@ -1039,11 +1046,13 @@ First public alpha. The editor is functional but not production-ready.
 - `analyze clusters` — repeated patterns.
 - All commands support `--json`.
 
+
 - Scene graph with flat Map storage and parentIndex tree.
 - FigmaAPI with ~65% Figma plugin API compatibility.
 - JSX renderer (TreeNode builder functions with shorthand props).
 - Kiwi binary codec (encode/decode).
 - Vector network blob encoder/decoder.
+
 
 - Tauri v2 (~5 MB).
 - Native menu bar, save/open dialogs.
@@ -1051,9 +1060,11 @@ First public alpha. The editor is functional but not production-ready.
 - Zstd compression in Rust.
 - macOS and Windows builds via GitHub Actions.
 
+
 - Runs at [app.openpencil.dev](https://app.openpencil.dev).
 - No installation required.
 - File System Access API for save/open (Chrome/Edge), download fallback elsewhere.
+
 
 - [openpencil.dev](https://openpencil.dev) — VitePress site with user guide, reference, and development docs.
 - Deployed via Cloudflare Pages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- Add a searchable command palette for editor and application actions.
+
+### Added
+
 - Render triangle and line arrow stroke caps on lines and open vector paths, and choose them from the stroke cap picker.
 - Add a timestamp-faithful pan and zoom benchmark workflow with physical macOS trackpad recording, CDP and DOM replay, Chromium traces, frame-pacing and latency distributions, zoom-anchor drift and viewport-jump detection, retained-backing settlement metrics, and a documented native Instruments acceptance procedure.
 
@@ -553,7 +557,6 @@
 - Fix component property override resolution through clone chains.
 - Fix text/property overrides clobbered by second transitive sync.
 
-
 - Fix text rendering with wrong fonts on file open — all font weights (including default family) are now loaded before the first render.
 - Fix `weightToStyle` mapping: weight 400 now correctly maps to "Regular" instead of "Medium".
 - Fix detached ArrayBuffer crash when switching pages after saving — export worker now copies image buffers before transferring.
@@ -676,7 +679,6 @@
 - Centralize all color utilities in `packages/core/src/color.ts` — `colorToHex8`, `colorToCSSCompact`, `normalizeColor`, `colorDistance`; remove 5 duplicate implementations across the codebase.
 - Add `geometry.ts` with shared rotation math (`degToRad`, `radToDeg`, `rotatePoint`, `rotatedCorners`, `rotatedBBox`).
 - Extract `isArrayMixed()` helper for multi-selection property panels.
-
 
 - Add `motion-v` for declarative animations — used in mobile drawer (spring-animated height with pan gestures) and toolbar (layout-animated category switching with directional slide transitions).
 - Mobile drawer: replace `useSwipe` + manual rAF animation with `motion.div` `:animate` + `@pan`/`@panEnd`; always-on tab state (no more null `activeRibbonTab`); content stays rendered when closed.
@@ -828,17 +830,14 @@
 - Fix font picker dropdown truncating long font names.
 - Show explanation in font picker when Local Font Access API unavailable (Safari/Firefox).
 
-
 - Auto-populate GitHub Release notes from CHANGELOG.md via `ffurrer2/extract-release-notes@v2`.
 - Skip already-published npm versions on CI re-runs instead of failing.
 - Exclude non-app directories from Vite file watcher.
-
 
 - Extract shared color constants (`BLACK`, `TRANSPARENT`, `DEFAULT_SHADOW_COLOR`) — replaces 8 inline literals across core.
 - Extract shared `NodeContextMenuContent` component to avoid menu duplication.
 - Fix `@open-pencil/core` dep in MCP package: `workspace:*` for local dev (pnpm resolves at publish time).
 - Replace store thunks with a late-binding proxy.
-
 
 - Clipboard roundtrip tests: encode to Figma Kiwi binary → decode → verify.
 - 9 visual regression snapshot tests for effects rendering.
@@ -870,7 +869,6 @@
 
 - Import additional properties from Figma clipboard: `layoutAlignSelf`, `clipsContent`, `fontWeight`, `italic`, `letterSpacing`, `lineHeight`.
 - Convert `letterSpacing` PERCENT units to pixels based on font size.
-
 
 - 7 new clipboard import unit tests (14 total).
 
@@ -1011,12 +1009,10 @@ First public alpha. The editor is functional but not production-ready.
 - ScrubInput drag-to-change number controls.
 - Resizable side panels via reka-ui Splitter.
 
-
 - .fig file import via Kiwi binary codec (194 definitions, ~390 fields).
 - .fig file export with Kiwi encoding, Zstd compression, thumbnail generation.
 - Figma clipboard: copy/paste between OpenPencil and Figma.
 - Round-trip fidelity for supported node types.
-
 
 - Built-in AI chat in properties panel (⌘J).
 - Direct browser → OpenRouter communication, no backend.
@@ -1025,11 +1021,9 @@ First public alpha. The editor is functional but not production-ready.
 - Streaming markdown responses (vue-stream-markdown).
 - Tool call timeline with collapsible details.
 
-
 - JSX export of selected nodes with Tailwind-like shorthand props.
 - Syntax highlighting via Prism.js.
 - Copy to clipboard.
-
 
 - `info` — document stats, node types, fonts.
 - `tree` — visual node tree.
@@ -1045,13 +1039,11 @@ First public alpha. The editor is functional but not production-ready.
 - `analyze clusters` — repeated patterns.
 - All commands support `--json`.
 
-
 - Scene graph with flat Map storage and parentIndex tree.
 - FigmaAPI with ~65% Figma plugin API compatibility.
 - JSX renderer (TreeNode builder functions with shorthand props).
 - Kiwi binary codec (encode/decode).
 - Vector network blob encoder/decoder.
-
 
 - Tauri v2 (~5 MB).
 - Native menu bar, save/open dialogs.
@@ -1059,11 +1051,9 @@ First public alpha. The editor is functional but not production-ready.
 - Zstd compression in Rust.
 - macOS and Windows builds via GitHub Actions.
 
-
 - Runs at [app.openpencil.dev](https://app.openpencil.dev).
 - No installation required.
 - File System Access API for save/open (Chrome/Edge), download fallback elsewhere.
-
 
 - [openpencil.dev](https://openpencil.dev) — VitePress site with user guide, reference, and development docs.
 - Deployed via Cloudflare Pages.

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,6 @@
         "dedent": "^1.7.2",
         "es-toolkit": "^1.51.0",
         "fflate": "^0.8.3",
-        "fuse.js": "7.5.0",
         "fzstd": "^0.1.1",
         "hast-util-to-html": "^9.0.5",
         "idb": "^8.0.3",

--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
         "dedent": "^1.7.2",
         "es-toolkit": "^1.51.0",
         "fflate": "^0.8.3",
+        "fuse.js": "7.5.0",
         "fzstd": "^0.1.1",
         "hast-util-to-html": "^9.0.5",
         "idb": "^8.0.3",
@@ -352,6 +353,7 @@
         "@open-pencil/scene-graph": "workspace:*",
         "@tanstack/vue-table": "^8.21.3",
         "@vueuse/core": "^14.4.0",
+        "fuse.js": "^7.5.0",
         "nanostores": "^1.5.0",
         "reka-ui": "^2.10.3",
       },
@@ -2758,6 +2760,8 @@
     "function.prototype.name": ["function.prototype.name@1.2.0", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2", "hasown": "^2.0.4", "is-callable": "^1.2.7", "is-document.all": "^1.0.0" } }, "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew=="],
 
     "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
+
+    "fuse.js": ["fuse.js@7.5.0", "", {}, "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow=="],
 
     "fzstd": ["fzstd@0.1.1", "", {}, "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA=="],
 

--- a/package.json
+++ b/package.json
@@ -209,9 +209,9 @@
     "ws": "^8.21.3"
   },
   "overrides": {
-    "@codemirror/view": "6.43.9",
     "protobufjs": "7.5.5",
-    "websocket-driver": "0.7.5"
+    "websocket-driver": "0.7.5",
+    "@codemirror/view": "6.43.9"
   },
   "packageManager": "bun@1.3.10"
 }

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "dedent": "^1.7.2",
     "es-toolkit": "^1.51.0",
     "fflate": "^0.8.3",
+    "fuse.js": "7.5.0",
     "fzstd": "^0.1.1",
     "hast-util-to-html": "^9.0.5",
     "idb": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "dedent": "^1.7.2",
     "es-toolkit": "^1.51.0",
     "fflate": "^0.8.3",
-    "fuse.js": "7.5.0",
     "fzstd": "^0.1.1",
     "hast-util-to-html": "^9.0.5",
     "idb": "^8.0.3",
@@ -210,9 +209,9 @@
     "ws": "^8.21.3"
   },
   "overrides": {
+    "@codemirror/view": "6.43.9",
     "protobufjs": "7.5.5",
-    "websocket-driver": "0.7.5",
-    "@codemirror/view": "6.43.9"
+    "websocket-driver": "0.7.5"
   },
   "packageManager": "bun@1.3.10"
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,7 +2,19 @@
   "name": "@open-pencil/vue",
   "version": "0.14.0",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-pencil/open-pencil.git",
+    "directory": "packages/vue"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -10,35 +22,13 @@
       "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "sideEffects": false,
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "scripts": {
-    "build": "bunx tsdown --config tsdown.config.ts",
-    "prepack": "bun run build"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/open-pencil/open-pencil.git",
-    "directory": "packages/vue"
-  },
   "publishConfig": {
     "access": "public",
     "provenance": true
   },
-  "peerDependencies": {
-    "@open-pencil/core": "workspace:*",
-    "canvaskit-wasm": ">=0.41.1",
-    "vue": "^3.5.41"
-  },
-  "peerDependenciesMeta": {
-    "canvaskit-wasm": {
-      "optional": true
-    }
+  "scripts": {
+    "build": "bunx tsdown --config tsdown.config.ts",
+    "prepack": "bun run build"
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.8.1",
@@ -56,5 +46,15 @@
     "tsdown": "^0.22.14",
     "unplugin-raw": "^0.7.0",
     "unplugin-vue": "^7.2.0"
+  },
+  "peerDependencies": {
+    "@open-pencil/core": "workspace:*",
+    "canvaskit-wasm": ">=0.41.1",
+    "vue": "^3.5.41"
+  },
+  "peerDependenciesMeta": {
+    "canvaskit-wasm": {
+      "optional": true
+    }
   }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -48,6 +48,7 @@
     "@open-pencil/scene-graph": "workspace:*",
     "@tanstack/vue-table": "^8.21.3",
     "@vueuse/core": "^14.4.0",
+    "fuse.js": "^7.5.0",
     "nanostores": "^1.5.0",
     "reka-ui": "^2.10.3"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,19 +2,7 @@
   "name": "@open-pencil/vue",
   "version": "0.14.0",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/open-pencil/open-pencil.git",
-    "directory": "packages/vue"
-  },
-  "files": [
-    "dist",
-    "README.md"
-  ],
   "type": "module",
-  "sideEffects": false,
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -22,13 +10,35 @@
       "default": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "bunx tsdown --config tsdown.config.ts",
+    "prepack": "bun run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-pencil/open-pencil.git",
+    "directory": "packages/vue"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true
   },
-  "scripts": {
-    "build": "bunx tsdown --config tsdown.config.ts",
-    "prepack": "bun run build"
+  "peerDependencies": {
+    "@open-pencil/core": "workspace:*",
+    "canvaskit-wasm": ">=0.41.1",
+    "vue": "^3.5.41"
+  },
+  "peerDependenciesMeta": {
+    "canvaskit-wasm": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.8.1",
@@ -46,15 +56,5 @@
     "tsdown": "^0.22.14",
     "unplugin-raw": "^0.7.0",
     "unplugin-vue": "^7.2.0"
-  },
-  "peerDependencies": {
-    "@open-pencil/core": "workspace:*",
-    "canvaskit-wasm": ">=0.41.1",
-    "vue": "^3.5.41"
-  },
-  "peerDependenciesMeta": {
-    "canvaskit-wasm": {
-      "optional": true
-    }
   }
 }

--- a/packages/vue/src/editor/menu-model/types.ts
+++ b/packages/vue/src/editor/menu-model/types.ts
@@ -10,6 +10,7 @@ export interface MenuActionNode {
   label: string
   icon?: Component
   shortcut?: string
+  paletteShortcut?: string
   action?: () => void
   disabled?: boolean
   testId?: TestId

--- a/packages/vue/src/editor/menu-model/types.ts
+++ b/packages/vue/src/editor/menu-model/types.ts
@@ -5,6 +5,7 @@ import type { TestId } from '#vue/testing/test-id'
 
 export interface MenuActionNode {
   separator?: false
+  menuId?: string
   id?: EditorCommandId
   label: string
   icon?: Component

--- a/packages/vue/src/editor/menu-model/types.ts
+++ b/packages/vue/src/editor/menu-model/types.ts
@@ -14,6 +14,12 @@ export interface MenuActionNode {
   testId?: TestId
   checked?: boolean
   onCheckedChange?: (checked: boolean) => void
+  palette?: {
+    icon?: Component
+    label?: string
+    description?: string
+    keywords?: string[]
+  }
   sub?: MenuEntry[]
 }
 

--- a/packages/vue/src/i18n/locales/de/commands.json
+++ b/packages/vue/src/i18n/locales/de/commands.json
@@ -39,5 +39,10 @@
   "distributeHorizontal": "Horizontalen Abstand verteilen",
   "distributeVertical": "Vertikalen Abstand verteilen",
   "selectInverse": "Auswahl umkehren",
-  "sendBackward": "Nach hinten"
+  "sendBackward": "Nach hinten",
+  "paletteSearchPlaceholder": "Befehl eingeben oder suchen…",
+  "paletteAriaLabel": "Befehlspalette",
+  "paletteSearchAriaLabel": "Befehle suchen",
+  "paletteDescription": "OpenPencil-Befehle suchen und ausführen.",
+  "paletteNoCommands": "Keine Befehle gefunden."
 }

--- a/packages/vue/src/i18n/locales/de/commands.json
+++ b/packages/vue/src/i18n/locales/de/commands.json
@@ -44,5 +44,6 @@
   "paletteAriaLabel": "Befehlspalette",
   "paletteSearchAriaLabel": "Befehle suchen",
   "paletteDescription": "OpenPencil-Befehle suchen und ausführen.",
-  "paletteNoCommands": "Keine Befehle gefunden."
+  "paletteNoCommands": "Keine Befehle gefunden.",
+  "paletteBack": "Zurück"
 }

--- a/packages/vue/src/i18n/locales/de/menu.json
+++ b/packages/vue/src/i18n/locales/de/menu.json
@@ -66,5 +66,9 @@
   "splitRight": "Nach rechts teilen",
   "splitDown": "Nach unten teilen",
   "closeView": "Ansicht schließen",
-  "removeGuide": "Hilfslinie entfernen"
+  "removeGuide": "Hilfslinie entfernen",
+  "exportSelectionAsPNG": "Auswahl als PNG exportieren",
+  "exportSelectionAsSVG": "Auswahl als SVG exportieren",
+  "exportSelectionAsPPTX": "Auswahl als PPTX exportieren",
+  "exportSelectionAsFig": "Auswahl als .fig exportieren"
 }

--- a/packages/vue/src/i18n/locales/es/commands.json
+++ b/packages/vue/src/i18n/locales/es/commands.json
@@ -39,5 +39,10 @@
   "distributeHorizontal": "Distribuir espacio horizontal",
   "distributeVertical": "Distribuir espacio vertical",
   "selectInverse": "Invertir selección",
-  "sendBackward": "Atrasar"
+  "sendBackward": "Atrasar",
+  "paletteSearchPlaceholder": "Escribe un comando o busca…",
+  "paletteAriaLabel": "Paleta de comandos",
+  "paletteSearchAriaLabel": "Buscar comandos",
+  "paletteDescription": "Busca y ejecuta comandos de OpenPencil.",
+  "paletteNoCommands": "No se encontraron comandos."
 }

--- a/packages/vue/src/i18n/locales/es/commands.json
+++ b/packages/vue/src/i18n/locales/es/commands.json
@@ -44,5 +44,6 @@
   "paletteAriaLabel": "Paleta de comandos",
   "paletteSearchAriaLabel": "Buscar comandos",
   "paletteDescription": "Busca y ejecuta comandos de OpenPencil.",
-  "paletteNoCommands": "No se encontraron comandos."
+  "paletteNoCommands": "No se encontraron comandos.",
+  "paletteBack": "Atrás"
 }

--- a/packages/vue/src/i18n/locales/es/menu.json
+++ b/packages/vue/src/i18n/locales/es/menu.json
@@ -66,5 +66,9 @@
   "splitRight": "Dividir a la derecha",
   "splitDown": "Dividir hacia abajo",
   "closeView": "Cerrar vista",
-  "removeGuide": "Eliminar guía"
+  "removeGuide": "Eliminar guía",
+  "exportSelectionAsPNG": "Exportar selección como PNG",
+  "exportSelectionAsSVG": "Exportar selección como SVG",
+  "exportSelectionAsPPTX": "Exportar selección como PPTX",
+  "exportSelectionAsFig": "Exportar selección como .fig"
 }

--- a/packages/vue/src/i18n/locales/fr/commands.json
+++ b/packages/vue/src/i18n/locales/fr/commands.json
@@ -44,5 +44,6 @@
   "paletteAriaLabel": "Palette de commandes",
   "paletteSearchAriaLabel": "Rechercher des commandes",
   "paletteDescription": "Rechercher et exécuter des commandes OpenPencil.",
-  "paletteNoCommands": "Aucune commande trouvée."
+  "paletteNoCommands": "Aucune commande trouvée.",
+  "paletteBack": "Retour"
 }

--- a/packages/vue/src/i18n/locales/fr/commands.json
+++ b/packages/vue/src/i18n/locales/fr/commands.json
@@ -39,5 +39,10 @@
   "distributeHorizontal": "Répartir l’espacement horizontal",
   "distributeVertical": "Répartir l’espacement vertical",
   "selectInverse": "Inverser la sélection",
-  "sendBackward": "Reculer"
+  "sendBackward": "Reculer",
+  "paletteSearchPlaceholder": "Saisissez une commande ou recherchez…",
+  "paletteAriaLabel": "Palette de commandes",
+  "paletteSearchAriaLabel": "Rechercher des commandes",
+  "paletteDescription": "Rechercher et exécuter des commandes OpenPencil.",
+  "paletteNoCommands": "Aucune commande trouvée."
 }

--- a/packages/vue/src/i18n/locales/fr/menu.json
+++ b/packages/vue/src/i18n/locales/fr/menu.json
@@ -66,5 +66,9 @@
   "splitRight": "Diviser à droite",
   "splitDown": "Diviser vers le bas",
   "closeView": "Fermer la vue",
-  "removeGuide": "Supprimer le repère"
+  "removeGuide": "Supprimer le repère",
+  "exportSelectionAsPNG": "Exporter la sélection en PNG",
+  "exportSelectionAsSVG": "Exporter la sélection en SVG",
+  "exportSelectionAsPPTX": "Exporter la sélection en PPTX",
+  "exportSelectionAsFig": "Exporter la sélection en .fig"
 }

--- a/packages/vue/src/i18n/locales/it/commands.json
+++ b/packages/vue/src/i18n/locales/it/commands.json
@@ -44,5 +44,6 @@
   "paletteAriaLabel": "Tavolozza dei comandi",
   "paletteSearchAriaLabel": "Cerca comandi",
   "paletteDescription": "Cerca ed esegui i comandi di OpenPencil.",
-  "paletteNoCommands": "Nessun comando trovato."
+  "paletteNoCommands": "Nessun comando trovato.",
+  "paletteBack": "Indietro"
 }

--- a/packages/vue/src/i18n/locales/it/commands.json
+++ b/packages/vue/src/i18n/locales/it/commands.json
@@ -39,5 +39,10 @@
   "distributeHorizontal": "Distribuisci spaziatura orizzontale",
   "distributeVertical": "Distribuisci spaziatura verticale",
   "selectInverse": "Inverti selezione",
-  "sendBackward": "Porta indietro"
+  "sendBackward": "Porta indietro",
+  "paletteSearchPlaceholder": "Digita un comando o cerca…",
+  "paletteAriaLabel": "Tavolozza dei comandi",
+  "paletteSearchAriaLabel": "Cerca comandi",
+  "paletteDescription": "Cerca ed esegui i comandi di OpenPencil.",
+  "paletteNoCommands": "Nessun comando trovato."
 }

--- a/packages/vue/src/i18n/locales/it/menu.json
+++ b/packages/vue/src/i18n/locales/it/menu.json
@@ -66,5 +66,9 @@
   "splitRight": "Dividi a destra",
   "splitDown": "Dividi in basso",
   "closeView": "Chiudi vista",
-  "removeGuide": "Rimuovi guida"
+  "removeGuide": "Rimuovi guida",
+  "exportSelectionAsPNG": "Esporta selezione come PNG",
+  "exportSelectionAsSVG": "Esporta selezione come SVG",
+  "exportSelectionAsPPTX": "Esporta selezione come PPTX",
+  "exportSelectionAsFig": "Esporta selezione come .fig"
 }

--- a/packages/vue/src/i18n/locales/ja/commands.json
+++ b/packages/vue/src/i18n/locales/ja/commands.json
@@ -44,5 +44,6 @@
   "paletteAriaLabel": "コマンドパレット",
   "paletteSearchAriaLabel": "コマンドを検索",
   "paletteDescription": "OpenPencil のコマンドを検索して実行します。",
-  "paletteNoCommands": "コマンドが見つかりません。"
+  "paletteNoCommands": "コマンドが見つかりません。",
+  "paletteBack": "戻る"
 }

--- a/packages/vue/src/i18n/locales/ja/commands.json
+++ b/packages/vue/src/i18n/locales/ja/commands.json
@@ -39,5 +39,10 @@
   "distributeHorizontal": "水平方向の間隔を均等に配置",
   "distributeVertical": "垂直方向の間隔を均等に配置",
   "selectInverse": "選択範囲を反転",
-  "sendBackward": "背面へ移動"
+  "sendBackward": "背面へ移動",
+  "paletteSearchPlaceholder": "コマンドを入力または検索…",
+  "paletteAriaLabel": "コマンドパレット",
+  "paletteSearchAriaLabel": "コマンドを検索",
+  "paletteDescription": "OpenPencil のコマンドを検索して実行します。",
+  "paletteNoCommands": "コマンドが見つかりません。"
 }

--- a/packages/vue/src/i18n/locales/ja/menu.json
+++ b/packages/vue/src/i18n/locales/ja/menu.json
@@ -66,5 +66,9 @@
   "splitRight": "右に分割",
   "splitDown": "下に分割",
   "closeView": "ビューを閉じる",
-  "removeGuide": "ガイドを削除"
+  "removeGuide": "ガイドを削除",
+  "exportSelectionAsPNG": "選択範囲を PNG としてエクスポート",
+  "exportSelectionAsSVG": "選択範囲を SVG としてエクスポート",
+  "exportSelectionAsPPTX": "選択範囲を PPTX としてエクスポート",
+  "exportSelectionAsFig": "選択範囲を .fig としてエクスポート"
 }

--- a/packages/vue/src/i18n/locales/pl/commands.json
+++ b/packages/vue/src/i18n/locales/pl/commands.json
@@ -39,5 +39,10 @@
   "distributeHorizontal": "Rozłóż odstępy w poziomie",
   "distributeVertical": "Rozłóż odstępy w pionie",
   "selectInverse": "Odwróć zaznaczenie",
-  "sendBackward": "Przesuń do tyłu"
+  "sendBackward": "Przesuń do tyłu",
+  "paletteSearchPlaceholder": "Wpisz polecenie lub wyszukaj…",
+  "paletteAriaLabel": "Paleta poleceń",
+  "paletteSearchAriaLabel": "Szukaj poleceń",
+  "paletteDescription": "Wyszukuj i uruchamiaj polecenia OpenPencil.",
+  "paletteNoCommands": "Nie znaleziono poleceń."
 }

--- a/packages/vue/src/i18n/locales/pl/commands.json
+++ b/packages/vue/src/i18n/locales/pl/commands.json
@@ -44,5 +44,6 @@
   "paletteAriaLabel": "Paleta poleceń",
   "paletteSearchAriaLabel": "Szukaj poleceń",
   "paletteDescription": "Wyszukuj i uruchamiaj polecenia OpenPencil.",
-  "paletteNoCommands": "Nie znaleziono poleceń."
+  "paletteNoCommands": "Nie znaleziono poleceń.",
+  "paletteBack": "Wstecz"
 }

--- a/packages/vue/src/i18n/locales/pl/menu.json
+++ b/packages/vue/src/i18n/locales/pl/menu.json
@@ -66,5 +66,9 @@
   "splitRight": "Podziel w prawo",
   "splitDown": "Podziel w dół",
   "closeView": "Zamknij widok",
-  "removeGuide": "Usuń prowadnicę"
+  "removeGuide": "Usuń prowadnicę",
+  "exportSelectionAsPNG": "Eksportuj zaznaczenie jako PNG",
+  "exportSelectionAsSVG": "Eksportuj zaznaczenie jako SVG",
+  "exportSelectionAsPPTX": "Eksportuj zaznaczenie jako PPTX",
+  "exportSelectionAsFig": "Eksportuj zaznaczenie jako .fig"
 }

--- a/packages/vue/src/i18n/locales/ru/commands.json
+++ b/packages/vue/src/i18n/locales/ru/commands.json
@@ -39,5 +39,10 @@
   "distributeHorizontal": "Распределить интервалы по горизонтали",
   "distributeVertical": "Распределить интервалы по вертикали",
   "selectInverse": "Инвертировать выделение",
-  "sendBackward": "Переместить назад"
+  "sendBackward": "Переместить назад",
+  "paletteSearchPlaceholder": "Type a command or search…",
+  "paletteAriaLabel": "Command palette",
+  "paletteSearchAriaLabel": "Search commands",
+  "paletteDescription": "Search and run OpenPencil commands.",
+  "paletteNoCommands": "No commands found."
 }

--- a/packages/vue/src/i18n/locales/ru/commands.json
+++ b/packages/vue/src/i18n/locales/ru/commands.json
@@ -40,10 +40,10 @@
   "distributeVertical": "Распределить интервалы по вертикали",
   "selectInverse": "Инвертировать выделение",
   "sendBackward": "Переместить назад",
-  "paletteSearchPlaceholder": "Type a command or search…",
-  "paletteAriaLabel": "Command palette",
-  "paletteSearchAriaLabel": "Search commands",
-  "paletteDescription": "Search and run OpenPencil commands.",
-  "paletteNoCommands": "No commands found.",
+  "paletteSearchPlaceholder": "Введите команду или выполните поиск…",
+  "paletteAriaLabel": "Палитра команд",
+  "paletteSearchAriaLabel": "Поиск команд",
+  "paletteDescription": "Поиск и выполнение команд OpenPencil.",
+  "paletteNoCommands": "Команды не найдены.",
   "paletteBack": "Назад"
 }

--- a/packages/vue/src/i18n/locales/ru/commands.json
+++ b/packages/vue/src/i18n/locales/ru/commands.json
@@ -44,5 +44,6 @@
   "paletteAriaLabel": "Command palette",
   "paletteSearchAriaLabel": "Search commands",
   "paletteDescription": "Search and run OpenPencil commands.",
-  "paletteNoCommands": "No commands found."
+  "paletteNoCommands": "No commands found.",
+  "paletteBack": "Назад"
 }

--- a/packages/vue/src/i18n/locales/ru/menu.json
+++ b/packages/vue/src/i18n/locales/ru/menu.json
@@ -66,5 +66,9 @@
   "splitRight": "Разделить вправо",
   "splitDown": "Разделить вниз",
   "closeView": "Закрыть вид",
-  "removeGuide": "Удалить направляющую"
+  "removeGuide": "Удалить направляющую",
+  "exportSelectionAsPNG": "Экспортировать выделение как PNG",
+  "exportSelectionAsSVG": "Экспортировать выделение как SVG",
+  "exportSelectionAsPPTX": "Экспортировать выделение как PPTX",
+  "exportSelectionAsFig": "Экспортировать выделение как .fig"
 }

--- a/packages/vue/src/i18n/locales/zh-cn/commands.json
+++ b/packages/vue/src/i18n/locales/zh-cn/commands.json
@@ -44,5 +44,6 @@
   "paletteAriaLabel": "命令面板",
   "paletteSearchAriaLabel": "搜索命令",
   "paletteDescription": "搜索并运行 OpenPencil 命令。",
-  "paletteNoCommands": "未找到命令。"
+  "paletteNoCommands": "未找到命令。",
+  "paletteBack": "返回"
 }

--- a/packages/vue/src/i18n/locales/zh-cn/commands.json
+++ b/packages/vue/src/i18n/locales/zh-cn/commands.json
@@ -39,5 +39,10 @@
   "distributeHorizontal": "水平等距分布",
   "distributeVertical": "垂直等距分布",
   "selectInverse": "反向选择",
-  "sendBackward": "下移一层"
+  "sendBackward": "下移一层",
+  "paletteSearchPlaceholder": "输入命令或搜索…",
+  "paletteAriaLabel": "命令面板",
+  "paletteSearchAriaLabel": "搜索命令",
+  "paletteDescription": "搜索并运行 OpenPencil 命令。",
+  "paletteNoCommands": "未找到命令。"
 }

--- a/packages/vue/src/i18n/locales/zh-cn/menu.json
+++ b/packages/vue/src/i18n/locales/zh-cn/menu.json
@@ -66,5 +66,9 @@
   "splitRight": "向右拆分",
   "splitDown": "向下拆分",
   "closeView": "关闭视图",
-  "removeGuide": "移除参考线"
+  "removeGuide": "移除参考线",
+  "exportSelectionAsPNG": "将所选内容导出为 PNG",
+  "exportSelectionAsSVG": "将所选内容导出为 SVG",
+  "exportSelectionAsPPTX": "将所选内容导出为 PPTX",
+  "exportSelectionAsFig": "将所选内容导出为 .fig"
 }

--- a/packages/vue/src/i18n/messages/commands.ts
+++ b/packages/vue/src/i18n/messages/commands.ts
@@ -41,7 +41,12 @@ export const commandMessageDefaults = {
   setOpacity: 'Set opacity',
   zoomTo100: 'Zoom to 100%',
   zoomToFit: 'Zoom to fit',
-  zoomToSelection: 'Zoom to selection'
+  zoomToSelection: 'Zoom to selection',
+  paletteSearchPlaceholder: 'Type a command or search…',
+  paletteAriaLabel: 'Command palette',
+  paletteSearchAriaLabel: 'Search commands',
+  paletteDescription: 'Search and run OpenPencil commands.',
+  paletteNoCommands: 'No commands found.'
 } as const
 
 export const commandMessages = i18n('commands', commandMessageDefaults)

--- a/packages/vue/src/i18n/messages/commands.ts
+++ b/packages/vue/src/i18n/messages/commands.ts
@@ -46,7 +46,8 @@ export const commandMessageDefaults = {
   paletteAriaLabel: 'Command palette',
   paletteSearchAriaLabel: 'Search commands',
   paletteDescription: 'Search and run OpenPencil commands.',
-  paletteNoCommands: 'No commands found.'
+  paletteNoCommands: 'No commands found.',
+  paletteBack: 'Back'
 } as const
 
 export const commandMessages = i18n('commands', commandMessageDefaults)

--- a/packages/vue/src/i18n/messages/menu.ts
+++ b/packages/vue/src/i18n/messages/menu.ts
@@ -14,6 +14,10 @@ export const menuMessageDefaults = {
   save: 'Save',
   saveAs: 'Save as…',
   exportSelection: 'Export selection…',
+  exportSelectionAsPNG: 'Export selection as PNG',
+  exportSelectionAsSVG: 'Export selection as SVG',
+  exportSelectionAsPPTX: 'Export selection as PPTX',
+  exportSelectionAsFig: 'Export selection as .fig',
   autosave: 'Auto-save to local file',
   closeTab: 'Close tab',
 

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -35,7 +35,7 @@ export { useEditorEvent } from '#vue/editor/events/use'
 export { useSelectionCapabilities } from '#vue/editor/selection-capabilities/use'
 
 /** Command palette primitives and search state. */
-export { CommandPaletteRoot, useCommandPaletteContext } from '#vue/primitives/CommandPalette'
+export { CommandPaletteRoot } from '#vue/primitives/CommandPalette'
 export type {
   CommandPaletteGroup,
   CommandPaletteItem,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -34,7 +34,16 @@ export { useSelectionState } from '#vue/editor/selection-state/use'
 export { useEditorEvent } from '#vue/editor/events/use'
 export { useSelectionCapabilities } from '#vue/editor/selection-capabilities/use'
 
-/** Command and menu composition helpers. */
+/** Command palette primitives and search state. */
+export { CommandPaletteRoot, useCommandPalette } from '#vue/primitives/CommandPalette'
+export type {
+  CommandPaletteGroup,
+  CommandPaletteItem,
+  CommandPaletteShortcut,
+  CommandPaletteUI,
+  UseCommandPaletteOptions
+} from '#vue/primitives/CommandPalette'
+
 export { useEditorCommands } from '#vue/editor/commands/use'
 export { EDITOR_COMMAND_METADATA, editorCommandMetadata } from '#vue/editor/commands/registry'
 export { formatShortcut, shortcutPlatform } from '#vue/editor/commands/shortcut'

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -35,11 +35,12 @@ export { useEditorEvent } from '#vue/editor/events/use'
 export { useSelectionCapabilities } from '#vue/editor/selection-capabilities/use'
 
 /** Command palette primitives and search state. */
-export { CommandPaletteRoot, useCommandPalette } from '#vue/primitives/CommandPalette'
+export { CommandPaletteRoot, useCommandPaletteContext } from '#vue/primitives/CommandPalette'
 export type {
   CommandPaletteGroup,
   CommandPaletteItem,
   CommandPaletteShortcut,
+  CommandPaletteLabels,
   CommandPaletteUI,
   UseCommandPaletteOptions
 } from '#vue/primitives/CommandPalette'

--- a/packages/vue/src/primitives/CommandPalette/CommandPalette.stories.ts
+++ b/packages/vue/src/primitives/CommandPalette/CommandPalette.stories.ts
@@ -36,5 +36,13 @@ export const Interaction: Story = {
     await expect(canvas.getByRole('status', { name: 'Last selection' })).toHaveTextContent(
       'Settings'
     )
+
+    await userEvent.clear(input)
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}{Enter}')
+    await expect(canvas.getByRole('button', { name: 'Export selection' })).toBeVisible()
+    await userEvent.click(canvas.getByRole('button', { name: 'Export selection' }))
+    await expect(canvas.getByText('Export selection as PNG')).toBeVisible()
+    await userEvent.keyboard('{Backspace}')
+    await expect(canvas.getByRole('button', { name: 'Export selection' })).toBeVisible()
   }
 }

--- a/packages/vue/src/primitives/CommandPalette/CommandPalette.stories.ts
+++ b/packages/vue/src/primitives/CommandPalette/CommandPalette.stories.ts
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { expect, userEvent, within } from 'storybook/test'
+
+import CommandPaletteDemo from './CommandPaletteDemo.vue'
+
+const meta = {
+  title: 'Vue SDK/Primitives/Command Palette',
+  component: CommandPaletteDemo,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'Headless searchable command list built on Reka UI Listbox primitives.'
+      }
+    }
+  }
+} satisfies Meta<typeof CommandPaletteDemo>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Interaction: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByRole('searchbox', { name: 'Command palette' })
+
+    await userEvent.click(input)
+    await userEvent.type(input, 'setting')
+    await expect(canvas.getByRole('option', { name: /Settings/ })).toBeVisible()
+    await expect(canvas.queryByRole('option', { name: 'Undo' })).not.toBeInTheDocument()
+
+    await userEvent.clear(input)
+    await userEvent.keyboard('{ArrowDown}{Enter}')
+    await expect(canvas.getByRole('status', { name: 'Last selection' })).toHaveTextContent(
+      'Settings'
+    )
+  }
+}

--- a/packages/vue/src/primitives/CommandPalette/CommandPalette.stories.ts
+++ b/packages/vue/src/primitives/CommandPalette/CommandPalette.stories.ts
@@ -24,25 +24,23 @@ export const Default: Story = {}
 export const Interaction: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
-    const input = canvas.getByRole('searchbox', { name: 'Command palette' })
+    const input = canvas.getByRole('searchbox', { name: 'Search commands' })
 
     await userEvent.click(input)
     await userEvent.type(input, 'setting')
     await expect(canvas.getByRole('option', { name: /Settings/ })).toBeVisible()
     await expect(canvas.queryByRole('option', { name: 'Undo' })).not.toBeInTheDocument()
 
-    await userEvent.clear(input)
-    await userEvent.keyboard('{ArrowDown}{Enter}')
+    await userEvent.click(canvas.getByRole('option', { name: /Settings/ }))
     await expect(canvas.getByRole('status', { name: 'Last selection' })).toHaveTextContent(
       'Settings'
     )
 
     await userEvent.clear(input)
-    await userEvent.keyboard('{ArrowDown}{ArrowDown}{Enter}')
-    await expect(canvas.getByRole('button', { name: 'Export selection' })).toBeVisible()
-    await userEvent.click(canvas.getByRole('button', { name: 'Export selection' }))
+    await userEvent.click(canvas.getByRole('option', { name: 'Export selection' }))
     await expect(canvas.getByText('Export selection as PNG')).toBeVisible()
+    await userEvent.click(input)
     await userEvent.keyboard('{Backspace}')
-    await expect(canvas.getByRole('button', { name: 'Export selection' })).toBeVisible()
+    await expect(canvas.getByRole('option', { name: 'Export selection' })).toBeVisible()
   }
 }

--- a/packages/vue/src/primitives/CommandPalette/CommandPaletteDemo.vue
+++ b/packages/vue/src/primitives/CommandPalette/CommandPaletteDemo.vue
@@ -6,6 +6,13 @@ import type { CommandPaletteGroup } from './types'
 
 const selected = ref('')
 const selectedLabels = ref<string[]>([])
+const labels = {
+  searchPlaceholder: 'Search commands…',
+  searchLabel: 'Search commands',
+  paletteLabel: 'Command palette',
+  empty: 'No commands found.',
+  back: 'Back'
+}
 const groups: CommandPaletteGroup[] = [
   {
     id: 'file',
@@ -28,6 +35,7 @@ const groups: CommandPaletteGroup[] = [
     <CommandPaletteRoot
       v-model="selected"
       :groups="groups"
+      :labels="labels"
       :ui="{
         root: 'w-[min(40rem,100%)] overflow-hidden rounded-xl border border-border bg-panel text-surface shadow-xl',
         search: 'h-12 w-full border-b border-border bg-transparent px-4 text-sm outline-none',

--- a/packages/vue/src/primitives/CommandPalette/CommandPaletteDemo.vue
+++ b/packages/vue/src/primitives/CommandPalette/CommandPaletteDemo.vue
@@ -19,7 +19,15 @@ const groups: CommandPaletteGroup[] = [
     label: 'File',
     items: [
       { id: 'new', label: 'New document', shortcut: { keys: ['⌘', 'N'] } },
-      { id: 'settings', label: 'Settings', shortcut: { keys: ['⌘', ','] } }
+      { id: 'settings', label: 'Settings', shortcut: { keys: ['⌘', ','] } },
+      {
+        id: 'export',
+        label: 'Export selection',
+        children: [
+          { id: 'export-png', label: 'Export selection as PNG' },
+          { id: 'export-svg', label: 'Export selection as SVG' }
+        ]
+      }
     ]
   },
   {

--- a/packages/vue/src/primitives/CommandPalette/CommandPaletteDemo.vue
+++ b/packages/vue/src/primitives/CommandPalette/CommandPaletteDemo.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import CommandPaletteRoot from './CommandPaletteRoot.vue'
+import type { CommandPaletteGroup } from './types'
+
+const selected = ref('')
+const selectedLabels = ref<string[]>([])
+const groups: CommandPaletteGroup[] = [
+  {
+    id: 'file',
+    label: 'File',
+    items: [
+      { id: 'new', label: 'New document', shortcut: { keys: ['⌘', 'N'] } },
+      { id: 'settings', label: 'Settings', shortcut: { keys: ['⌘', ','] } }
+    ]
+  },
+  {
+    id: 'edit',
+    label: 'Edit',
+    items: [{ id: 'undo', label: 'Undo', shortcut: { keys: ['⌘', 'Z'] } }]
+  }
+]
+</script>
+
+<template>
+  <div class="space-y-2">
+    <CommandPaletteRoot
+      v-model="selected"
+      :groups="groups"
+      :ui="{
+        root: 'w-[min(40rem,100%)] overflow-hidden rounded-xl border border-border bg-panel text-surface shadow-xl',
+        search: 'h-12 w-full border-b border-border bg-transparent px-4 text-sm outline-none',
+        content: 'max-h-96 overflow-y-auto p-2',
+        label: 'px-2 py-1 text-[11px] text-muted',
+        item: 'flex h-8 cursor-pointer items-center gap-2 rounded-md p-1 text-[13px] data-[highlighted]:bg-hover',
+        itemIcon: 'flex size-6 shrink-0 items-center justify-center text-muted',
+        itemLabel: 'min-w-0 flex-1 truncate',
+        shortcut: 'flex items-center gap-1 text-xs text-muted',
+        key: 'rounded border border-border bg-input px-1.5 py-1 font-mono leading-none'
+      }"
+      @select="selectedLabels.push($event.label)"
+    />
+    <div v-if="selectedLabels.length" role="status" aria-label="Last selection">
+      {{ selectedLabels.at(-1) }}
+    </div>
+  </div>
+</template>

--- a/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
+++ b/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
@@ -69,7 +69,7 @@ function select(item: CommandPaletteItem) {
         :aria-label="labels.searchLabel"
         :class="ui?.search"
         autocomplete="off"
-        @input="palette.searchTerm.value = ($event.target as HTMLInputElement).value"
+        @keydown.backspace="palette.searchTerm.value || palette.navigateBack()"
       />
     </ListboxFilter>
     <ListboxContent :class="ui?.content">

--- a/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
+++ b/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
@@ -33,14 +33,14 @@ const {
 }>()
 
 const emit = defineEmits<{ select: [item: CommandPaletteItem] }>()
-const palette = useCommandPalette(() => ({ groups, labels, resultLimit }))
+const palette = useCommandPalette(() => ({ groups, resultLimit }))
 
 provide(COMMAND_PALETTE_KEY, {
   groups: toRef(() => groups),
   searchTerm: palette.searchTerm,
   isNested: palette.isNested,
-  labels,
-  ui,
+  labels: toRef(() => labels),
+  ui: toRef(() => ui),
   navigate: palette.navigate,
   navigateBack: palette.navigateBack,
   select: palette.select

--- a/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
+++ b/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
@@ -61,17 +61,21 @@ function select(item: CommandPaletteItem) {
     <div v-if="palette.isNested.value" :class="ui?.back">
       <button type="button" @click="palette.navigateBack()">{{ labels.back }}</button>
     </div>
-    <ListboxFilter v-model="palette.searchTerm.value" as-child>
-      <input
-        type="search"
-        :value="palette.searchTerm.value"
-        :placeholder="placeholder ?? labels.searchPlaceholder"
-        :aria-label="labels.searchLabel"
-        :class="ui?.search"
-        autocomplete="off"
-        @keydown.backspace="palette.searchTerm.value || palette.navigateBack()"
-      />
-    </ListboxFilter>
+    <div :class="ui?.searchWrapper">
+      <slot name="search-leading" />
+      <ListboxFilter v-model="palette.searchTerm.value" as-child>
+        <input
+          type="search"
+          :value="palette.searchTerm.value"
+          :placeholder="placeholder ?? labels.searchPlaceholder"
+          :aria-label="labels.searchLabel"
+          :class="ui?.search"
+          autocomplete="off"
+          @keydown.backspace="palette.searchTerm.value || palette.navigateBack()"
+        />
+      </ListboxFilter>
+      <slot name="search-trailing" />
+    </div>
     <ListboxContent :class="ui?.content">
       <template v-if="palette.filteredGroups.value.length">
         <ListboxGroup

--- a/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
+++ b/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import {
+  ListboxContent,
+  ListboxFilter,
+  ListboxGroup,
+  ListboxGroupLabel,
+  ListboxItem,
+  ListboxRoot
+} from 'reka-ui'
+
+import { useCommandMessages } from '#vue/i18n'
+import { useCommandPalette } from './useCommandPalette'
+import type { CommandPaletteGroup, CommandPaletteItem, CommandPaletteUI } from './types'
+
+const { groups, ui, placeholder, resultLimit } = defineProps<{
+  groups: CommandPaletteGroup[]
+  ui?: CommandPaletteUI
+  placeholder?: string
+  resultLimit?: number
+}>()
+
+const emit = defineEmits<{ select: [item: CommandPaletteItem] }>()
+const commands = useCommandMessages()
+const palette = useCommandPalette(() => ({ groups, resultLimit }))
+
+function select(item: CommandPaletteItem) {
+  palette.select(item)
+  emit('select', item)
+}
+</script>
+
+<template>
+  <ListboxRoot v-model="palette.selectedId.value" :class="ui?.root" aria-label="Command palette">
+    <ListboxFilter v-model="palette.searchTerm.value" as-child>
+      <input
+        type="search"
+        :value="palette.searchTerm.value"
+        :placeholder="placeholder ?? commands.paletteSearchPlaceholder"
+        :aria-label="commands.paletteSearchAriaLabel"
+        :class="ui?.search"
+        autocomplete="off"
+        @input="palette.searchTerm.value = ($event.target as HTMLInputElement).value"
+      />
+    </ListboxFilter>
+
+    <ListboxContent :class="ui?.content">
+      <template v-if="palette.filteredGroups.value.length">
+        <ListboxGroup
+          v-for="group in palette.filteredGroups.value"
+          :key="group.id"
+          :class="ui?.group"
+        >
+          <ListboxGroupLabel v-if="group.label" :class="ui?.label">
+            {{ group.label }}
+          </ListboxGroupLabel>
+          <ListboxItem
+            v-for="item in group.items"
+            :key="item.id"
+            :value="item.id"
+            :disabled="item.disabled"
+            :class="ui?.item"
+            @select="select(item)"
+          >
+            <span :class="ui?.itemIcon">
+              <slot name="item-icon" :item="item" />
+            </span>
+            <span :class="ui?.itemLabel">{{ item.label }}</span>
+            <span v-if="item.description" :class="ui?.itemDescription">
+              {{ item.description }}
+            </span>
+            <span v-if="item.shortcut" :class="ui?.shortcut">
+              <kbd v-for="key in item.shortcut.keys" :key="key" :class="ui?.key">{{ key }}</kbd>
+            </span>
+          </ListboxItem>
+        </ListboxGroup>
+      </template>
+      <slot v-else name="empty">{{ commands.paletteNoCommands }}</slot>
+    </ListboxContent>
+  </ListboxRoot>
+</template>

--- a/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
+++ b/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { provide, toRef } from 'vue'
 import {
   ListboxContent,
   ListboxFilter,
@@ -7,20 +8,43 @@ import {
   ListboxItem,
   ListboxRoot
 } from 'reka-ui'
-import { useCommandMessages } from '#vue/i18n'
-import { useCommandPalette } from './useCommandPalette'
-import type { CommandPaletteGroup, CommandPaletteItem, CommandPaletteUI } from './types'
 
-const { groups, ui, placeholder, resultLimit } = defineProps<{
+import { COMMAND_PALETTE_KEY } from './context'
+import { useCommandPalette } from './useCommandPalette'
+import type {
+  CommandPaletteGroup,
+  CommandPaletteItem,
+  CommandPaletteLabels,
+  CommandPaletteUI
+} from './types'
+
+const {
+  groups,
+  labels,
+  ui,
+  placeholder,
+  resultLimit = 12
+} = defineProps<{
   groups: CommandPaletteGroup[]
+  labels: CommandPaletteLabels
   ui?: CommandPaletteUI
   placeholder?: string
   resultLimit?: number
-  backLabel?: string
 }>()
+
 const emit = defineEmits<{ select: [item: CommandPaletteItem] }>()
-const commands = useCommandMessages()
-const palette = useCommandPalette(() => ({ groups, resultLimit }))
+const palette = useCommandPalette(() => ({ groups, labels, resultLimit }))
+
+provide(COMMAND_PALETTE_KEY, {
+  groups: toRef(() => groups),
+  searchTerm: palette.searchTerm,
+  isNested: palette.isNested,
+  labels,
+  ui,
+  navigate: palette.navigate,
+  navigateBack: palette.navigateBack,
+  select: palette.select
+})
 
 function select(item: CommandPaletteItem) {
   palette.select(item)
@@ -32,19 +56,17 @@ function select(item: CommandPaletteItem) {
   <ListboxRoot
     v-model="palette.selectedId.value"
     :class="ui?.root"
-    :aria-label="commands.paletteAriaLabel"
+    :aria-label="labels.paletteLabel"
   >
     <div v-if="palette.isNested.value" :class="ui?.back">
-      <button type="button" @click="palette.navigateBack()">
-        {{ backLabel ?? commands.paletteBack }}
-      </button>
+      <button type="button" @click="palette.navigateBack()">{{ labels.back }}</button>
     </div>
     <ListboxFilter v-model="palette.searchTerm.value" as-child>
       <input
         type="search"
         :value="palette.searchTerm.value"
-        :placeholder="placeholder ?? commands.paletteSearchPlaceholder"
-        :aria-label="commands.paletteSearchAriaLabel"
+        :placeholder="placeholder ?? labels.searchPlaceholder"
+        :aria-label="labels.searchLabel"
         :class="ui?.search"
         autocomplete="off"
         @input="palette.searchTerm.value = ($event.target as HTMLInputElement).value"
@@ -60,37 +82,24 @@ function select(item: CommandPaletteItem) {
           <ListboxGroupLabel v-if="group.label" :class="ui?.label">{{
             group.label
           }}</ListboxGroupLabel>
-          <template v-for="item in group.items" :key="item.id">
-            <button
-              v-if="item.children?.length"
-              type="button"
-              :class="ui?.item"
-              :disabled="item.disabled"
-              @click="palette.navigate(item)"
-            >
-              <span :class="ui?.itemIcon"><slot name="item-icon" :item="item" /></span>
-              <span :class="ui?.itemLabel">{{ item.label }}</span>
-            </button>
-            <ListboxItem
-              v-else
-              :value="item.id"
-              :disabled="item.disabled"
-              :class="ui?.item"
-              @select="select(item)"
-            >
-              <span :class="ui?.itemIcon"><slot name="item-icon" :item="item" /></span>
-              <span :class="ui?.itemLabel">{{ item.label }}</span>
-              <span v-if="item.description" :class="ui?.itemDescription">{{
-                item.description
-              }}</span>
-              <span v-if="item.shortcut" :class="ui?.shortcut">
-                <kbd v-for="key in item.shortcut.keys" :key="key" :class="ui?.key">{{ key }}</kbd>
-              </span>
-            </ListboxItem>
-          </template>
+          <ListboxItem
+            v-for="item in group.items"
+            :key="item.id"
+            :value="item.id"
+            :disabled="item.disabled"
+            :class="ui?.item"
+            @select="select(item)"
+          >
+            <span :class="ui?.itemIcon"><slot name="item-icon" :item="item" /></span>
+            <span :class="ui?.itemLabel">{{ item.label }}</span>
+            <span v-if="item.description" :class="ui?.itemDescription">{{ item.description }}</span>
+            <span v-if="item.shortcut" :class="ui?.shortcut">
+              <kbd v-for="key in item.shortcut.keys" :key="key" :class="ui?.key">{{ key }}</kbd>
+            </span>
+          </ListboxItem>
         </ListboxGroup>
       </template>
-      <slot v-else name="empty">{{ commands.paletteNoCommands }}</slot>
+      <slot v-else name="empty">{{ labels.empty }}</slot>
     </ListboxContent>
   </ListboxRoot>
 </template>

--- a/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
+++ b/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
@@ -7,7 +7,6 @@ import {
   ListboxItem,
   ListboxRoot
 } from 'reka-ui'
-
 import { useCommandMessages } from '#vue/i18n'
 import { useCommandPalette } from './useCommandPalette'
 import type { CommandPaletteGroup, CommandPaletteItem, CommandPaletteUI } from './types'
@@ -17,8 +16,8 @@ const { groups, ui, placeholder, resultLimit } = defineProps<{
   ui?: CommandPaletteUI
   placeholder?: string
   resultLimit?: number
+  backLabel?: string
 }>()
-
 const emit = defineEmits<{ select: [item: CommandPaletteItem] }>()
 const commands = useCommandMessages()
 const palette = useCommandPalette(() => ({ groups, resultLimit }))
@@ -30,7 +29,16 @@ function select(item: CommandPaletteItem) {
 </script>
 
 <template>
-  <ListboxRoot v-model="palette.selectedId.value" :class="ui?.root" aria-label="Command palette">
+  <ListboxRoot
+    v-model="palette.selectedId.value"
+    :class="ui?.root"
+    :aria-label="commands.paletteAriaLabel"
+  >
+    <div v-if="palette.isNested.value" :class="ui?.back">
+      <button type="button" @click="palette.navigateBack()">
+        {{ backLabel ?? commands.paletteBack }}
+      </button>
+    </div>
     <ListboxFilter v-model="palette.searchTerm.value" as-child>
       <input
         type="search"
@@ -42,7 +50,6 @@ function select(item: CommandPaletteItem) {
         @input="palette.searchTerm.value = ($event.target as HTMLInputElement).value"
       />
     </ListboxFilter>
-
     <ListboxContent :class="ui?.content">
       <template v-if="palette.filteredGroups.value.length">
         <ListboxGroup
@@ -50,28 +57,37 @@ function select(item: CommandPaletteItem) {
           :key="group.id"
           :class="ui?.group"
         >
-          <ListboxGroupLabel v-if="group.label" :class="ui?.label">
-            {{ group.label }}
-          </ListboxGroupLabel>
-          <ListboxItem
-            v-for="item in group.items"
-            :key="item.id"
-            :value="item.id"
-            :disabled="item.disabled"
-            :class="ui?.item"
-            @select="select(item)"
-          >
-            <span :class="ui?.itemIcon">
-              <slot name="item-icon" :item="item" />
-            </span>
-            <span :class="ui?.itemLabel">{{ item.label }}</span>
-            <span v-if="item.description" :class="ui?.itemDescription">
-              {{ item.description }}
-            </span>
-            <span v-if="item.shortcut" :class="ui?.shortcut">
-              <kbd v-for="key in item.shortcut.keys" :key="key" :class="ui?.key">{{ key }}</kbd>
-            </span>
-          </ListboxItem>
+          <ListboxGroupLabel v-if="group.label" :class="ui?.label">{{
+            group.label
+          }}</ListboxGroupLabel>
+          <template v-for="item in group.items" :key="item.id">
+            <button
+              v-if="item.children?.length"
+              type="button"
+              :class="ui?.item"
+              :disabled="item.disabled"
+              @click="palette.navigate(item)"
+            >
+              <span :class="ui?.itemIcon"><slot name="item-icon" :item="item" /></span>
+              <span :class="ui?.itemLabel">{{ item.label }}</span>
+            </button>
+            <ListboxItem
+              v-else
+              :value="item.id"
+              :disabled="item.disabled"
+              :class="ui?.item"
+              @select="select(item)"
+            >
+              <span :class="ui?.itemIcon"><slot name="item-icon" :item="item" /></span>
+              <span :class="ui?.itemLabel">{{ item.label }}</span>
+              <span v-if="item.description" :class="ui?.itemDescription">{{
+                item.description
+              }}</span>
+              <span v-if="item.shortcut" :class="ui?.shortcut">
+                <kbd v-for="key in item.shortcut.keys" :key="key" :class="ui?.key">{{ key }}</kbd>
+              </span>
+            </ListboxItem>
+          </template>
         </ListboxGroup>
       </template>
       <slot v-else name="empty">{{ commands.paletteNoCommands }}</slot>

--- a/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
+++ b/packages/vue/src/primitives/CommandPalette/CommandPaletteRoot.vue
@@ -57,6 +57,7 @@ function select(item: CommandPaletteItem) {
     v-model="palette.selectedId.value"
     :class="ui?.root"
     :aria-label="labels.paletteLabel"
+    :data-searching="palette.searchTerm.value ? '' : undefined"
   >
     <div v-if="palette.isNested.value" :class="ui?.back">
       <button type="button" @click="palette.navigateBack()">{{ labels.back }}</button>
@@ -103,7 +104,7 @@ function select(item: CommandPaletteItem) {
           </ListboxItem>
         </ListboxGroup>
       </template>
-      <slot v-else name="empty">{{ labels.empty }}</slot>
+      <slot v-else name="empty" :search-term="palette.searchTerm.value">{{ labels.empty }}</slot>
     </ListboxContent>
   </ListboxRoot>
 </template>

--- a/packages/vue/src/primitives/CommandPalette/context.ts
+++ b/packages/vue/src/primitives/CommandPalette/context.ts
@@ -1,0 +1,21 @@
+import type { InjectionKey, Ref } from 'vue'
+
+import type {
+  CommandPaletteGroup,
+  CommandPaletteItem,
+  CommandPaletteLabels,
+  CommandPaletteUI
+} from './types'
+
+export interface CommandPaletteContext {
+  groups: Ref<CommandPaletteGroup[]>
+  searchTerm: Ref<string>
+  isNested: Ref<boolean>
+  labels: CommandPaletteLabels
+  ui?: CommandPaletteUI
+  navigate: (item: CommandPaletteItem) => boolean
+  navigateBack: () => boolean
+  select: (item: CommandPaletteItem) => void
+}
+
+export const COMMAND_PALETTE_KEY: InjectionKey<CommandPaletteContext> = Symbol('command-palette')

--- a/packages/vue/src/primitives/CommandPalette/context.ts
+++ b/packages/vue/src/primitives/CommandPalette/context.ts
@@ -11,8 +11,8 @@ export interface CommandPaletteContext {
   groups: Ref<CommandPaletteGroup[]>
   searchTerm: Ref<string>
   isNested: Ref<boolean>
-  labels: CommandPaletteLabels
-  ui?: CommandPaletteUI
+  labels: Ref<CommandPaletteLabels>
+  ui: Ref<CommandPaletteUI | undefined>
   navigate: (item: CommandPaletteItem) => boolean
   navigateBack: () => boolean
   select: (item: CommandPaletteItem) => void

--- a/packages/vue/src/primitives/CommandPalette/index.ts
+++ b/packages/vue/src/primitives/CommandPalette/index.ts
@@ -1,9 +1,11 @@
 export { default as CommandPaletteRoot } from '#vue/primitives/CommandPalette/CommandPaletteRoot.vue'
 export { useCommandPalette } from '#vue/primitives/CommandPalette/useCommandPalette'
+export { useCommandPaletteContext } from '#vue/primitives/CommandPalette/useCommandPaletteContext'
 export type {
   CommandPaletteGroup,
   CommandPaletteItem,
   CommandPaletteShortcut,
   CommandPaletteUI,
+  CommandPaletteLabels,
   UseCommandPaletteOptions
 } from '#vue/primitives/CommandPalette/types'

--- a/packages/vue/src/primitives/CommandPalette/index.ts
+++ b/packages/vue/src/primitives/CommandPalette/index.ts
@@ -1,0 +1,9 @@
+export { default as CommandPaletteRoot } from '#vue/primitives/CommandPalette/CommandPaletteRoot.vue'
+export { useCommandPalette } from '#vue/primitives/CommandPalette/useCommandPalette'
+export type {
+  CommandPaletteGroup,
+  CommandPaletteItem,
+  CommandPaletteShortcut,
+  CommandPaletteUI,
+  UseCommandPaletteOptions
+} from '#vue/primitives/CommandPalette/types'

--- a/packages/vue/src/primitives/CommandPalette/index.ts
+++ b/packages/vue/src/primitives/CommandPalette/index.ts
@@ -1,6 +1,5 @@
 export { default as CommandPaletteRoot } from '#vue/primitives/CommandPalette/CommandPaletteRoot.vue'
 export { useCommandPalette } from '#vue/primitives/CommandPalette/useCommandPalette'
-export { useCommandPaletteContext } from '#vue/primitives/CommandPalette/useCommandPaletteContext'
 export type {
   CommandPaletteGroup,
   CommandPaletteItem,

--- a/packages/vue/src/primitives/CommandPalette/types.ts
+++ b/packages/vue/src/primitives/CommandPalette/types.ts
@@ -49,6 +49,5 @@ export interface CommandPaletteUI {
 
 export interface UseCommandPaletteOptions {
   groups: CommandPaletteGroup[]
-  labels: CommandPaletteLabels
   resultLimit?: number
 }

--- a/packages/vue/src/primitives/CommandPalette/types.ts
+++ b/packages/vue/src/primitives/CommandPalette/types.ts
@@ -22,6 +22,14 @@ export interface CommandPaletteGroup {
   items: CommandPaletteItem[]
 }
 
+export interface CommandPaletteLabels {
+  searchPlaceholder: string
+  searchLabel: string
+  paletteLabel: string
+  empty: string
+  back: string
+}
+
 export interface CommandPaletteUI {
   root?: string
   search?: string
@@ -41,5 +49,6 @@ export interface CommandPaletteUI {
 
 export interface UseCommandPaletteOptions {
   groups: CommandPaletteGroup[]
+  labels: CommandPaletteLabels
   resultLimit?: number
 }

--- a/packages/vue/src/primitives/CommandPalette/types.ts
+++ b/packages/vue/src/primitives/CommandPalette/types.ts
@@ -32,6 +32,7 @@ export interface CommandPaletteLabels {
 
 export interface CommandPaletteUI {
   root?: string
+  searchWrapper?: string
   search?: string
   back?: string
   content?: string

--- a/packages/vue/src/primitives/CommandPalette/types.ts
+++ b/packages/vue/src/primitives/CommandPalette/types.ts
@@ -25,6 +25,7 @@ export interface CommandPaletteGroup {
 export interface CommandPaletteUI {
   root?: string
   search?: string
+  back?: string
   content?: string
   viewport?: string
   group?: string

--- a/packages/vue/src/primitives/CommandPalette/types.ts
+++ b/packages/vue/src/primitives/CommandPalette/types.ts
@@ -1,0 +1,44 @@
+import type { Component } from 'vue'
+
+export interface CommandPaletteShortcut {
+  keys: string[]
+}
+
+export interface CommandPaletteItem {
+  id: string
+  label: string
+  description?: string
+  keywords?: string[]
+  icon?: Component
+  shortcut?: CommandPaletteShortcut
+  disabled?: boolean
+  children?: CommandPaletteItem[]
+  onSelect?: () => void
+}
+
+export interface CommandPaletteGroup {
+  id: string
+  label?: string
+  items: CommandPaletteItem[]
+}
+
+export interface CommandPaletteUI {
+  root?: string
+  search?: string
+  content?: string
+  viewport?: string
+  group?: string
+  label?: string
+  item?: string
+  itemIcon?: string
+  itemLabel?: string
+  itemDescription?: string
+  shortcut?: string
+  key?: string
+  empty?: string
+}
+
+export interface UseCommandPaletteOptions {
+  groups: CommandPaletteGroup[]
+  resultLimit?: number
+}

--- a/packages/vue/src/primitives/CommandPalette/useCommandPalette.ts
+++ b/packages/vue/src/primitives/CommandPalette/useCommandPalette.ts
@@ -37,7 +37,6 @@ function filterGroups(
 }
 
 export function useCommandPalette(options: MaybeRefOrGetter<UseCommandPaletteOptions>) {
-  const open = ref(false)
   const searchTerm = ref('')
   const selectedId = ref<string>()
   const navigation = ref<CommandPaletteGroup[]>([])
@@ -64,7 +63,6 @@ export function useCommandPalette(options: MaybeRefOrGetter<UseCommandPaletteOpt
   }
 
   function close() {
-    open.value = false
     resetNavigation()
   }
 
@@ -92,7 +90,6 @@ export function useCommandPalette(options: MaybeRefOrGetter<UseCommandPaletteOpt
   }
 
   return {
-    open,
     searchTerm,
     selectedId,
     filteredGroups,

--- a/packages/vue/src/primitives/CommandPalette/useCommandPalette.ts
+++ b/packages/vue/src/primitives/CommandPalette/useCommandPalette.ts
@@ -32,10 +32,7 @@ function filterGroups(
   const groupedResults = groupBy(itemsWithGroups, ({ groupId }) => groupId)
 
   return groups
-    .map((group) => ({
-      ...group,
-      items: groupedResults[group.id]?.map(({ item }) => item) ?? []
-    }))
+    .map((group) => ({ ...group, items: groupedResults[group.id]?.map(({ item }) => item) ?? [] }))
     .filter((group) => group.items.length > 0)
 }
 
@@ -43,44 +40,52 @@ export function useCommandPalette(options: MaybeRefOrGetter<UseCommandPaletteOpt
   const open = ref(false)
   const searchTerm = ref('')
   const selectedId = ref<string>()
+  const navigation = ref<CommandPaletteGroup[]>([])
 
   const groups = computed(() => toValue(options).groups)
   const resultLimit = computed(() => toValue(options).resultLimit ?? 12)
-  const navigation = ref<CommandPaletteGroup[]>()
-  const currentGroups = computed(() => navigation.value ?? groups.value)
-  const items = computed(() => currentGroups.value.flatMap((group) => group.items))
-
-  const filteredGroups = computed<CommandPaletteGroup[]>(() => {
-    const results = searchItems(items.value, searchTerm.value.trim(), resultLimit.value)
-    return filterGroups(currentGroups.value, results)
+  const currentGroups = computed(() => {
+    const current = navigation.value.at(-1)
+    return current ? [current] : groups.value
   })
+  const items = computed(() => currentGroups.value.flatMap((group) => group.items))
+  const filteredGroups = computed(() =>
+    filterGroups(
+      currentGroups.value,
+      searchItems(items.value, searchTerm.value.trim(), resultLimit.value)
+    )
+  )
+  const isNested = computed(() => navigation.value.length > 0)
 
-  function close() {
-    open.value = false
+  function resetNavigation() {
+    navigation.value = []
     searchTerm.value = ''
-    navigation.value = undefined
     selectedId.value = undefined
   }
 
-  function navigate(item: CommandPaletteItem) {
+  function close() {
+    open.value = false
+    resetNavigation()
+  }
+
+  function navigate(item: CommandPaletteItem): boolean {
     if (!item.children?.length) return false
-    navigation.value = [{ id: item.id, label: item.label, items: item.children }]
+    navigation.value.push({ id: item.id, label: item.label, items: item.children })
     searchTerm.value = ''
     selectedId.value = undefined
     return true
   }
 
-  function navigateBack() {
-    if (!navigation.value) return false
-    navigation.value = undefined
+  function navigateBack(): boolean {
+    if (navigation.value.length === 0) return false
+    navigation.value.pop()
     searchTerm.value = ''
     selectedId.value = undefined
     return true
   }
 
   function select(item: CommandPaletteItem) {
-    if (item.disabled) return
-    if (navigate(item)) return
+    if (item.disabled || navigate(item)) return
     selectedId.value = item.id
     item.onSelect?.()
     close()
@@ -91,7 +96,7 @@ export function useCommandPalette(options: MaybeRefOrGetter<UseCommandPaletteOpt
     searchTerm,
     selectedId,
     filteredGroups,
-    isNested: computed(() => navigation.value !== undefined),
+    isNested,
     close,
     navigate,
     navigateBack,

--- a/packages/vue/src/primitives/CommandPalette/useCommandPalette.ts
+++ b/packages/vue/src/primitives/CommandPalette/useCommandPalette.ts
@@ -46,26 +46,55 @@ export function useCommandPalette(options: MaybeRefOrGetter<UseCommandPaletteOpt
 
   const groups = computed(() => toValue(options).groups)
   const resultLimit = computed(() => toValue(options).resultLimit ?? 12)
-  const items = computed(() => groups.value.flatMap((group) => group.items))
+  const navigation = ref<CommandPaletteGroup[]>()
+  const currentGroups = computed(() => navigation.value ?? groups.value)
+  const items = computed(() => currentGroups.value.flatMap((group) => group.items))
 
   const filteredGroups = computed<CommandPaletteGroup[]>(() => {
     const results = searchItems(items.value, searchTerm.value.trim(), resultLimit.value)
-    return filterGroups(groups.value, results)
+    return filterGroups(currentGroups.value, results)
   })
 
   function close() {
     open.value = false
     searchTerm.value = ''
+    navigation.value = undefined
     selectedId.value = undefined
+  }
+
+  function navigate(item: CommandPaletteItem) {
+    if (!item.children?.length) return false
+    navigation.value = [{ id: item.id, label: item.label, items: item.children }]
+    searchTerm.value = ''
+    selectedId.value = undefined
+    return true
+  }
+
+  function navigateBack() {
+    if (!navigation.value) return false
+    navigation.value = undefined
+    searchTerm.value = ''
+    selectedId.value = undefined
+    return true
   }
 
   function select(item: CommandPaletteItem) {
     if (item.disabled) return
-    if (item.children?.length) return
+    if (navigate(item)) return
     selectedId.value = item.id
     item.onSelect?.()
     close()
   }
 
-  return { open, searchTerm, selectedId, filteredGroups, close, select }
+  return {
+    open,
+    searchTerm,
+    selectedId,
+    filteredGroups,
+    isNested: computed(() => navigation.value !== undefined),
+    close,
+    navigate,
+    navigateBack,
+    select
+  }
 }

--- a/packages/vue/src/primitives/CommandPalette/useCommandPalette.ts
+++ b/packages/vue/src/primitives/CommandPalette/useCommandPalette.ts
@@ -1,0 +1,71 @@
+import { groupBy } from 'es-toolkit/array'
+import Fuse from 'fuse.js'
+import { computed, ref, type MaybeRefOrGetter, toValue } from 'vue'
+
+import type { CommandPaletteGroup, CommandPaletteItem, UseCommandPaletteOptions } from './types'
+
+function searchItems(
+  items: CommandPaletteItem[],
+  query: string,
+  resultLimit: number
+): CommandPaletteItem[] {
+  if (!query) return items.slice(0, resultLimit)
+
+  return new Fuse(items, {
+    keys: ['label', 'description', 'keywords'],
+    threshold: 0.35,
+    ignoreLocation: true
+  })
+    .search(query)
+    .slice(0, resultLimit)
+    .map((result) => result.item)
+}
+
+function filterGroups(
+  groups: CommandPaletteGroup[],
+  results: CommandPaletteItem[]
+): CommandPaletteGroup[] {
+  const resultSet = new Set(results)
+  const itemsWithGroups = groups.flatMap((group) =>
+    group.items.filter((item) => resultSet.has(item)).map((item) => ({ groupId: group.id, item }))
+  )
+  const groupedResults = groupBy(itemsWithGroups, ({ groupId }) => groupId)
+
+  return groups
+    .map((group) => ({
+      ...group,
+      items: groupedResults[group.id]?.map(({ item }) => item) ?? []
+    }))
+    .filter((group) => group.items.length > 0)
+}
+
+export function useCommandPalette(options: MaybeRefOrGetter<UseCommandPaletteOptions>) {
+  const open = ref(false)
+  const searchTerm = ref('')
+  const selectedId = ref<string>()
+
+  const groups = computed(() => toValue(options).groups)
+  const resultLimit = computed(() => toValue(options).resultLimit ?? 12)
+  const items = computed(() => groups.value.flatMap((group) => group.items))
+
+  const filteredGroups = computed<CommandPaletteGroup[]>(() => {
+    const results = searchItems(items.value, searchTerm.value.trim(), resultLimit.value)
+    return filterGroups(groups.value, results)
+  })
+
+  function close() {
+    open.value = false
+    searchTerm.value = ''
+    selectedId.value = undefined
+  }
+
+  function select(item: CommandPaletteItem) {
+    if (item.disabled) return
+    if (item.children?.length) return
+    selectedId.value = item.id
+    item.onSelect?.()
+    close()
+  }
+
+  return { open, searchTerm, selectedId, filteredGroups, close, select }
+}

--- a/packages/vue/src/primitives/CommandPalette/useCommandPalette.ts
+++ b/packages/vue/src/primitives/CommandPalette/useCommandPalette.ts
@@ -13,7 +13,7 @@ function searchItems(
 
   return new Fuse(items, {
     keys: ['label', 'description', 'keywords'],
-    threshold: 0.35,
+    threshold: 0.2,
     ignoreLocation: true
   })
     .search(query)
@@ -25,14 +25,13 @@ function filterGroups(
   groups: CommandPaletteGroup[],
   results: CommandPaletteItem[]
 ): CommandPaletteGroup[] {
-  const resultSet = new Set(results)
-  const itemsWithGroups = groups.flatMap((group) =>
-    group.items.filter((item) => resultSet.has(item)).map((item) => ({ groupId: group.id, item }))
+  const groupByItem = new Map(
+    groups.flatMap((group) => group.items.map((item) => [item, group.id] as const))
   )
-  const groupedResults = groupBy(itemsWithGroups, ({ groupId }) => groupId)
+  const groupedResults = groupBy(results, (item) => groupByItem.get(item) ?? '')
 
   return groups
-    .map((group) => ({ ...group, items: groupedResults[group.id]?.map(({ item }) => item) ?? [] }))
+    .map((group) => ({ ...group, items: groupedResults[group.id] ?? [] }))
     .filter((group) => group.items.length > 0)
 }
 

--- a/packages/vue/src/primitives/CommandPalette/useCommandPaletteContext.ts
+++ b/packages/vue/src/primitives/CommandPalette/useCommandPaletteContext.ts
@@ -1,0 +1,9 @@
+import { inject } from 'vue'
+
+import { COMMAND_PALETTE_KEY } from './context'
+
+export function useCommandPaletteContext() {
+  const context = inject(COMMAND_PALETTE_KEY)
+  if (!context) throw new Error('CommandPalette components must be used inside CommandPaletteRoot')
+  return context
+}

--- a/packages/vue/src/primitives/CommandPalette/useCommandPaletteContext.ts
+++ b/packages/vue/src/primitives/CommandPalette/useCommandPaletteContext.ts
@@ -1,9 +1,0 @@
-import { inject } from 'vue'
-
-import { COMMAND_PALETTE_KEY } from './context'
-
-export function useCommandPaletteContext() {
-  const context = inject(COMMAND_PALETTE_KEY)
-  if (!context) throw new Error('CommandPalette components must be used inside CommandPaletteRoot')
-  return context
-}

--- a/src/app/shell/menu/app-menu.ts
+++ b/src/app/shell/menu/app-menu.ts
@@ -16,7 +16,7 @@ import IconZoomIn from '~icons/lucide/zoom-in'
 import IconZoomOut from '~icons/lucide/zoom-out'
 
 import type { CommandPaletteGroup, CommandPaletteItem, MenuEntry } from '@open-pencil/vue'
-import { useEditorCommands, useI18n } from '@open-pencil/vue'
+import { shortcutPlatform, useEditorCommands, useI18n } from '@open-pencil/vue'
 
 import { useEditorStore } from '@/app/editor/active-store'
 import { openSettingsDialog } from '@/app/settings/dialog'
@@ -59,10 +59,11 @@ const APP_MENU_ICONS: Record<AppMenuIcon, Component> = {
 
 function shortcutKeys(shortcut: string | undefined): string[] | undefined {
   if (!shortcut) return undefined
+  const platform = shortcutPlatform()
   return shortcut.split('+').map((key) => {
-    if (key === 'MOD') return '⌘'
-    if (key === 'SHIFT') return '⇧'
-    if (key === 'ALT') return '⌥'
+    if (key === 'MOD') return platform === 'mac' ? '⌘' : 'Ctrl'
+    if (key === 'SHIFT') return platform === 'mac' ? '⇧' : 'Shift'
+    if (key === 'ALT') return platform === 'mac' ? '⌥' : 'Alt'
     return key
   })
 }
@@ -274,6 +275,7 @@ export function useAppMenu() {
         palette: entry.palette
           ? {
               ...entry.palette,
+              label: entry.palette.label ? menu.value[entry.palette.label] : undefined,
               icon: entry.palette.icon ? APP_MENU_ICONS[entry.palette.icon] : undefined
             }
           : undefined
@@ -286,6 +288,7 @@ export function useAppMenu() {
       palette: entry.palette
         ? {
             ...entry.palette,
+            label: entry.palette.label ? menu.value[entry.palette.label] : undefined,
             icon: entry.palette.icon ? APP_MENU_ICONS[entry.palette.icon] : undefined
           }
         : undefined,
@@ -317,13 +320,15 @@ export function useAppMenu() {
 
     const item: CommandPaletteItem = {
       id: entry.menuId,
-      label: entry.label,
+      label: entry.palette?.label ?? entry.label,
       icon: entry.palette?.icon ?? undefined,
       shortcut: entry.shortcut ? { keys: shortcutKeys(entry.shortcut) ?? [] } : undefined,
       description: entry.palette?.description,
       keywords: entry.palette?.keywords,
       disabled: entry.disabled,
-      onSelect: entry.action
+      onSelect:
+        entry.action ??
+        (entry.onCheckedChange ? () => entry.onCheckedChange?.(!entry.checked) : undefined)
     }
     const children = entry.sub?.flatMap((child) => paletteEntries(child, category)) ?? []
     return [item, ...children]

--- a/src/app/shell/menu/app-menu.ts
+++ b/src/app/shell/menu/app-menu.ts
@@ -1,7 +1,21 @@
+import type { Component } from 'vue'
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import IconDownload from '~icons/lucide/download'
+import IconEye from '~icons/lucide/eye'
+import IconFile from '~icons/lucide/file'
+import IconFolderOpen from '~icons/lucide/folder-open'
+import IconLayers from '~icons/lucide/layers-2'
+import IconPencil from '~icons/lucide/pencil'
+import IconRedo from '~icons/lucide/redo-2'
+import IconSave from '~icons/lucide/save'
+import IconSettings from '~icons/lucide/settings'
+import IconType from '~icons/lucide/type'
+import IconUndo from '~icons/lucide/undo-2'
+import IconZoomIn from '~icons/lucide/zoom-in'
+import IconZoomOut from '~icons/lucide/zoom-out'
 
-import type { MenuEntry } from '@open-pencil/vue'
+import type { CommandPaletteGroup, CommandPaletteItem, MenuEntry } from '@open-pencil/vue'
 import { useEditorCommands, useI18n } from '@open-pencil/vue'
 
 import { useEditorStore } from '@/app/editor/active-store'
@@ -9,7 +23,12 @@ import { openSettingsDialog } from '@/app/settings/dialog'
 import { setSnappingPreference } from '@/app/settings/preferences/apply'
 import { createSharedEditorMenuActions } from '@/app/shell/menu/editor-actions'
 import { openStorageWorkspace } from '@/app/shell/menu/navigation'
-import type { AppMenuActionItem, AppMenuEntry, AppMenuGroupSchema } from '@/app/shell/menu/schema'
+import type {
+  AppMenuActionItem,
+  AppMenuEntry,
+  AppMenuGroupSchema,
+  AppMenuIcon
+} from '@/app/shell/menu/schema'
 import { APP_MENU_SCHEMA } from '@/app/shell/menu/schema'
 import { createSelectionMenuActions } from '@/app/shell/menu/selection-actions'
 import { appMenuShortcutLabel } from '@/app/shell/menu/shortcut'
@@ -20,6 +39,32 @@ import { closeTab, activeTab } from '@/app/tabs'
 export interface AppMenuGroup {
   label: string
   items: MenuEntry[]
+}
+
+const APP_MENU_ICONS: Record<AppMenuIcon, Component> = {
+  download: IconDownload,
+  eye: IconEye,
+  file: IconFile,
+  'folder-open': IconFolderOpen,
+  layers: IconLayers,
+  pencil: IconPencil,
+  redo: IconRedo,
+  save: IconSave,
+  settings: IconSettings,
+  type: IconType,
+  undo: IconUndo,
+  'zoom-in': IconZoomIn,
+  'zoom-out': IconZoomOut
+}
+
+function shortcutKeys(shortcut: string | undefined): string[] | undefined {
+  if (!shortcut) return undefined
+  return shortcut.split('+').map((key) => {
+    if (key === 'MOD') return '⌘'
+    if (key === 'SHIFT') return '⇧'
+    if (key === 'ALT') return '⌥'
+    return key
+  })
 }
 
 function isVisible(entry: { target?: string }): boolean {
@@ -228,6 +273,12 @@ export function useAppMenu() {
 
     return {
       label: menuLabel(entry),
+      palette: entry.palette
+        ? {
+            ...entry.palette,
+            icon: entry.palette.icon ? APP_MENU_ICONS[entry.palette.icon] : undefined
+          }
+        : undefined,
       shortcut: appMenuShortcutLabel(entry.id),
       action: itemAction(entry),
       disabled: disabled(entry),
@@ -250,9 +301,42 @@ export function useAppMenu() {
     }
   }
 
+  function paletteEntries(
+    entry: MenuEntry,
+    category: string,
+    parentId?: string
+  ): CommandPaletteItem[] {
+    if ('separator' in entry) return []
+    const children = entry.sub?.flatMap((child) => paletteEntries(child, category, entry.id)) ?? []
+    if (!entry.id) return children
+    const item: CommandPaletteItem = {
+      id: entry.id,
+      label:
+        entry.palette?.label ??
+        (parentId === 'export-selection'
+          ? `${menu.value.exportSelection} ${entry.label}`
+          : entry.label),
+      icon: entry.palette?.icon ?? undefined,
+      shortcut: entry.shortcut ? { keys: shortcutKeys(entry.shortcut) ?? [] } : undefined,
+      description: entry.palette?.description,
+      keywords: entry.palette?.keywords,
+      disabled: entry.disabled,
+      onSelect: entry.action
+    }
+    return [item, ...children]
+  }
+
   const topMenus = computed<AppMenuGroup[]>(() =>
     APP_MENU_SCHEMA.map(buildGroup).filter((group): group is AppMenuGroup => group !== null)
   )
 
-  return { topMenus }
+  const commandGroups = computed<CommandPaletteGroup[]>(() =>
+    topMenus.value.map((group) => ({
+      id: group.label.toLowerCase(),
+      label: group.label,
+      items: group.items.flatMap((entry) => paletteEntries(entry, group.label))
+    }))
+  )
+
+  return { topMenus, commandGroups }
 }

--- a/src/app/shell/menu/app-menu.ts
+++ b/src/app/shell/menu/app-menu.ts
@@ -38,6 +38,7 @@ import { closeTab, activeTab } from '@/app/tabs'
 
 export interface AppMenuGroup {
   label: string
+  paletteIcon?: Component
   items: MenuEntry[]
 }
 
@@ -308,18 +309,24 @@ export function useAppMenu() {
     if (!isVisible(group)) return null
     return {
       label: groupLabel(group),
+      paletteIcon: group.paletteIcon ? APP_MENU_ICONS[group.paletteIcon] : undefined,
       items: group.items.map(buildEntry).filter((item): item is MenuEntry => item !== null)
     }
   }
 
-  function paletteEntries(entry: MenuEntry, category: string): CommandPaletteItem[] {
+  function paletteEntries(
+    entry: MenuEntry,
+    category: string,
+    fallbackIcon?: Component
+  ): CommandPaletteItem[] {
     if ('separator' in entry) return []
-    if (!entry.menuId) return entry.sub?.flatMap((child) => paletteEntries(child, category)) ?? []
+    if (!entry.menuId)
+      return entry.sub?.flatMap((child) => paletteEntries(child, category, fallbackIcon)) ?? []
 
     const item: CommandPaletteItem = {
       id: entry.menuId,
       label: entry.palette?.label ?? entry.label,
-      icon: entry.palette?.icon ?? undefined,
+      icon: entry.palette?.icon ?? fallbackIcon,
       shortcut: entry.shortcut ? { keys: shortcutKeys(entry.shortcut) ?? [] } : undefined,
       description: entry.palette?.description,
       keywords: entry.palette?.keywords,
@@ -328,7 +335,8 @@ export function useAppMenu() {
         entry.action ??
         (entry.onCheckedChange ? () => entry.onCheckedChange?.(!entry.checked) : undefined)
     }
-    const children = entry.sub?.flatMap((child) => paletteEntries(child, category)) ?? []
+    const children =
+      entry.sub?.flatMap((child) => paletteEntries(child, category, fallbackIcon)) ?? []
     return [item, ...children]
   }
 
@@ -340,7 +348,7 @@ export function useAppMenu() {
     topMenus.value.map((group) => ({
       id: group.label.toLowerCase(),
       label: group.label,
-      items: group.items.flatMap((entry) => paletteEntries(entry, group.label))
+      items: group.items.flatMap((entry) => paletteEntries(entry, group.label, group.paletteIcon))
     }))
   )
 

--- a/src/app/shell/menu/app-menu.ts
+++ b/src/app/shell/menu/app-menu.ts
@@ -311,22 +311,13 @@ export function useAppMenu() {
     }
   }
 
-  function paletteEntries(
-    entry: MenuEntry,
-    category: string,
-    parentId?: string
-  ): CommandPaletteItem[] {
+  function paletteEntries(entry: MenuEntry, category: string): CommandPaletteItem[] {
     if ('separator' in entry) return []
-    const children =
-      entry.sub?.flatMap((child) => paletteEntries(child, category, entry.menuId)) ?? []
+    const children = entry.sub?.flatMap((child) => paletteEntries(child, category)) ?? []
     if (!entry.menuId) return children
     const item: CommandPaletteItem = {
       id: entry.menuId,
-      label:
-        entry.palette?.label ??
-        (parentId === 'export-selection'
-          ? `${menu.value.exportSelection} ${entry.label}`
-          : entry.label),
+      label: entry.palette?.label ?? entry.label,
       icon: entry.palette?.icon ?? undefined,
       shortcut: entry.shortcut ? { keys: shortcutKeys(entry.shortcut) ?? [] } : undefined,
       description: entry.palette?.description,

--- a/src/app/shell/menu/app-menu.ts
+++ b/src/app/shell/menu/app-menu.ts
@@ -268,10 +268,20 @@ export function useAppMenu() {
     }
 
     if (entry.command) {
-      return commandMenuItem(entry.command, appMenuShortcutLabel(entry.id))
+      return {
+        ...commandMenuItem(entry.command, appMenuShortcutLabel(entry.id)),
+        menuId: entry.id,
+        palette: entry.palette
+          ? {
+              ...entry.palette,
+              icon: entry.palette.icon ? APP_MENU_ICONS[entry.palette.icon] : undefined
+            }
+          : undefined
+      }
     }
 
     return {
+      menuId: entry.id,
       label: menuLabel(entry),
       palette: entry.palette
         ? {
@@ -307,10 +317,11 @@ export function useAppMenu() {
     parentId?: string
   ): CommandPaletteItem[] {
     if ('separator' in entry) return []
-    const children = entry.sub?.flatMap((child) => paletteEntries(child, category, entry.id)) ?? []
-    if (!entry.id) return children
+    const children =
+      entry.sub?.flatMap((child) => paletteEntries(child, category, entry.menuId)) ?? []
+    if (!entry.menuId) return children
     const item: CommandPaletteItem = {
-      id: entry.id,
+      id: entry.menuId,
       label:
         entry.palette?.label ??
         (parentId === 'export-selection'

--- a/src/app/shell/menu/app-menu.ts
+++ b/src/app/shell/menu/app-menu.ts
@@ -246,6 +246,16 @@ export function useAppMenu() {
     return key ? menu.value[key] : entry.label
   }
 
+  function resolvePalette(entry: AppMenuActionItem) {
+    return entry.palette
+      ? {
+          ...entry.palette,
+          label: entry.palette.label ? menu.value[entry.palette.label] : undefined,
+          icon: entry.palette.icon ? APP_MENU_ICONS[entry.palette.icon] : undefined
+        }
+      : undefined
+  }
+
   function buildEntry(entry: AppMenuEntry): MenuEntry | null {
     if (!isVisible(entry)) return null
     if (isSeparator(entry)) return { separator: true }
@@ -272,26 +282,14 @@ export function useAppMenu() {
       return {
         ...commandMenuItem(entry.command, appMenuShortcutLabel(entry.id)),
         menuId: entry.id,
-        palette: entry.palette
-          ? {
-              ...entry.palette,
-              label: entry.palette.label ? menu.value[entry.palette.label] : undefined,
-              icon: entry.palette.icon ? APP_MENU_ICONS[entry.palette.icon] : undefined
-            }
-          : undefined
+        palette: resolvePalette(entry)
       }
     }
 
     return {
       menuId: entry.id,
       label: menuLabel(entry),
-      palette: entry.palette
-        ? {
-            ...entry.palette,
-            label: entry.palette.label ? menu.value[entry.palette.label] : undefined,
-            icon: entry.palette.icon ? APP_MENU_ICONS[entry.palette.icon] : undefined
-          }
-        : undefined,
+      palette: resolvePalette(entry),
       shortcut: appMenuShortcutLabel(entry.id),
       action: itemAction(entry),
       disabled: disabled(entry),

--- a/src/app/shell/menu/app-menu.ts
+++ b/src/app/shell/menu/app-menu.ts
@@ -313,11 +313,11 @@ export function useAppMenu() {
 
   function paletteEntries(entry: MenuEntry, category: string): CommandPaletteItem[] {
     if ('separator' in entry) return []
-    const children = entry.sub?.flatMap((child) => paletteEntries(child, category)) ?? []
-    if (!entry.menuId) return children
+    if (!entry.menuId) return entry.sub?.flatMap((child) => paletteEntries(child, category)) ?? []
+
     const item: CommandPaletteItem = {
       id: entry.menuId,
-      label: entry.palette?.label ?? entry.label,
+      label: entry.label,
       icon: entry.palette?.icon ?? undefined,
       shortcut: entry.shortcut ? { keys: shortcutKeys(entry.shortcut) ?? [] } : undefined,
       description: entry.palette?.description,
@@ -325,6 +325,7 @@ export function useAppMenu() {
       disabled: entry.disabled,
       onSelect: entry.action
     }
+    const children = entry.sub?.flatMap((child) => paletteEntries(child, category)) ?? []
     return [item, ...children]
   }
 

--- a/src/app/shell/menu/app-menu.ts
+++ b/src/app/shell/menu/app-menu.ts
@@ -283,7 +283,8 @@ export function useAppMenu() {
       return {
         ...commandMenuItem(entry.command, appMenuShortcutLabel(entry.id)),
         menuId: entry.id,
-        palette: resolvePalette(entry)
+        palette: resolvePalette(entry),
+        paletteShortcut: entry.shortcut
       }
     }
 
@@ -291,6 +292,7 @@ export function useAppMenu() {
       menuId: entry.id,
       label: menuLabel(entry),
       palette: resolvePalette(entry),
+      paletteShortcut: entry.shortcut,
       shortcut: appMenuShortcutLabel(entry.id),
       action: itemAction(entry),
       disabled: disabled(entry),
@@ -327,7 +329,9 @@ export function useAppMenu() {
       id: entry.menuId,
       label: entry.palette?.label ?? entry.label,
       icon: entry.palette?.icon ?? fallbackIcon,
-      shortcut: entry.shortcut ? { keys: shortcutKeys(entry.shortcut) ?? [] } : undefined,
+      shortcut: entry.paletteShortcut
+        ? { keys: shortcutKeys(entry.paletteShortcut) ?? [] }
+        : undefined,
       description: entry.palette?.description,
       keywords: entry.palette?.keywords,
       disabled: entry.disabled,

--- a/src/app/shell/menu/index.ts
+++ b/src/app/shell/menu/index.ts
@@ -1,2 +1,0 @@
-export { useAppMenu } from './app-menu'
-export type { AppMenuGroup } from './app-menu'

--- a/src/app/shell/menu/index.ts
+++ b/src/app/shell/menu/index.ts
@@ -1,0 +1,2 @@
+export { useAppMenu } from './app-menu'
+export type { AppMenuGroup } from './app-menu'

--- a/src/app/shell/menu/schema.ts
+++ b/src/app/shell/menu/schema.ts
@@ -1,6 +1,28 @@
 import type { EditorCommandId } from '@open-pencil/vue'
 
 export type AppMenuTarget = 'all' | 'browser' | 'native'
+
+export type AppMenuIcon =
+  | 'download'
+  | 'eye'
+  | 'file'
+  | 'folder-open'
+  | 'layers'
+  | 'pencil'
+  | 'redo'
+  | 'save'
+  | 'settings'
+  | 'type'
+  | 'undo'
+  | 'zoom-in'
+  | 'zoom-out'
+
+export interface AppMenuPaletteMetadata {
+  icon?: AppMenuIcon
+  description?: string
+  keywords?: string[]
+}
+
 export type AppMenuHandler = 'editor' | 'shell'
 
 export interface AppMenuActionItem {
@@ -13,6 +35,7 @@ export interface AppMenuActionItem {
   checkbox?: boolean
   target?: AppMenuTarget
   handler?: AppMenuHandler
+  palette?: AppMenuPaletteMetadata
   sub?: AppMenuEntry[]
 }
 
@@ -46,10 +69,10 @@ export const APP_MENU_SCHEMA = [
         label: 'Export Selection',
         shortcut: 'MOD+SHIFT+E',
         sub: [
-          { id: 'export-png', label: 'PNG' },
-          { id: 'export-svg', label: 'SVG' },
-          { id: 'export-pptx', label: 'PPTX' },
-          { id: 'export-fig', label: '.fig' }
+          { id: 'export-png', label: 'PNG', palette: { icon: 'download' } },
+          { id: 'export-svg', label: 'SVG', palette: { icon: 'download' } },
+          { id: 'export-pptx', label: 'PPTX', palette: { icon: 'download' } },
+          { id: 'export-fig', label: '.fig', palette: { icon: 'download' } }
         ]
       },
       { type: 'separator' },

--- a/src/app/shell/menu/schema.ts
+++ b/src/app/shell/menu/schema.ts
@@ -67,6 +67,7 @@ export const APP_MENU_SCHEMA = [
       {
         id: 'export-selection',
         label: 'Export Selection',
+        palette: { icon: 'download' },
         shortcut: 'MOD+SHIFT+E',
         sub: [
           { id: 'export-png', label: 'PNG', palette: { icon: 'download' } },

--- a/src/app/shell/menu/schema.ts
+++ b/src/app/shell/menu/schema.ts
@@ -56,12 +56,14 @@ export type AppMenuEntry = AppMenuActionItem | AppMenuSeparatorItem
 export interface AppMenuGroupSchema {
   label: string
   target?: AppMenuTarget
+  paletteIcon?: AppMenuIcon
   items: AppMenuEntry[]
 }
 
 export const APP_MENU_SCHEMA = [
   {
     label: 'File',
+    paletteIcon: 'file',
     items: [
       { id: 'new', label: 'New', shortcut: 'MOD+N' },
       { id: 'open', label: 'Open…', shortcut: 'MOD+O' },
@@ -106,6 +108,7 @@ export const APP_MENU_SCHEMA = [
   },
   {
     label: 'Edit',
+    paletteIcon: 'pencil',
     items: [
       {
         id: 'edit.undo',
@@ -148,6 +151,7 @@ export const APP_MENU_SCHEMA = [
   },
   {
     label: 'View',
+    paletteIcon: 'eye',
     items: [
       {
         id: 'view.zoom100',
@@ -230,6 +234,7 @@ export const APP_MENU_SCHEMA = [
   },
   {
     label: 'Object',
+    paletteIcon: 'layers',
     items: [
       {
         id: 'selection.group',
@@ -366,6 +371,7 @@ export const APP_MENU_SCHEMA = [
   },
   {
     label: 'Text',
+    paletteIcon: 'type',
     items: [
       { id: 'text.bold', label: 'Bold', shortcut: 'MOD+B' },
       { id: 'text.italic', label: 'Italic', shortcut: 'MOD+I' },
@@ -374,6 +380,7 @@ export const APP_MENU_SCHEMA = [
   },
   {
     label: 'Arrange',
+    paletteIcon: 'layers',
     items: [
       {
         id: 'selection.wrapInAutoLayout',

--- a/src/app/shell/menu/schema.ts
+++ b/src/app/shell/menu/schema.ts
@@ -70,10 +70,10 @@ export const APP_MENU_SCHEMA = [
         palette: { icon: 'download' },
         shortcut: 'MOD+SHIFT+E',
         sub: [
-          { id: 'export-png', label: 'PNG', palette: { icon: 'download' } },
-          { id: 'export-svg', label: 'SVG', palette: { icon: 'download' } },
-          { id: 'export-pptx', label: 'PPTX', palette: { icon: 'download' } },
-          { id: 'export-fig', label: '.fig', palette: { icon: 'download' } }
+          { id: 'export-png', label: 'Export selection as PNG', palette: { icon: 'download' } },
+          { id: 'export-svg', label: 'Export selection as SVG', palette: { icon: 'download' } },
+          { id: 'export-pptx', label: 'Export selection as PPTX', palette: { icon: 'download' } },
+          { id: 'export-fig', label: 'Export selection as .fig', palette: { icon: 'download' } }
         ]
       },
       { type: 'separator' },

--- a/src/app/shell/menu/schema.ts
+++ b/src/app/shell/menu/schema.ts
@@ -17,8 +17,15 @@ export type AppMenuIcon =
   | 'zoom-in'
   | 'zoom-out'
 
+export type AppMenuPaletteLabel =
+  | 'exportSelectionAsPNG'
+  | 'exportSelectionAsSVG'
+  | 'exportSelectionAsPPTX'
+  | 'exportSelectionAsFig'
+
 export interface AppMenuPaletteMetadata {
   icon?: AppMenuIcon
+  label?: AppMenuPaletteLabel
   description?: string
   keywords?: string[]
 }
@@ -70,10 +77,26 @@ export const APP_MENU_SCHEMA = [
         palette: { icon: 'download' },
         shortcut: 'MOD+SHIFT+E',
         sub: [
-          { id: 'export-png', label: 'Export selection as PNG', palette: { icon: 'download' } },
-          { id: 'export-svg', label: 'Export selection as SVG', palette: { icon: 'download' } },
-          { id: 'export-pptx', label: 'Export selection as PPTX', palette: { icon: 'download' } },
-          { id: 'export-fig', label: 'Export selection as .fig', palette: { icon: 'download' } }
+          {
+            id: 'export-png',
+            label: 'PNG',
+            palette: { icon: 'download', label: 'exportSelectionAsPNG' }
+          },
+          {
+            id: 'export-svg',
+            label: 'SVG',
+            palette: { icon: 'download', label: 'exportSelectionAsSVG' }
+          },
+          {
+            id: 'export-pptx',
+            label: 'PPTX',
+            palette: { icon: 'download', label: 'exportSelectionAsPPTX' }
+          },
+          {
+            id: 'export-fig',
+            label: '.fig',
+            palette: { icon: 'download', label: 'exportSelectionAsFig' }
+          }
         ]
       },
       { type: 'separator' },

--- a/src/components/commands/CommandPalette.vue
+++ b/src/components/commands/CommandPalette.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useEventListener } from '@vueuse/core'
 import { CommandPaletteRoot, useCommandMessages } from '@open-pencil/vue'
 import { DialogDescription, DialogTitle, VisuallyHidden } from 'reka-ui'
@@ -8,6 +9,13 @@ import AppDialogRoot from '@/components/ui/dialog/AppDialogRoot.vue'
 
 const { commandGroups: groups } = useAppMenu()
 const commands = useCommandMessages()
+const labels = computed(() => ({
+  searchPlaceholder: commands.value.paletteSearchPlaceholder,
+  searchLabel: commands.value.paletteSearchAriaLabel,
+  paletteLabel: commands.value.paletteAriaLabel,
+  empty: commands.value.paletteNoCommands,
+  back: commands.value.paletteBack
+}))
 const open = defineModel<boolean>('open', { default: false })
 
 function close() {
@@ -38,7 +46,7 @@ useEventListener(window, 'keydown', (event) => {
     </VisuallyHidden>
     <CommandPaletteRoot
       :groups="groups"
-      :aria-label="commands.paletteSearchAriaLabel"
+      :labels="labels"
       :ui="{
         root: 'flex max-h-[min(70vh,32rem)] flex-col overflow-hidden',
         search:

--- a/src/components/commands/CommandPalette.vue
+++ b/src/components/commands/CommandPalette.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { useEventListener } from '@vueuse/core'
+import { CommandPaletteRoot, useCommandMessages } from '@open-pencil/vue'
+import { DialogDescription, DialogTitle, VisuallyHidden } from 'reka-ui'
+
+import { useAppMenu } from '@/app/shell/menu/app-menu'
+import AppDialogRoot from '@/components/ui/dialog/AppDialogRoot.vue'
+
+const { commandGroups: groups } = useAppMenu()
+const commands = useCommandMessages()
+const open = defineModel<boolean>('open', { default: false })
+
+function close() {
+  open.value = false
+}
+
+useEventListener(window, 'keydown', (event) => {
+  if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.code !== 'KeyK')
+    return
+  event.preventDefault()
+  open.value = true
+})
+</script>
+
+<template>
+  <AppDialogRoot
+    v-model:open="open"
+    size="md"
+    :ui="{
+      content: 'w-[min(40rem,94vw)] p-0',
+      overlay: 'bg-black/40'
+    }"
+    @escape-key-down="close"
+  >
+    <VisuallyHidden>
+      <DialogTitle>{{ commands.paletteAriaLabel }}</DialogTitle>
+      <DialogDescription>{{ commands.paletteDescription }}</DialogDescription>
+    </VisuallyHidden>
+    <CommandPaletteRoot
+      :groups="groups"
+      :aria-label="commands.paletteSearchAriaLabel"
+      :ui="{
+        root: 'flex max-h-[min(70vh,32rem)] flex-col overflow-hidden',
+        search:
+          'h-8 flex-1 rounded-none border-0 bg-transparent px-0 text-[13px] outline-none placeholder:text-muted',
+        content:
+          'min-h-0 max-h-[min(56vh,28rem)] overflow-y-auto px-2 pb-2 pt-1 [scrollbar-color:theme(colors.muted)_transparent]',
+        label: 'px-2 py-1 text-[11px] font-medium text-muted',
+        group: 'mb-2 last:mb-0',
+        item: 'mx-0 flex h-8 cursor-pointer items-center gap-2 rounded-md p-1 text-[13px] leading-6 text-surface outline-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-40 data-[highlighted]:bg-hover',
+        itemIcon: 'flex size-6 shrink-0 items-center justify-center text-muted',
+        itemLabel: 'min-w-0 flex-1 truncate',
+        shortcut: 'flex shrink-0 items-center gap-1 text-xs text-muted',
+        key: 'inline-flex min-w-5 items-center justify-center rounded border border-border bg-panel px-1.5 py-1 font-mono leading-none'
+      }"
+      @select="open = false"
+    >
+      <template #item-icon="{ item }">
+        <component :is="item.icon" v-if="item.icon" class="size-4" />
+      </template>
+    </CommandPaletteRoot>
+  </AppDialogRoot>
+</template>

--- a/src/components/commands/CommandPalette.vue
+++ b/src/components/commands/CommandPalette.vue
@@ -75,6 +75,11 @@ if (IS_BROWSER) {
           <X class="size-5" />
         </button>
       </template>
+      <template #empty>
+        <p class="px-4 py-8 text-center text-xs text-muted">
+          {{ commands.paletteNoCommands }}
+        </p>
+      </template>
       <template #item-icon="{ item }">
         <component :is="item.icon" v-if="item.icon" class="size-4" />
       </template>

--- a/src/components/commands/CommandPalette.vue
+++ b/src/components/commands/CommandPalette.vue
@@ -6,9 +6,11 @@ import { DialogDescription, DialogTitle, VisuallyHidden } from 'reka-ui'
 
 import { useAppMenu } from '@/app/shell/menu/app-menu'
 import AppDialogRoot from '@/components/ui/dialog/AppDialogRoot.vue'
+import { useCommandPaletteUI } from './ui'
 
 const { commandGroups: groups } = useAppMenu()
 const commands = useCommandMessages()
+const paletteUI = useCommandPaletteUI()
 const labels = computed(() => ({
   searchPlaceholder: commands.value.paletteSearchPlaceholder,
   searchLabel: commands.value.paletteSearchAriaLabel,
@@ -44,25 +46,7 @@ useEventListener(window, 'keydown', (event) => {
       <DialogTitle>{{ commands.paletteAriaLabel }}</DialogTitle>
       <DialogDescription>{{ commands.paletteDescription }}</DialogDescription>
     </VisuallyHidden>
-    <CommandPaletteRoot
-      :groups="groups"
-      :labels="labels"
-      :ui="{
-        root: 'flex max-h-[min(70vh,32rem)] flex-col overflow-hidden',
-        search:
-          'h-8 flex-1 rounded-none border-0 bg-transparent px-0 text-[13px] outline-none placeholder:text-muted',
-        content:
-          'min-h-0 max-h-[min(56vh,28rem)] overflow-y-auto px-2 pb-2 pt-1 [scrollbar-color:theme(colors.muted)_transparent]',
-        label: 'px-2 py-1 text-[11px] font-medium text-muted',
-        group: 'mb-2 last:mb-0',
-        item: 'mx-0 flex h-8 cursor-pointer items-center gap-2 rounded-md p-1 text-[13px] leading-6 text-surface outline-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-40 data-[highlighted]:bg-hover',
-        itemIcon: 'flex size-6 shrink-0 items-center justify-center text-muted',
-        itemLabel: 'min-w-0 flex-1 truncate',
-        shortcut: 'flex shrink-0 items-center gap-1 text-xs text-muted',
-        key: 'inline-flex min-w-5 items-center justify-center rounded border border-border bg-panel px-1.5 py-1 font-mono leading-none'
-      }"
-      @select="open = false"
-    >
+    <CommandPaletteRoot :groups="groups" :labels="labels" :ui="paletteUI" @select="open = false">
       <template #item-icon="{ item }">
         <component :is="item.icon" v-if="item.icon" class="size-4" />
       </template>

--- a/src/components/commands/CommandPalette.vue
+++ b/src/components/commands/CommandPalette.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useEventListener } from '@vueuse/core'
-import { CommandPaletteRoot, useCommandMessages, useCommonMessages } from '@open-pencil/vue'
+import {
+  CommandPaletteRoot,
+  shortcutPlatform,
+  useCommandMessages,
+  useCommonMessages
+} from '@open-pencil/vue'
 import { DialogDescription, DialogTitle, VisuallyHidden } from 'reka-ui'
 
 import Search from '~icons/lucide/search'
@@ -28,12 +33,17 @@ function close() {
   open.value = false
 }
 
-useEventListener(window, 'keydown', (event) => {
-  if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.code !== 'KeyK')
-    return
-  event.preventDefault()
-  open.value = true
-})
+if (typeof window !== 'undefined') {
+  const isMac = shortcutPlatform() === 'mac'
+  useEventListener(window, 'keydown', (event) => {
+    const hasPlatformModifier = isMac
+      ? event.metaKey && !event.ctrlKey
+      : event.ctrlKey && !event.metaKey
+    if (!hasPlatformModifier || event.altKey || event.shiftKey || event.code !== 'KeyK') return
+    event.preventDefault()
+    open.value = true
+  })
+}
 </script>
 
 <template>

--- a/src/components/commands/CommandPalette.vue
+++ b/src/components/commands/CommandPalette.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useEventListener } from '@vueuse/core'
-import { CommandPaletteRoot, useCommandMessages, useI18n } from '@open-pencil/vue'
+import { CommandPaletteRoot, useCommandMessages, useCommonMessages } from '@open-pencil/vue'
 import { DialogDescription, DialogTitle, VisuallyHidden } from 'reka-ui'
 
 import Search from '~icons/lucide/search'
@@ -13,7 +13,7 @@ import { useCommandPaletteUI } from './ui'
 
 const { commandGroups: groups } = useAppMenu()
 const commands = useCommandMessages()
-const { dialogs } = useI18n()
+const common = useCommonMessages()
 const paletteUI = useCommandPaletteUI()
 const labels = computed(() => ({
   searchPlaceholder: commands.value.paletteSearchPlaceholder,
@@ -58,7 +58,7 @@ useEventListener(window, 'keydown', (event) => {
         <button
           type="button"
           class="ml-2 inline-flex size-8 shrink-0 items-center justify-center rounded text-muted hover:bg-hover hover:text-surface"
-          :aria-label="dialogs.close"
+          :aria-label="common.close"
           @click="close"
         >
           <X class="size-5" />

--- a/src/components/commands/CommandPalette.vue
+++ b/src/components/commands/CommandPalette.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useEventListener } from '@vueuse/core'
-import { CommandPaletteRoot, useCommandMessages } from '@open-pencil/vue'
+import { CommandPaletteRoot, useCommandMessages, useI18n } from '@open-pencil/vue'
 import { DialogDescription, DialogTitle, VisuallyHidden } from 'reka-ui'
+
+import Search from '~icons/lucide/search'
+import X from '~icons/lucide/x'
 
 import { useAppMenu } from '@/app/shell/menu/app-menu'
 import AppDialogRoot from '@/components/ui/dialog/AppDialogRoot.vue'
@@ -10,6 +13,7 @@ import { useCommandPaletteUI } from './ui'
 
 const { commandGroups: groups } = useAppMenu()
 const commands = useCommandMessages()
+const { dialogs } = useI18n()
 const paletteUI = useCommandPaletteUI()
 const labels = computed(() => ({
   searchPlaceholder: commands.value.paletteSearchPlaceholder,
@@ -47,6 +51,19 @@ useEventListener(window, 'keydown', (event) => {
       <DialogDescription>{{ commands.paletteDescription }}</DialogDescription>
     </VisuallyHidden>
     <CommandPaletteRoot :groups="groups" :labels="labels" :ui="paletteUI" @select="open = false">
+      <template #search-leading>
+        <Search class="mx-2 size-5 shrink-0 text-muted" />
+      </template>
+      <template #search-trailing>
+        <button
+          type="button"
+          class="ml-2 inline-flex size-8 shrink-0 items-center justify-center rounded text-muted hover:bg-hover hover:text-surface"
+          :aria-label="dialogs.close"
+          @click="close"
+        >
+          <X class="size-5" />
+        </button>
+      </template>
       <template #item-icon="{ item }">
         <component :is="item.icon" v-if="item.icon" class="size-4" />
       </template>

--- a/src/components/commands/CommandPalette.vue
+++ b/src/components/commands/CommandPalette.vue
@@ -12,6 +12,7 @@ import { DialogDescription, DialogTitle, VisuallyHidden } from 'reka-ui'
 import Search from '~icons/lucide/search'
 import X from '~icons/lucide/x'
 
+import { IS_BROWSER } from '@/constants'
 import { useAppMenu } from '@/app/shell/menu/app-menu'
 import AppDialogRoot from '@/components/ui/dialog/AppDialogRoot.vue'
 import { useCommandPaletteUI } from './ui'
@@ -33,7 +34,7 @@ function close() {
   open.value = false
 }
 
-if (typeof window !== 'undefined') {
+if (IS_BROWSER) {
   const isMac = shortcutPlatform() === 'mac'
   useEventListener(window, 'keydown', (event) => {
     const hasPlatformModifier = isMac

--- a/src/components/commands/ui.ts
+++ b/src/components/commands/ui.ts
@@ -8,6 +8,7 @@ export function useCommandPaletteUI() {
   const ui = commandPalette()
   return {
     root: ui.root(),
+    searchWrapper: ui.searchWrapper(),
     search: ui.search(),
     back: ui.back(),
     content: ui.content(),

--- a/src/components/commands/ui.ts
+++ b/src/components/commands/ui.ts
@@ -1,0 +1,22 @@
+import { tv } from 'tailwind-variants'
+
+import commandPaletteTheme from '@/theme/command-palette'
+
+export const commandPalette = tv(commandPaletteTheme)
+
+export function useCommandPaletteUI() {
+  const ui = commandPalette()
+  return {
+    root: ui.root(),
+    search: ui.search(),
+    back: ui.back(),
+    content: ui.content(),
+    label: ui.label(),
+    group: ui.group(),
+    item: ui.item(),
+    itemIcon: ui.itemIcon(),
+    itemLabel: ui.itemLabel(),
+    shortcut: ui.shortcut(),
+    key: ui.key()
+  }
+}

--- a/src/theme/command-palette.ts
+++ b/src/theme/command-palette.ts
@@ -1,15 +1,15 @@
 export default {
   slots: {
-    root: 'flex max-h-[min(70vh,32rem)] flex-col overflow-hidden',
+    root: 'flex h-[min(70vh,32rem)] flex-col overflow-hidden',
     searchWrapper: 'flex h-14 shrink-0 items-center border-b border-border px-3',
     search:
       'h-8 flex-1 rounded-none border-0 bg-transparent px-0 text-[13px] outline-none placeholder:text-muted',
     back: 'px-2 pt-2 text-xs text-muted',
     content:
-      'min-h-0 max-h-[min(56vh,28rem)] overflow-y-auto px-2 pb-2 pt-1 [scrollbar-color:theme(colors.muted)_transparent]',
+      'min-h-0 flex-1 overflow-y-auto px-2 pb-2 pt-1 [scrollbar-color:theme(colors.muted)_transparent]',
     label: 'px-2 py-1 text-[11px] font-medium text-muted',
     group: 'mb-2 last:mb-0',
-    item: 'mx-0 flex h-8 cursor-pointer items-center gap-2 rounded-md p-1 text-[13px] leading-6 text-surface outline-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-40 data-[highlighted]:bg-hover',
+    item: 'mx-0 flex h-8 cursor-pointer items-center gap-2 rounded-md p-1 text-[13px] leading-6 text-surface outline-none data-[disabled]:cursor-not-allowed data-[disabled]:text-muted data-[disabled]:opacity-55 data-[highlighted]:bg-hover',
     itemIcon: 'flex size-6 shrink-0 items-center justify-center text-muted',
     itemLabel: 'min-w-0 flex-1 truncate',
     shortcut: 'flex shrink-0 items-center gap-1 text-xs text-muted',

--- a/src/theme/command-palette.ts
+++ b/src/theme/command-palette.ts
@@ -1,0 +1,17 @@
+export default {
+  slots: {
+    root: 'flex max-h-[min(70vh,32rem)] flex-col overflow-hidden',
+    search:
+      'h-8 flex-1 rounded-none border-0 bg-transparent px-0 text-[13px] outline-none placeholder:text-muted',
+    back: 'px-2 pt-2 text-xs text-muted',
+    content:
+      'min-h-0 max-h-[min(56vh,28rem)] overflow-y-auto px-2 pb-2 pt-1 [scrollbar-color:theme(colors.muted)_transparent]',
+    label: 'px-2 py-1 text-[11px] font-medium text-muted',
+    group: 'mb-2 last:mb-0',
+    item: 'mx-0 flex h-8 cursor-pointer items-center gap-2 rounded-md p-1 text-[13px] leading-6 text-surface outline-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-40 data-[highlighted]:bg-hover',
+    itemIcon: 'flex size-6 shrink-0 items-center justify-center text-muted',
+    itemLabel: 'min-w-0 flex-1 truncate',
+    shortcut: 'flex shrink-0 items-center gap-1 text-xs text-muted',
+    key: 'inline-flex min-w-5 items-center justify-center rounded border border-border bg-panel px-1.5 py-1 font-mono leading-none'
+  }
+} as const

--- a/src/theme/command-palette.ts
+++ b/src/theme/command-palette.ts
@@ -12,7 +12,7 @@ export default {
     item: 'mx-0 flex h-8 cursor-pointer items-center gap-2 rounded-md p-1 text-[13px] leading-6 text-surface outline-none data-[disabled]:cursor-not-allowed data-[disabled]:text-muted data-[disabled]:opacity-55 data-[highlighted]:bg-hover',
     itemIcon: 'flex size-6 shrink-0 items-center justify-center text-muted',
     itemLabel: 'min-w-0 flex-1 truncate',
-    shortcut: 'flex shrink-0 items-center gap-2 text-xs text-muted',
-    key: 'inline-flex min-w-7 items-center justify-center rounded-md border border-border bg-panel px-2.5 py-1.5 font-mono text-[11px] leading-none'
+    shortcut: 'flex shrink-0 items-center gap-1 text-xs text-muted',
+    key: 'inline-flex min-w-5 items-center justify-center rounded border border-border bg-panel px-1 py-0.5 font-mono text-[10px] leading-none'
   }
 } as const

--- a/src/theme/command-palette.ts
+++ b/src/theme/command-palette.ts
@@ -1,6 +1,7 @@
 export default {
   slots: {
     root: 'flex max-h-[min(70vh,32rem)] flex-col overflow-hidden',
+    searchWrapper: 'flex h-14 shrink-0 items-center border-b border-border px-3',
     search:
       'h-8 flex-1 rounded-none border-0 bg-transparent px-0 text-[13px] outline-none placeholder:text-muted',
     back: 'px-2 pt-2 text-xs text-muted',

--- a/src/theme/command-palette.ts
+++ b/src/theme/command-palette.ts
@@ -12,7 +12,7 @@ export default {
     item: 'mx-0 flex h-8 cursor-pointer items-center gap-2 rounded-md p-1 text-[13px] leading-6 text-surface outline-none data-[disabled]:cursor-not-allowed data-[disabled]:text-muted data-[disabled]:opacity-55 data-[highlighted]:bg-hover',
     itemIcon: 'flex size-6 shrink-0 items-center justify-center text-muted',
     itemLabel: 'min-w-0 flex-1 truncate',
-    shortcut: 'flex shrink-0 items-center gap-1 text-xs text-muted',
-    key: 'inline-flex min-w-5 items-center justify-center rounded border border-border bg-panel px-1.5 py-1 font-mono leading-none'
+    shortcut: 'flex shrink-0 items-center gap-2 text-xs text-muted',
+    key: 'inline-flex min-w-7 items-center justify-center rounded-md border border-border bg-panel px-2.5 py-1.5 font-mono text-[11px] leading-none'
   }
 } as const

--- a/src/views/WorkspaceView.vue
+++ b/src/views/WorkspaceView.vue
@@ -21,9 +21,10 @@ import {
 } from '@/app/tabs'
 import { isTauri } from '@/app/tauri/env'
 import FontStatusBanner from '@/components/font-status/FontStatusBanner.vue'
-import RenameSelectionDialog from '@/components/selection/RenameSelectionDialog.vue'
+import CommandPalette from '@/components/commands/CommandPalette.vue'
 import SafariBanner from '@/components/SafariBanner.vue'
 import TabBar from '@/components/TabBar.vue'
+import RenameSelectionDialog from '@/components/selection/RenameSelectionDialog.vue'
 import EditorWorkspace from '@/components/editor/EditorWorkspace.vue'
 import HomeWorkspace from '@/components/home/HomeWorkspace.vue'
 
@@ -100,6 +101,7 @@ onUnmounted(() => {
     <SafariBanner />
     <FontStatusBanner />
     <RenameSelectionDialog />
+    <CommandPalette />
     <TabBar />
     <HomeWorkspace v-show="activeTab?.kind === 'home'" @new-document="createDocumentInCurrentTab" />
     <EditorWorkspace v-if="activeTab?.kind !== 'home'" />

--- a/tests/e2e/app/command-palette.spec.ts
+++ b/tests/e2e/app/command-palette.spec.ts
@@ -2,8 +2,12 @@ import { expect, test, useEditorSetup } from '#tests/e2e/fixtures'
 
 const editor = useEditorSetup()
 
+function commandPaletteShortcut() {
+  return process.platform === 'darwin' ? 'Meta+KeyK' : 'Control+KeyK'
+}
+
 test('command palette opens, searches, and closes', async () => {
-  await editor.page.keyboard.press('Control+KeyK')
+  await editor.page.keyboard.press(commandPaletteShortcut())
 
   const palette = editor.page.getByRole('dialog', { name: 'Command palette' })
   await expect(palette).toBeVisible()
@@ -19,7 +23,7 @@ test('command palette opens, searches, and closes', async () => {
 })
 
 test('command palette exposes contextual export labels', async () => {
-  await editor.page.keyboard.press('Control+KeyK')
+  await editor.page.keyboard.press(commandPaletteShortcut())
 
   const palette = editor.page.getByRole('dialog', { name: 'Command palette' })
   await palette.getByRole('searchbox', { name: 'Search commands' }).fill('export')

--- a/tests/e2e/app/command-palette.spec.ts
+++ b/tests/e2e/app/command-palette.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test, useEditorSetup } from '#tests/e2e/fixtures'
+
+const editor = useEditorSetup()
+
+test('command palette opens, searches, and closes', async () => {
+  await editor.page.keyboard.press('Control+KeyK')
+
+  const palette = editor.page.getByRole('dialog', { name: 'Command palette' })
+  await expect(palette).toBeVisible()
+
+  const search = palette.getByRole('searchbox', { name: 'Search commands' })
+  await expect(search).toBeFocused()
+  await search.fill('zoom')
+  await expect(palette.getByRole('option', { name: /Zoom to fit/ })).toBeVisible()
+  await expect(palette.getByRole('option', { name: 'New' })).not.toBeVisible()
+
+  await editor.page.keyboard.press('Escape')
+  await expect(palette).not.toBeVisible()
+})
+
+test('command palette exposes contextual export labels', async () => {
+  await editor.page.keyboard.press('Control+KeyK')
+
+  const palette = editor.page.getByRole('dialog', { name: 'Command palette' })
+  await palette.getByRole('searchbox', { name: 'Search commands' }).fill('export')
+  await expect(palette.getByText('Export selection as PNG')).toBeVisible()
+  await expect(palette.getByText('Export selection as SVG')).toBeVisible()
+
+  await editor.page.keyboard.press('Escape')
+})

--- a/tools/i18n/mixed-script-baseline.txt
+++ b/tools/i18n/mixed-script-baseline.txt
@@ -2,7 +2,6 @@ ja:ai.apiKey
 ja:ai.apiType
 ja:ai.baseURL
 ja:ai.baseURLPlaceholder
-ja:ai.connectProvider
 ja:ai.connectionTestAPITypeMismatch
 ja:ai.connectionTestAuthFailed
 ja:ai.connectionTestBrowserNetworkFailed
@@ -12,6 +11,7 @@ ja:ai.connectionTestMissingBaseURL
 ja:ai.connectionTestMissingModel
 ja:ai.connectionTestModelNotFound
 ja:ai.connectionTestNetworkFailed
+ja:ai.connectProvider
 ja:ai.customModelID
 ja:ai.getProviderAPIKey
 ja:ai.modelID
@@ -45,6 +45,7 @@ ja:code.copyJSXReference
 ja:collaboration.clickToFollowPeer
 ja:collaboration.followingPeerStop
 ja:collaboration.pasteRoomLinkOrId
+ja:commands.paletteDescription
 ja:credentials.getAPIKey
 ja:credentials.storage
 ja:diagnostics.acpFailed
@@ -60,9 +61,9 @@ ja:editor.showUI
 ja:editor.toolOptions
 ja:files.browserFileAPINotSupported
 ja:files.clipboardImageFetchFailed
-ja:files.clipboardImageUnavailableWeb
 ja:files.clipboardImagesFetchFailed
 ja:files.clipboardImagesUnavailableWeb
+ja:files.clipboardImageUnavailableWeb
 ja:files.closeTab
 ja:files.importFailed
 ja:files.importHTMLCSS
@@ -79,8 +80,8 @@ ja:fonts.providerEnabled
 ja:fonts.webFontProvidersRequireDesktopApp
 ja:media.getPexelsAPIKey
 ja:media.getUnsplashAccessKey
-ja:media.pexelsAPIKey
 ja:media.pexelsAlternativeOptional
+ja:media.pexelsAPIKey
 ja:media.stockPhotoToolOptional
 ja:media.unsplashAccessKey
 ja:media.vectorizationDescription
@@ -89,6 +90,10 @@ ja:menu.copyAsPNG
 ja:menu.copyAsSVG
 ja:menu.copyNodeId
 ja:menu.copyXPath
+ja:menu.exportSelectionAsFig
+ja:menu.exportSelectionAsPNG
+ja:menu.exportSelectionAsPPTX
+ja:menu.exportSelectionAsSVG
 ja:menu.toggleUI
 ja:pages.pageName
 ja:panels.assetVariantSummary
@@ -128,7 +133,6 @@ zh-cn:ai.apiKey
 zh-cn:ai.apiType
 zh-cn:ai.baseURLPlaceholder
 zh-cn:ai.chatOutputLimit
-zh-cn:ai.connectProvider
 zh-cn:ai.connectionTestAPITypeMismatch
 zh-cn:ai.connectionTestAuthFailed
 zh-cn:ai.connectionTestBrowserNetworkFailed
@@ -138,6 +142,7 @@ zh-cn:ai.connectionTestMissingBaseURL
 zh-cn:ai.connectionTestMissingModel
 zh-cn:ai.connectionTestModelNotFound
 zh-cn:ai.connectionTestNetworkFailed
+zh-cn:ai.connectProvider
 zh-cn:ai.customModelID
 zh-cn:ai.getProviderAPIKey
 zh-cn:ai.maxOutputTokens
@@ -172,6 +177,7 @@ zh-cn:code.copyJSXReference
 zh-cn:collaboration.clickToFollowPeer
 zh-cn:collaboration.followingPeerStop
 zh-cn:collaboration.pasteRoomLinkOrId
+zh-cn:commands.paletteDescription
 zh-cn:credentials.getAPIKey
 zh-cn:credentials.storage
 zh-cn:diagnostics.acpFailed
@@ -203,8 +209,8 @@ zh-cn:fonts.providerDisabled
 zh-cn:fonts.providerEnabled
 zh-cn:media.getPexelsAPIKey
 zh-cn:media.getUnsplashAccessKey
-zh-cn:media.pexelsAPIKey
 zh-cn:media.pexelsAlternativeOptional
+zh-cn:media.pexelsAPIKey
 zh-cn:media.stockPhotoToolOptional
 zh-cn:media.unsplashAccessKey
 zh-cn:media.vectorizationDescription
@@ -213,6 +219,10 @@ zh-cn:menu.copyAsPNG
 zh-cn:menu.copyAsSVG
 zh-cn:menu.copyNodeId
 zh-cn:menu.copyXPath
+zh-cn:menu.exportSelectionAsFig
+zh-cn:menu.exportSelectionAsPNG
+zh-cn:menu.exportSelectionAsPPTX
+zh-cn:menu.exportSelectionAsSVG
 zh-cn:pages.pageName
 zh-cn:panels.assetVariantSummary
 zh-cn:panels.colorHintHsb


### PR DESCRIPTION
## Summary

- add a searchable command palette opened with `⌘K` on macOS and `Ctrl+K` on Windows/Linux
- add a reusable Reka Listbox-based `CommandPaletteRoot` primitive to `@open-pencil/vue`
- derive app commands from the shared menu model with localized labels, platform-aware keycaps, icons, and Fuse.js search
- add Storybook interaction coverage and Playwright app integration tests

## Validation

- `bun run check:arch`
- `bun run check:vue`
- `bun run check:i18n`
- `bun run test:dupes`
- `bun run build-storybook`
- `bunx playwright test tests/e2e/app/command-palette.spec.ts --project=openpencil`

## Notes

- `bun run test:unit` passed the relevant editor, Vue SDK, rendering, SVG, and FIG tests, then encountered existing MCP WebSocket timeout/port-contention failures before the full suite completed.
- Normal File → Export Selection submenu labels remain concise (`PNG`, `SVG`, `PPTX`, `.fig`); the command palette uses separately localized contextual labels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a searchable command palette for editor and application actions.
  * Open it with **Ctrl/Cmd+K**, search commands, navigate nested actions, and use keyboard shortcuts.
  * Added contextual export commands for PNG, SVG, PPTX, and `.fig` formats.
  * Added customizable command-palette components for Vue integrations.
* **Accessibility**
  * Added accessible labels, focus handling, empty states, and keyboard navigation.
* **Localization**
  * Added command-palette and export-menu translations across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->