### PR TITLE
docs: align contribution and review policy

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,13 +4,15 @@ early_access: false
 
 reviews:
   profile: "assertive"
-  request_changes_workflow: true
+  request_changes_workflow: false
   high_level_summary: true
   review_status: true
   auto_review:
     enabled: true
     drafts: false
   pre_merge_checks:
+    docstrings:
+      mode: "off"
     title:
       mode: "error"
       requirements: "Apply CONTRIBUTING.md → Pull requests → PR title. Request a clearer title when it is non-English, vague, placeholder-like, or does not identify the actual change."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ App dialogs compose the Reka-backed components under `src/components/ui/dialog/`
 
 - `bun run dev:portless` — preferred browser development server at `https://open-pencil.localhost`; linked worktrees use `https://<branch>.open-pencil.localhost`
 - `bun run dev` — direct Vite server at `http://localhost:1420`, used by Playwright, Tauri, and Dev Containers
-- `bun run check` — type-aware lint + typecheck via oxlint + tsgo + architecture checks (run before committing)
+- `bun run check` — complete repository quality gate: package builds, lint and type checks, architecture, docs, package/dependency/security checks, tooling tests, and duplicate detection
 - `bun run check:arch` — Steiger architecture lint for project-specific import boundaries
 - `bun run check:vue` — vue-tsc type-check for app and Vue SDK .vue files
 - `bun run test:dupes` — jscpd copy-paste detection across product TS sources
@@ -168,7 +168,7 @@ Keep this section light; implementation details move often.
 
 - Do not place code or tests ad hoc. Before adding or moving files, inspect the existing folder structure and nearby patterns, then put changes in the established domain-specific location. If no proper location exists, create one deliberately and update docs/conventions as needed.
 - Architecture boundaries are enforced by `bun run check:arch` and related lint rules; keep app/package boundaries clean instead of relying on review to catch private imports. In practice: use public workspace exports across boundaries, keep core framework-agnostic, keep app services separate from component/view layers, keep shared UI free of app stores/services, and keep property-panel internals inside the property panel.
-- Test placement is strict: app E2E in `tests/e2e/**/*.spec.ts`, Figma automation in `tests/figma/**/*.spec.ts`, engine/unit tests in `tests/engine/**/*.test.ts`, shared test utilities in `tests/helpers/**`, and standalone package tests in their package `tests/**` when established. UI-visible behavior belongs in E2E; graph/internal-state assertions belong in engine/unit tests. Do not commit temporary/profile specs.
+- Test placement is strict: app E2E in `tests/e2e/**/*.spec.ts`, Figma automation in `tests/figma/**/*.spec.ts`, engine/unit tests in `tests/engine/**/*.test.ts`, shared test utilities in `tests/helpers/**`, and standalone package tests in their package `tests/**` when established. Mirror the source domain inside the appropriate test root where practical. Tests must exercise behavior or stable contracts, not inspect source text or implementation details. UI-visible behavior belongs in E2E; graph/internal-state assertions belong in engine/unit tests. Do not commit temporary/profile specs.
 
 ### File and folder naming
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,6 @@
 ```bash
 git clone https://github.com/open-pencil/open-pencil.git
 cd open-pencil
-git clone https://github.com/open-pencil/vue-stream-markdown.git
 bun install
 ```
 
@@ -49,85 +48,54 @@ CodeRabbit may flag PR description or readability issues for maintainers to revi
 Run all of these before submitting a PR:
 
 ```bash
-bun run check        # oxlint + typecheck
+bun run check        # lint, type checks, architecture, package, duplication, and tooling checks
 bun run format       # oxfmt with import sorting
-bun run test:dupes   # jscpd < 3% duplication
-bun run test:unit    # bun:test (tests/engine/)
-bun run test         # Playwright E2E (auto-starts dev server)
+bun run test:unit    # bun:test engine/unit suite
+bun run test         # Playwright browser E2E and visual regression
 ```
 
 ## Project structure
 
-- `packages/core` — scene graph, renderer, layout, codec (zero DOM deps)
-- `packages/cli` — headless CLI for .fig inspection and export
-- `packages/mcp` — MCP server for AI tools (stdio + HTTP)
-- `packages/docs` — VitePress documentation site (openpencil.dev)
-- `src/` — Tauri/Vite desktop editor
+OpenPencil is a Bun monorepo. Stable ownership boundaries are:
+
+- `packages/scene-graph`, `pen`, `kiwi`, and `fig` — framework-neutral document models and format layers.
+- `packages/core` — renderer, layout, editor core, Figma API, tools, and app-facing document I/O.
+- `packages/dom-css` and `vue` — DOM/CSS projection and the headless Vue SDK.
+- `packages/cli`, `mcp`, and `harness` — automation and agent-facing entry points.
+- `src/app` — app services, state, and integrations; `src/components` and `src/views` — app UI and views.
+- `packages/docs` — the published VitePress site.
+
+See [`AGENTS.md`](./AGENTS.md) for canonical package ownership and architecture rules, and [Architecture](https://openpencil.dev/development/architecture) for the public overview.
+
+## Tests
+
+Place tests in the established layer and mirror the source domain where practical:
+
+- `tests/e2e/**/*.spec.ts` — browser UI and visual behavior.
+- `tests/figma/**/*.spec.ts` — Figma automation.
+- `tests/engine/**/*.test.ts` — engine and unit behavior.
+- `tests/helpers/**` — shared test utilities.
+- Package-local `tests/**` — standalone package coverage where that structure already exists.
+
+Test behavior and stable contracts, not source text or implementation details. Before adding a test file or helper, inspect nearby tests and follow their existing structure.
+
+### Test selectors
+
+Playwright tests should locate behavior the way users and assistive technology do: prefer roles and accessible names, labels, and visible text. Scope repeated controls to a named region. Multi-part components expose local `data-slot` anatomy, while stable app concepts may expose semantic attributes such as `data-property`, `data-command`, or `data-node-id`.
+
+Reserve `data-test-id` for integration boundaries that have no meaningful user-facing or domain identity. Do not add test-ID props to reusable components or generate compound IDs from component nesting.
 
 ## Conventions
 
 See [`AGENTS.md`](./AGENTS.md) for the full architecture reference, code conventions, and quality checklist. Key points:
 
-- Bun runtime, not Node
-- Tailwind 4 for styles, no inline CSS or `<style>` blocks
-- No `any`, no `!` non-null assertions
-- `@/` import alias for app code, relative imports within core
-- Use `crypto.getRandomValues()`, never `Math.random()`
-- Icons via unplugin-icons (`<icon-lucide-*>`)
-- Use existing deps and Reka UI components before hand-rolling (see AGENTS.md → Code quality)
-- Follow the Reka UI-inspired file structure: PascalCase component namespace folders and Vue files, lowercase/kebab non-component domains, and multi-file root components colocated inside their namespace folder
-- Keep UI labels translatable. Do not hardcode user-facing strings in Vue templates when an i18n namespace exists.
-- Keep shortcuts out of labels/translations. Put command shortcut tokens and keyboard bindings in `packages/vue/src/editor/commands/registry.ts`, then render them with `formatShortcut()` so macOS and Windows/Linux display correctly.
-- Canvas context-menu grouping belongs in `packages/vue/src/editor/menu-model/canvas.ts`; components should render the menu model instead of hand-building command groups.
-
-## Test IDs (`data-test-id`)
-
-Every interactive or structurally significant element must have a `data-test-id` attribute. These are used by Playwright E2E tests and must follow the naming convention below.
-
-### Naming rules
-
-- **kebab-case**, all lowercase
-- Pattern: `{component}-{element}` or `{component}-{element}-{variant}`
-- Mobile counterparts are prefixed with `mobile-`
-- Dynamic IDs use template literals: `` :data-test-id="`toolbar-tool-${key.toLowerCase()}`" ``
-
-### Nomenclature
-
-| Prefix | Component | Examples |
-|--------|-----------|---------|
-| `toolbar-` | Desktop toolbar | `toolbar`, `toolbar-tool-select`, `toolbar-flyout-frame`, `toolbar-flyout-item-ellipse` |
-| `mobile-toolbar-` | Mobile toolbar | `mobile-toolbar`, `mobile-toolbar-prev`, `mobile-toolbar-next`, `mobile-toolbar-tool-select`, `mobile-toolbar-flyout-frame`, `mobile-toolbar-copy`, `mobile-toolbar-front` |
-| `mobile-toolbar-tools` | Mobile tools category | Container for drawing tools |
-| `mobile-toolbar-edit` | Mobile edit category | Container for edit actions (copy, paste, cut, duplicate, delete) |
-| `mobile-toolbar-arrange` | Mobile arrange category | Container for arrange actions (front, back, group, ungroup, lock) |
-| `mobile-drawer-` | Mobile bottom drawer | `mobile-drawer`, `mobile-drawer-handle`, `mobile-drawer-pages`, `mobile-drawer-content`, `mobile-drawer-layers`, `mobile-drawer-design`, `mobile-drawer-code`, `mobile-drawer-ai` |
-| `mobile-ribbon-` | Mobile bottom tab bar | `mobile-ribbon`, `mobile-ribbon-layers`, `mobile-ribbon-design`, `mobile-ribbon-code`, `mobile-ribbon-ai` |
-| `layers-` | Layers panel | `layers-panel`, `layers-header`, `layers-tree`, `layers-item` |
-| `pages-` | Pages panel | `pages-panel`, `pages-header`, `pages-item`, `pages-item-input`, `pages-add` |
-| `properties-` | Properties panel | `properties-panel`, `properties-tab-design`, `properties-tab-code`, `properties-tab-ai`, `properties-zoom` |
-| `design-` | Design tab | `design-node-header`, `design-multi-header`, `design-panel-single`, `design-panel-multi`, `design-panel-empty` |
-| `position-` | Position section | `position-section`, `position-align-left`, `position-flip-horizontal`, `position-rotate-90` |
-| `layout-` | Layout section | `layout-section`, `layout-add-auto`, `layout-remove-auto`, `layout-direction-horizontal` |
-| `fill-` | Fill section | `fill-section`, `fill-section-add`, `fill-item` |
-| `stroke-` | Stroke section | `stroke-section`, `stroke-section-add`, `stroke-item` |
-| `effects-` | Effects section | `effects-section`, `effects-section-add`, `effects-item` |
-| `export-` | Export section | `export-section`, `export-section-add`, `export-button`, `export-item` |
-| `typography-` | Typography section | `typography-section`, `typography-missing-font` |
-| `variables-` | Variables | `variables-section`, `variables-dialog`, `variables-add-variable` |
-| `context-` | Context menu | `context-copy`, `context-paste`, `context-delete`, `context-group` |
-| `color-` | Color picker | `color-picker-popover`, `color-picker-swatch`, `color-hex-input` |
-| `fill-picker-` | Fill picker | `fill-picker-swatch`, `fill-picker-tab-solid`, `fill-picker-tab-gradient` |
-| `font-picker-` | Font picker | `font-picker-trigger`, `font-picker-search`, `font-picker-item` |
-| `chat-` | Chat / AI panel | `chat-panel`, `chat-input`, `chat-send-button`, `chat-messages` |
-| `code-` | Code panel | `code-panel`, `code-panel-header`, `code-panel-copy` |
-| `collab-` | Collaboration | `collab-popover`, `collab-share-button`, `collab-copy-link` |
-| `canvas-` | Canvas | `canvas-area`, `canvas-element`, `canvas-loading` |
-| `editor-` | Editor root | `editor-root`, `editor-document-name`, `editor-show-ui` |
-| `app-` | App chrome | `app-logo`, `app-document-name`, `app-toggle-ui`, `app-select-trigger` |
-| `tabbar-` | Tab bar | `tabbar-tab`, `tabbar-new`, `tabbar-close` |
-| `number-field` | Number field | `number-field`, `number-field-input` |
-| `toast-` | Toast notifications | `toast-item`, `toast-close`, `toast-copy-error` |
-| `safari-banner` | Safari warning | `safari-banner`, `safari-banner-dismiss` |
+- Bun runtime, not Node.
+- Tailwind 4 for styles; no inline CSS or component `<style>` blocks.
+- No `any` or non-null assertions; use guards and precise types.
+- Use public package exports across package boundaries.
+- Use `crypto.getRandomValues()`, never `Math.random()`.
+- Use existing dependencies and Reka UI components before hand-rolling.
+- Keep UI labels translatable and shortcuts in the shared command registry.
 
 ## Test fixtures
 
@@ -135,4 +103,4 @@ Every interactive or structurally significant element must have a `data-test-id`
 
 ## Commits
 
-Follow the existing style in `git log`. Keep messages concise. Update `CHANGELOG.md` for user-facing changes.
+Follow the commit-message conventions in [`AGENTS.md`](./AGENTS.md). Update `CHANGELOG.md` for user-facing changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,12 @@ OpenPencil is a Bun monorepo. Stable ownership boundaries are:
 
 See [`AGENTS.md`](./AGENTS.md) for canonical package ownership and architecture rules, and [Architecture](https://openpencil.dev/development/architecture) for the public overview.
 
+## Codebase fit
+
+Before adding a helper, type, component, state mechanism, parser, or test utility, inspect the owning domain, nearby implementations, existing dependencies, and tests. Reuse or extend the established mechanism; extract genuinely shared logic instead of introducing a parallel implementation.
+
+Keep package boundaries and public exports intact. Keep pull requests focused: exclude temporary or development scaffolding, unrelated refactors, and changelog claims that are not represented by the diff.
+
 ## Tests
 
 Place tests in the established layer and mirror the source domain where practical:

--- a/packages/docs/development/contributing.md
+++ b/packages/docs/development/contributing.md
@@ -18,7 +18,7 @@ bun run docs:dev     # Docs at localhost:5173
 
 ## Pull requests
 
-Follow the root PR template. Explain what changed, why it changed, and how it was validated. Remove template comments and unfinished placeholders, keep the title and body primarily in English, and complete the AI assistance section.
+Follow the root PR template. Explain what changed, why it changed, and how it was validated. Remove template comments and unfinished placeholders, keep the title in English and the body primarily in English, and complete the AI assistance section.
 
 CodeRabbit may flag description or readability issues for maintainers to review. Missing template sections or validation details are normal review feedback, not by themselves a judgment on the contributor.
 

--- a/packages/docs/development/contributing.md
+++ b/packages/docs/development/contributing.md
@@ -1,32 +1,14 @@
 # Contributing
 
-## Project Structure
+The root [`CONTRIBUTING.md`](https://github.com/open-pencil/open-pencil/blob/master/CONTRIBUTING.md) is the source of truth for setup, pull-request requirements, validation, and commit expectations. Developers and coding agents should also read [`AGENTS.md`](https://github.com/open-pencil/open-pencil/blob/master/AGENTS.md) for current package ownership and architecture rules.
 
-```
-packages/
-  core/              @open-pencil/core — engine (zero DOM deps)
-    src/             Scene graph, renderer, layout, codec, kiwi, types
-  cli/               @open-pencil/cli — headless CLI for .fig operations
-    src/commands/    info, tree, find, export, eval, analyze
-  mcp/               @open-pencil/mcp — MCP server for AI tools
-    src/             stdio + HTTP (Hono) transports, 87 tools
-src/
-  components/        Vue SFCs (canvas, panels, toolbar, color picker)
-    properties/      Property panel sections (Appearance, Fill, Stroke, etc.)
-  composables/       Canvas input, keyboard shortcuts, rendering hooks
-  stores/            Editor state (Vue reactivity)
-  engine/            Re-export shims from @open-pencil/core
-  kiwi/              Re-export shims from @open-pencil/core
-  types.ts           Shared types (re-exported from core)
-  constants.ts       UI colors, defaults, thresholds
-desktop/             Tauri v2 (Rust + config)
-tests/
-  e2e/               Playwright visual regression
-  engine/            Unit tests (bun:test)
-docs/                VitePress documentation site
-```
+## Project structure
 
-## Development Setup
+OpenPencil is a Bun monorepo: framework-neutral document and format packages feed the core editor, DOM/CSS and Vue SDK layers, automation entry points, and the Tauri/Vite app.
+
+See [Architecture](/development/architecture) for a public overview. Use root `AGENTS.md` when exact package ownership or paths matter; do not infer ownership from an older copied tree.
+
+## Development setup
 
 ```sh
 bun install
@@ -34,78 +16,45 @@ bun run dev          # Editor at localhost:1420
 bun run docs:dev     # Docs at localhost:5173
 ```
 
+## Pull requests
+
+Follow the root PR template. Explain what changed, why it changed, and how it was validated. Remove template comments and unfinished placeholders, keep the title and body primarily in English, and complete the AI assistance section.
+
+CodeRabbit may flag description or readability issues for maintainers to review. Missing template sections or validation details are normal review feedback, not by themselves a judgment on the contributor.
+
+## Validation
+
+Run the checks relevant to the change. The normal complete gate is:
+
+```sh
+bun run check
+bun run format
+bun run test:unit
+bun run test
+```
+
+Rendering and other pixel-affecting changes require targeted visual coverage. Package publishing changes require the package verification commands documented in `AGENTS.md`.
+
+## Test placement
+
+Place tests in the established layer and mirror the source domain where practical:
+
+- `tests/e2e/**/*.spec.ts` — browser UI and visual behavior.
+- `tests/figma/**/*.spec.ts` — Figma automation.
+- `tests/engine/**/*.test.ts` — engine and unit behavior.
+- `tests/helpers/**` — shared test utilities.
+- Package-local `tests/**` — standalone package coverage where already established.
+
+Test behavior and stable contracts, not source text or implementation details. Before adding a test file or helper, inspect nearby tests and follow their existing structure.
+
+### Test selectors
+
+Playwright tests should locate behavior the way users and assistive technology do: prefer roles and accessible names, labels, and visible text. Scope repeated controls to a named region. Multi-part UI components expose local `data-slot` anatomy, while stable app concepts may expose semantic attributes such as `data-property`, `data-command`, or `data-node-id`.
+
+Reserve `data-test-id` for integration boundaries that have no meaningful user-facing or domain identity. Do not add test-ID props to reusable components or generate compound IDs from component nesting.
+
 ## SDK documentation
 
 VitePress is the canonical public documentation, while Storybook is the internal component-state workshop. Shared Vue demos live beside their SDK primitives and are embedded in both surfaces. The docs Tailwind entry scans these demos, so examples use the same utility-first styling in both environments.
 
-Component API tables are extracted from Vue source and JSDoc with `vue-component-meta`. Keep descriptions next to the public props, events, and slots instead of duplicating signatures in Markdown. VitePress processes SDK code examples with Twoslash so imports and types stay aligned with the public package API.
-
-## Code Style
-
-### Tooling
-
-| Tool | Command | Purpose |
-|------|---------|---------|
-| oxlint | `bun run lint` | Linting (Rust-based, fast) |
-| oxfmt | `bun run format` | Code formatting |
-| tsgo | `bun run typecheck` | Type checking (Go-based TypeScript checker) |
-
-Run all checks:
-
-```sh
-bun run check
-```
-
-### Conventions
-
-- **File names** — kebab-case (`scene-graph.ts`, `use-canvas-input.ts`)
-- **Components** — PascalCase Vue SFCs (`EditorCanvas.vue`, `NumberField.vue`)
-- **Constants** — SCREAMING_SNAKE_CASE
-- **Functions/variables** — camelCase
-- **Types/interfaces** — PascalCase
-
-### Test selectors
-
-Playwright tests should locate behavior the way users and assistive technology do: prefer roles and
-accessible names, labels, and visible text. Scope repeated controls to a named region. Multi-part UI
-components expose local `data-slot` anatomy, while stable app concepts may expose semantic
-attributes such as `data-property`, `data-command`, or `data-node-id`.
-
-Reserve `data-test-id` for integration boundaries that have no meaningful user-facing or domain
-identity. Do not add test-ID props to reusable components or generate compound IDs from current
-component nesting.
-
-### AI Agent Conventions
-
-Developers and AI agents working on the codebase should read `AGENTS.md` in the repo root ([view on GitHub](https://github.com/open-pencil/open-pencil/blob/master/AGENTS.md)). Covers rendering, scene graph, components & instances, layout, UI, file format, Tauri conventions, and known issues.
-
-## Making Changes
-
-1. Implement the change
-2. Run `bun run check` and `bun run test`
-3. Submit a pull request
-
-## Key Files
-
-Core engine source lives in `packages/core/src/`. App-specific editor, document, AI, collaboration, shell, demo, and automation code lives under `src/app/*`; the Vue SDK owns reusable canvas/composable code under `packages/vue/src/`.
-
-| File | Purpose |
-|------|---------|
-| `packages/scene-graph/src/` | Scene graph: nodes, variables, instances, hit testing, undo |
-| `packages/core/src/canvas/renderer.ts` | CanvasKit rendering pipeline |
-| `packages/core/src/layout/` | Yoga layout adapter |
-| `packages/core/src/clipboard.ts` | Figma-compatible clipboard |
-| `packages/core/src/vector/` | Vector network model |
-| `packages/core/src/io/formats/raster/render.ts` | Offscreen image export (PNG/JPG/WEBP) |
-| `packages/kiwi/src/schema-runtime/` | Kiwi schema runtime and binary codec |
-| `packages/fig/src/node-change/` | SceneGraph and Figma NodeChange conversion policy |
-| `packages/core/src/io/formats/fig/` | App-facing .fig read/write orchestration |
-| `packages/cli/src/index.ts` | CLI entry point |
-| `packages/core/src/tools/` | Unified tool definitions split by domain (read, create, modify, structure, variables, vector, analyze) |
-| `packages/core/src/figma-api/` | Figma Plugin API implementation |
-| `packages/mcp/src/server.ts` | MCP server factory |
-| `packages/cli/src/commands/` | CLI commands (info, tree, find, export, eval, analyze) |
-| `src/app/editor/session/create.ts` | Editor session assembly |
-| `packages/vue/src/canvas/CanvasRoot.vue` | Canvas rendering composable |
-| `packages/vue/src/canvas/useCanvasInput.ts` | Mouse/touch input handling |
-| `src/app/shell/keyboard/use.ts` | Keyboard shortcut handling |
+Component API tables are extracted from Vue source and JSDoc with `vue-component-meta`. Keep descriptions next to public props, events, and slots instead of duplicating signatures in Markdown. VitePress processes SDK examples with Twoslash so imports and types stay aligned with the public package API.


### PR DESCRIPTION
### Summary

Align contributor guidance and automated review behavior with the current monorepo conventions.

### What changed

- Remove the obsolete `vue-stream-markdown` clone step and stale source-tree descriptions.
- Keep detailed package ownership canonical in `AGENTS.md` while documenting stable contributor-facing boundaries.
- Document test placement, source-domain mirroring, behavior-based assertions, and semantic Playwright selectors.
- Disable CodeRabbit's generic docstring threshold and automatic approve/request-changes workflow while retaining review and PR-hygiene feedback.

### AI assistance

Models: OpenAI Codex (GPT-5.6)

### Validation

- [x] `bun run check`
- [x] `bun run build:packages`
- [x] `bun run docs:build`
- [x] `bun run check:docs`
- [x] `bun run check:arch`
- [x] CodeRabbit configuration validated against the current schema
- [x] Tests not added because this changes documentation and review configuration only
- [x] `CHANGELOG.md` not updated because this does not change product or package behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution and development guides for the current monorepo structure and workflows.
  * Added guidance for pull requests, validation commands, test placement, repository conventions, and package publishing checks.
  * Centralized shared guidance and removed outdated project structure, tooling, and naming details.
  * Clarified the complete repository quality gate and test organization.

* **Chores**
  * Updated review automation settings to disable request-change workflows and docstring pre-merge checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->