### PR TITLE
docs: add one-click deployment option (RepoCloud and Render)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ See the [roadmap](https://openpencil.dev/development/roadmap) for product direct
 
 One-click deployment providers: 
 
-[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/open-pencil/)
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/OpenPencil/)
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https%3A%2F%2Fgithub.com%2Fopen-pencil%2Fopen-pencil)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ OpenPencil is the alternative: open source (MIT), reads .fig files natively, eve
 
 See the [roadmap](https://openpencil.dev/development/roadmap) for product direction and current Figma compatibility gaps.
 
+## Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/open-pencil/)
+
 ## Contributing
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -247,9 +247,12 @@ OpenPencil is the alternative: open source (MIT), reads .fig files natively, eve
 
 See the [roadmap](https://openpencil.dev/development/roadmap) for product direction and current Figma compatibility gaps.
 
-## Deploy
+## Deployment
+
+One-click deployment providers: 
 
 [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/open-pencil/)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https%3A%2F%2Fgithub.com%2Fopen-pencil%2Fopen-pencil)
 
 ## Contributing
 


### PR DESCRIPTION
Adds section and buttons for one-click deployment providers to the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Deployment section to the README.
  * Included one-click deployment options for RepoCloud and Render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->