### PR TITLE
fix(app): remove misleading browser font warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Stop showing a misleading desktop-only warning when web font loading or catalog lookup fails.
+
 ### Added
 
 - Add a searchable command palette for editor and application actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Fixed
-
-- Stop showing a misleading desktop-only warning when web font loading or catalog lookup fails.
-
 ### Added
 
 - Add a searchable command palette for editor and application actions.
@@ -41,6 +37,7 @@
 
 ### Fixed
 
+- Stop showing a misleading desktop-only warning when web font loading or catalog lookup fails.
 - Preserve source text offsets when resolving fallback languages after text-case transformations.
 - Track character coverage restored from downloaded font cache entries.
 

--- a/src/app/editor/fonts/index.ts
+++ b/src/app/editor/fonts/index.ts
@@ -22,7 +22,6 @@ import {
 import { isTauri } from '@/app/tauri/env'
 import { tauriFetch } from '@/app/tauri/http'
 import { IS_TAURI } from '@/constants'
-import { IS_TAURI } from '@/constants'
 
 if (typeof navigator !== 'undefined') {
   fontManager.setFallbackUserAgent(navigator.userAgent)

--- a/src/app/editor/fonts/index.ts
+++ b/src/app/editor/fonts/index.ts
@@ -12,7 +12,6 @@ import {
   type WebFontProviderId
 } from '@open-pencil/core/text'
 import type { SceneGraph } from '@open-pencil/scene-graph'
-import { fontsMessages } from '@open-pencil/vue'
 
 import { browserWebFontFetch } from '@/app/editor/fonts/browser-fetch'
 import {
@@ -20,9 +19,9 @@ import {
   createTauriDownloadedFontCache,
   downloadedFontCacheSummary as tauriDownloadedFontCacheSummary
 } from '@/app/editor/fonts/cache'
-import { toast } from '@/app/shell/ui'
 import { isTauri } from '@/app/tauri/env'
 import { tauriFetch } from '@/app/tauri/http'
+import { IS_TAURI } from '@/constants'
 import { IS_TAURI } from '@/constants'
 
 if (typeof navigator !== 'undefined') {
@@ -55,14 +54,6 @@ watch(
 )
 
 let tauriFontCacheConfigured = false
-let webFontUnavailableToastShown = false
-
-function showWebFontUnavailableToast(): void {
-  if (webFontUnavailableToastShown || isTauri() || !onlineFontsEnabled.value) return
-  if (!WEB_FONT_PROVIDER_IDS.some((provider) => fontProviderSettings.value[provider])) return
-  webFontUnavailableToastShown = true
-  toast.warning(fontsMessages.get().webFontProvidersRequireDesktopApp)
-}
 
 function configureTauriFontCache() {
   if (tauriFontCacheConfigured || !isTauri()) return
@@ -152,7 +143,6 @@ export async function listFamilies(): Promise<FontFamilyOption[]> {
       byFamily.set(font.family, { family: font.family, source: 'local' })
     return [...byFamily.values()].sort((a, b) => a.family.localeCompare(b.family))
   }
-  showWebFontUnavailableToast()
   return fontManager.listFamilyOptions()
 }
 
@@ -227,7 +217,5 @@ export async function loadFont(
   signal?: AbortSignal
 ): Promise<ArrayBuffer | null> {
   configureTauriFontCache()
-  const loaded = await fontManager.loadFont(family, style, characters, signal)
-  if (!loaded) showWebFontUnavailableToast()
-  return loaded
+  return fontManager.loadFont(family, style, characters, signal)
 }


### PR DESCRIPTION
## Summary

- Remove the misleading desktop-only warning from browser font catalog and load failures.
- Preserve the existing missing/substituted-font handling for genuine failures.

This follows the browser font loading work in #633.

## Tests

- `bun test tests/engine/app/settings/font.test.ts tests/engine/text/fonts/loading.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed misleading desktop-only warnings when web font loading fails.
  * Font catalog lookup failures no longer trigger unnecessary notifications while browsing or loading fonts.
  * Font-loading failures are handled without interrupting the experience with redundant warning messages.
  * Users can continue working with available fonts without being presented with inaccurate availability warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->