### PR TITLE
fix(fig): preserve explicit blend modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 
 ### Fixed
 
+- Preserve explicit normal blend modes on imported Figma text and vector nodes across save and reload.
+
 - Preserve implicit fixed-size text inside imported Figma auto-layout frames across save and reload.
 - Stop showing a misleading desktop-only warning when web font loading or catalog lookup fails.
 - Preserve source text offsets when resolving fallback languages after text-case transformations.

--- a/packages/fig/src/node-change/convert.ts
+++ b/packages/fig/src/node-change/convert.ts
@@ -1043,6 +1043,7 @@ export const FIGMA_RAW_NODE_FIELD_KEYS = [
   'parameterConsumptionMap',
   'editInfo',
   'backgroundColor',
+  'blendMode',
   'pageType',
   'isPageDivider',
   'guides',

--- a/tests/engine/io/fig/import/legacy/blend/mode.test.ts
+++ b/tests/engine/io/fig/import/legacy/blend/mode.test.ts
@@ -23,9 +23,11 @@ describe('fig-import: blend mode', () => {
       canvas(),
       node('TEXT', 10, 1),
       node('VECTOR', 11, 1),
-      node('FRAME', 12, 1)
+      node('FRAME', 12, 1),
+      node('RECTANGLE', 13, 1)
     ])
     expect(graph.getChildren(graph.getPages()[0].id).map((item) => item.blendMode)).toEqual([
+      'PASS_THROUGH',
       'PASS_THROUGH',
       'PASS_THROUGH',
       'PASS_THROUGH'

--- a/tests/engine/io/fig/import/legacy/blend/mode.test.ts
+++ b/tests/engine/io/fig/import/legacy/blend/mode.test.ts
@@ -17,9 +17,18 @@ describe('fig-import: blend mode', () => {
     expect(n.blendMode).toBe('MULTIPLY')
   })
 
-  test('defaults to PASS_THROUGH', () => {
-    const graph = importNodeChanges([doc(), canvas(), node('RECTANGLE', 10, 1)])
-    const n = graph.getChildren(graph.getPages()[0].id)[0]
-    expect(n.blendMode).toBe('PASS_THROUGH')
+  test('keeps omitted blend modes as PASS_THROUGH', () => {
+    const graph = importNodeChanges([
+      doc(),
+      canvas(),
+      node('TEXT', 10, 1),
+      node('VECTOR', 11, 1),
+      node('FRAME', 12, 1)
+    ])
+    expect(graph.getChildren(graph.getPages()[0].id).map((item) => item.blendMode)).toEqual([
+      'PASS_THROUGH',
+      'PASS_THROUGH',
+      'PASS_THROUGH'
+    ])
   })
 })

--- a/tests/engine/io/fig/import/raw-field-coverage.test.ts
+++ b/tests/engine/io/fig/import/raw-field-coverage.test.ts
@@ -74,6 +74,7 @@ const RAW_FIELD_COVERAGE = {
   ],
   roundTripOnly: [
     'annotationCategories',
+    'blendMode',
     'brushType',
     'codeSyntax',
     'componentPropRefs',

--- a/tests/engine/io/fig/roundtrip/basic.test.ts
+++ b/tests/engine/io/fig/roundtrip/basic.test.ts
@@ -150,6 +150,30 @@ describe('roundtrip: export → re-import', () => {
     reImportedNodes = collectAllNodes(reImported)
   })
 
+  test('preserves explicit NORMAL on imported nodes', async () => {
+    await initCodec()
+    const graph = new SceneGraph()
+    const page = graph.getPages()[0]
+    const text = graph.createNode('TEXT', page.id, {
+      name: 'Normal text',
+      source: {
+        ...page.source,
+        format: 'fig',
+        id: '1:2',
+        fig: {
+          ...page.source.fig,
+          rawNodeFields: { blendMode: 'NORMAL' }
+        }
+      }
+    })
+
+    const restored = await parseFigFile((await exportFigFile(graph)).buffer as ArrayBuffer)
+    const roundTripped = restored.getAllNodes().find((node) => node.name === text.name)
+
+    expect(roundTripped?.blendMode).toBe('NORMAL')
+    expect(roundTripped?.source.fig.rawNodeFields.blendMode).toBe('NORMAL')
+  })
+
   test('preserves page count', () => {
     expect(reImported.getPages().length).toBe(2)
   })


### PR DESCRIPTION
## Summary

- Preserve explicit imported Figma `blendMode` values in raw node metadata.
- Keep omitted blend modes on their existing pass-through default.
- Add import, raw-field coverage, and export/re-import tests for explicit `NORMAL` values.

## Validation

- `bun test tests/engine/io/fig/import/legacy/blend/mode.test.ts tests/engine/io/fig/import/raw-field-coverage.test.ts tests/engine/io/fig/roundtrip/basic.test.ts`
- `bun run build:packages`
- `bun run lint`
- `bun run test:dupes`
- `bun run check:changelog`
- Material 3 round-trip inventory: changed nodes decrease from 510 to 242; `blendMode` differences decrease from 268 to 0.

This preserves only values explicitly encoded by Figma and does not change omission defaults for newly created nodes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved explicitly set **Normal** blend modes on imported Figma text and vector nodes when saving and reloading.
  - Ensured imported text, vector, frame, and rectangle nodes without a specified blend mode default to **Pass Through**.
  - Improved blend mode round-tripping so imported node settings remain consistent after export and re-import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->