### PR TITLE
fix(fig): preserve marker-based instance text edits on export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### Fixed
 
+- Preserve edited instance text, including cleared labels, when saving and reopening `.fig` files.
 - Honor `.pen` frame layout defaults and sizing and padding shorthands so imported auto-layout frames keep their computed dimensions and child positions. (#564)
 - Avoid macOS Keychain prompts during credential status checks and pause repeated credential access after failures until explicitly retried from Settings.
 

--- a/packages/fig/src/node-change/export-node.ts
+++ b/packages/fig/src/node-change/export-node.ts
@@ -401,12 +401,15 @@ function serializeTextOverrides(
 ): KiwiSymbolOverridePayload[] {
   const result: KiwiSymbolOverridePayload[] = []
   forEachInstanceOverride(instance.instanceOverrides, (nodeId, field, value) => {
-    if (field !== 'text' || typeof value !== 'string' || !nodeId) return
+    if (field !== 'text' || !nodeId) return
     const target = context.graph.getNode(nodeId)
     if (!target || !isDescendantOf(context, nodeId, instance.id)) return
     const targetGuid = resolveOverrideTargetGuid(context, target, localIdCounter)
     if (targetGuid)
-      result.push({ guidPath: { guids: [targetGuid] }, textData: { characters: value } })
+      result.push({
+        guidPath: { guids: [targetGuid] },
+        textData: { characters: typeof value === 'string' ? value : target.text }
+      })
   })
   return result
 }

--- a/tests/engine/io/fig/instance/text-marker-roundtrip.test.ts
+++ b/tests/engine/io/fig/instance/text-marker-roundtrip.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'bun:test'
+
+import { FigmaAPI } from '@open-pencil/core'
+import { exportFigFile, parseFigFile } from '@open-pencil/core/io'
+import { initCodec } from '@open-pencil/core/kiwi'
+import { SceneGraph, getInstanceOverride } from '@open-pencil/scene-graph'
+
+for (const text of ['User edit', '']) {
+  test(`preserves API instance text edit ${JSON.stringify(text)} across save/reload`, async () => {
+    await initCodec()
+    const graph = new SceneGraph()
+    const api = new FigmaAPI(graph)
+    const component = api.createComponent()
+    const label = api.createText()
+    label.characters = 'Default'
+    component.appendChild(label)
+    const edited = component.createInstance()
+    edited.name = 'Edited'
+    const inherited = component.createInstance()
+    inherited.name = 'Inherited'
+    edited.children[0].characters = text
+    const raw = graph.getNode(edited.id)
+    if (!raw) throw new Error('Missing instance')
+    expect(
+      getInstanceOverride(raw.instanceOverrides, edited.id, edited.children[0].id, 'text')
+    ).toBe(true)
+    label.characters = 'Component edit'
+    graph.syncInstances(component.id)
+    expect(edited.children[0].characters).toBe(text)
+    expect(inherited.children[0].characters).toBe('Component edit')
+
+    const bytes = await exportFigFile(graph)
+    const restored = await parseFigFile(bytes.buffer as ArrayBuffer)
+    for (const [name, expected] of [
+      ['Edited', text],
+      ['Inherited', 'Component edit']
+    ]) {
+      const instance = [...restored.getAllNodes()].find(
+        (node) => node.type === 'INSTANCE' && node.name === name
+      )
+      if (!instance) throw new Error(`Missing ${name}`)
+      expect(restored.getChildren(instance.id)[0]?.text).toBe(expected)
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- Export live descendant text when its structured override is a protection marker; retain explicit stored strings.
- Cover edited and cleared labels through existing FigmaAPI creation, component synchronization, and save/reload APIs. No experimental interpreter dependency.

## Validation
- Both new regressions fail before the fix and pass afterward.
- 13 focused tests pass, including existing explicit-string and fill override coverage.
- `bun run check` passes.
- Imported the exported fixture into Figma and read its actual plugin API values: edited label `Edited label`, cleared label `""`, inherited label `Component edit` (component text also `Component edit`). Verified document key `jJXSVQenAi4W5rJ9iyehIT`.

Separate from the experimental occurrence interpreter in #646.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Edited instance text, including cleared labels, is now preserved when saving and reopening `.fig` files.
  - Text overrides continue to retain their correct values after component updates and file round trips.
  - Instance text remains accurate even when a component’s original label changes after an instance has been edited.
  - Empty text overrides are preserved correctly instead of being lost during save and reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->