### PR TITLE
fix(pen): honor layout and sizing defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### Fixed
 
+- Honor `.pen` frame layout defaults and sizing and padding shorthands so imported auto-layout frames keep their computed dimensions and child positions. (#564)
 - Avoid macOS Keychain prompts during credential status checks and pause repeated credential access after failures until explicitly retried from Settings.
 
 - Route browser Command/Ctrl plus and minus shortcuts to canvas zoom instead of page zoom.

--- a/packages/pen/src/convert.ts
+++ b/packages/pen/src/convert.ts
@@ -413,22 +413,56 @@ export function applyPadding(node: SceneNode, padding: PenNode['padding'], ctx?:
   node.paddingLeft = resolved
 }
 
-export function parseSize(value: number | string | undefined, fallback: number, ctx?: VarContext) {
-  if (value === undefined) return { value: fallback, sizing: 'FIXED' as LayoutSizing }
-  if (typeof value === 'number') return { value, sizing: 'FIXED' as LayoutSizing }
-  const sizing = /^(fill_container|fit_content|hug_content)(?:\(([^)]+)\))?$/.exec(value)
-  if (sizing) {
-    const fallbackValue = sizing.at(2)
-    const parsedFallback = fallbackValue === undefined ? fallback : Number(fallbackValue)
-    return {
-      value: Number.isFinite(parsedFallback) ? parsedFallback : fallback,
-      sizing: sizing[1] === 'fill_container' ? ('FILL' as LayoutSizing) : ('HUG' as LayoutSizing)
-    }
+interface ParsedSize {
+  value: number
+  sizing: LayoutSizing
+  /** Fallback used only when fit_content(N) has no children. */
+  fitContentFallback?: number
+}
+
+function parseParameterizedFallback(value: string, behavior: string): number | undefined {
+  const prefix = `${behavior}(`
+  if (!value.startsWith(prefix) || !value.endsWith(')')) return
+
+  const rawFallback = value.slice(prefix.length, -1).trim()
+  if (rawFallback === '') return
+
+  const parsedFallback = Number(rawFallback)
+  return Number.isFinite(parsedFallback) ? parsedFallback : undefined
+}
+
+function parseSizingBehavior(value: string, fallback: number): ParsedSize | undefined {
+  if (value === 'fill_container') return { value: fallback, sizing: 'FILL' }
+  if (value === 'fit_content') return { value: fallback, sizing: 'HUG' }
+
+  // Older generated .pen files used hug_content as an alias for fit_content.
+  if (value === 'hug_content') return { value: fallback, sizing: 'HUG' }
+
+  const fillFallback = parseParameterizedFallback(value, 'fill_container')
+  if (fillFallback !== undefined) return { value: fillFallback, sizing: 'FILL' }
+
+  const fitFallback =
+    parseParameterizedFallback(value, 'fit_content') ??
+    parseParameterizedFallback(value, 'hug_content')
+  if (fitFallback !== undefined) {
+    return { value: fitFallback, sizing: 'HUG', fitContentFallback: fitFallback }
   }
-  if (isVarRef(value) && ctx)
-    return { value: ctx.resolveNumber(value), sizing: 'FIXED' as LayoutSizing }
+}
+
+export function parseSize(
+  value: number | string | undefined,
+  fallback: number,
+  ctx?: VarContext
+): ParsedSize {
+  if (value === undefined) return { value: fallback, sizing: 'FIXED' }
+  if (typeof value === 'number') return { value, sizing: 'FIXED' }
+
+  const behavior = parseSizingBehavior(value, fallback)
+  if (behavior) return behavior
+
+  if (isVarRef(value) && ctx) return { value: ctx.resolveNumber(value), sizing: 'FIXED' }
   const parsed = Number(value)
-  return { value: Number.isFinite(parsed) ? parsed : fallback, sizing: 'FIXED' as LayoutSizing }
+  return { value: Number.isFinite(parsed) ? parsed : fallback, sizing: 'FIXED' }
 }
 
 export function mapLayoutMode(pen: PenNode): LayoutMode {

--- a/packages/pen/src/convert.ts
+++ b/packages/pen/src/convert.ts
@@ -66,6 +66,11 @@ interface PenFillObject {
 }
 
 type PenFill = string | PenFillObject | PenFillObject[]
+type PenSpacingValue = number | string
+type PenPadding =
+  | PenSpacingValue
+  | [PenSpacingValue, PenSpacingValue]
+  | [PenSpacingValue, PenSpacingValue, PenSpacingValue, PenSpacingValue]
 
 export interface PenNode {
   type: string
@@ -88,7 +93,7 @@ export interface PenNode {
   effect?: PenEffect | PenEffect[]
   layout?: string
   gap?: number | string
-  padding?: number | string | (number | string)[]
+  padding?: PenPadding
   justifyContent?: string
   alignItems?: string
   children?: PenNode[]
@@ -386,6 +391,15 @@ export function applyPadding(node: SceneNode, padding: PenNode['padding'], ctx?:
   const resolve = (v: number | string): number =>
     typeof v === 'string' ? (isVarRef(v) && ctx ? ctx.resolveNumber(v) : Number(v) || 0) : v
   if (Array.isArray(padding)) {
+    if (padding.length === 2) {
+      const vertical = resolve(padding[0])
+      const horizontal = resolve(padding[1])
+      node.paddingTop = vertical
+      node.paddingRight = horizontal
+      node.paddingBottom = vertical
+      node.paddingLeft = horizontal
+      return
+    }
     node.paddingTop = resolve(padding[0] ?? 0)
     node.paddingRight = resolve(padding[1] ?? 0)
     node.paddingBottom = resolve(padding[2] ?? 0)
@@ -402,8 +416,15 @@ export function applyPadding(node: SceneNode, padding: PenNode['padding'], ctx?:
 export function parseSize(value: number | string | undefined, fallback: number, ctx?: VarContext) {
   if (value === undefined) return { value: fallback, sizing: 'FIXED' as LayoutSizing }
   if (typeof value === 'number') return { value, sizing: 'FIXED' as LayoutSizing }
-  if (value === 'fill_container') return { value: fallback, sizing: 'FILL' as LayoutSizing }
-  if (value === 'hug_content') return { value: fallback, sizing: 'HUG' as LayoutSizing }
+  const sizing = /^(fill_container|fit_content|hug_content)(?:\(([^)]+)\))?$/.exec(value)
+  if (sizing) {
+    const fallbackValue = sizing.at(2)
+    const parsedFallback = fallbackValue === undefined ? fallback : Number(fallbackValue)
+    return {
+      value: Number.isFinite(parsedFallback) ? parsedFallback : fallback,
+      sizing: sizing[1] === 'fill_container' ? ('FILL' as LayoutSizing) : ('HUG' as LayoutSizing)
+    }
+  }
   if (isVarRef(value) && ctx)
     return { value: ctx.resolveNumber(value), sizing: 'FIXED' as LayoutSizing }
   const parsed = Number(value)
@@ -413,6 +434,7 @@ export function parseSize(value: number | string | undefined, fallback: number, 
 export function mapLayoutMode(pen: PenNode): LayoutMode {
   if (pen.layout === 'row' || pen.layout === 'horizontal') return 'HORIZONTAL'
   if (pen.layout === 'column' || pen.layout === 'vertical') return 'VERTICAL'
+  if (pen.type === 'frame' && pen.layout === undefined) return 'HORIZONTAL'
   return 'NONE'
 }
 

--- a/packages/pen/src/convert.ts
+++ b/packages/pen/src/convert.ts
@@ -422,10 +422,10 @@ interface ParsedSize {
 
 function parseParameterizedFallback(value: string, behavior: string): number | undefined {
   const prefix = `${behavior}(`
-  if (!value.startsWith(prefix) || !value.endsWith(')')) return
+  if (!value.startsWith(prefix) || !value.endsWith(')')) return undefined
 
   const rawFallback = value.slice(prefix.length, -1).trim()
-  if (rawFallback === '') return
+  if (rawFallback === '') return undefined
 
   const parsedFallback = Number(rawFallback)
   return Number.isFinite(parsedFallback) ? parsedFallback : undefined
@@ -447,6 +447,7 @@ function parseSizingBehavior(value: string, fallback: number): ParsedSize | unde
   if (fitFallback !== undefined) {
     return { value: fitFallback, sizing: 'HUG', fitContentFallback: fitFallback }
   }
+  return undefined
 }
 
 export function parseSize(

--- a/packages/pen/src/read.ts
+++ b/packages/pen/src/read.ts
@@ -233,6 +233,9 @@ function createSceneNode(
   const overrides = buildBaseOverrides(pen)
   overrides.width = w.value
   overrides.height = h.value
+  const hasChildren = (pen.children?.length ?? 0) > 0
+  if (!hasChildren && w.fitContentFallback !== undefined) overrides.minWidth = w.fitContentFallback
+  if (!hasChildren && h.fitContentFallback !== undefined) overrides.minHeight = h.fitContentFallback
 
   const parentLayout = graph.getNode(parentId)?.layoutMode ?? 'NONE'
   if (layout !== 'NONE') {

--- a/tests/e2e/canvas/pen-layout.spec.ts
+++ b/tests/e2e/canvas/pen-layout.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test, useEditorSetup } from '#tests/e2e/fixtures'
+
+const editor = useEditorSetup('/?test&no-chrome&no-rulers')
+
+test('lays out Pen frames whose default horizontal layout is omitted', async () => {
+  await editor.page.evaluate(() =>
+    window.openPencil?.openFile?.('/tests/fixtures/pen-layout-defaults.pen')
+  )
+  await editor.canvas.waitForInit()
+
+  const geometry = await editor.page.evaluate(() => {
+    const graph = window.openPencil?.getStore?.().graph
+    if (!graph) throw new Error('OpenPencil graph not initialized')
+    const section = graph.getNode('section')
+    const fixed = graph.getNode('fixed-child')
+    const fill = graph.getNode('fill-child')
+    if (!section || !fixed || !fill) throw new Error('Imported layout nodes are missing')
+    return {
+      section: {
+        layoutMode: section.layoutMode,
+        width: section.width,
+        height: section.height
+      },
+      fixed: { x: fixed.x, y: fixed.y, width: fixed.width, height: fixed.height },
+      fill: { x: fill.x, y: fill.y, width: fill.width, height: fill.height }
+    }
+  })
+
+  expect(geometry).toEqual({
+    section: { layoutMode: 'HORIZONTAL', width: 1440, height: 564 },
+    fixed: { x: 80, y: 72, width: 620, height: 420 },
+    fill: { x: 756, y: 72, width: 604, height: 420 }
+  })
+})

--- a/tests/engine/pen/layout.test.ts
+++ b/tests/engine/pen/layout.test.ts
@@ -76,6 +76,47 @@ describe('parsePenFile — Pen layout defaults (#564)', () => {
     })
   })
 
+  test('uses the parameterized fit-content value when a frame has no content', () => {
+    const graph = parseLayoutDocument([
+      {
+        id: 'empty',
+        type: 'frame',
+        width: 'fit_content(240)',
+        height: 'fit_content(120)'
+      }
+    ])
+
+    expect(graph.getNode('empty')).toMatchObject({
+      layoutMode: 'HORIZONTAL',
+      primaryAxisSizing: 'HUG',
+      counterAxisSizing: 'HUG',
+      width: 240,
+      height: 120,
+      minWidth: 240,
+      minHeight: 120
+    })
+  })
+
+  test('ignores the parameterized fallback when content determines the size', () => {
+    const graph = parseLayoutDocument([
+      {
+        id: 'content-frame',
+        type: 'frame',
+        width: 'fit_content(240)',
+        height: 'fit_content(120)',
+        padding: 10,
+        children: [{ id: 'content', type: 'frame', width: 20, height: 30 }]
+      }
+    ])
+
+    expect(graph.getNode('content-frame')).toMatchObject({
+      width: 40,
+      height: 50,
+      minWidth: null,
+      minHeight: null
+    })
+  })
+
   test('keeps explicit freeform frames out of auto-layout', () => {
     const graph = parseLayoutDocument([
       {
@@ -94,4 +135,19 @@ describe('parseSize — Pen sizing fallbacks (#564)', () => {
   test('preserves parameterized fill-container fallback values', () => {
     expect(parseSize('fill_container(900)', 100)).toEqual({ value: 900, sizing: 'FILL' })
   })
+
+  test('preserves parameterized fit-content fallback metadata', () => {
+    expect(parseSize('fit_content(900)', 100)).toEqual({
+      value: 900,
+      sizing: 'HUG',
+      fitContentFallback: 900
+    })
+  })
+
+  test.each(['fit_content()', 'fit_content(nope)', 'fit_content(100)garbage'])(
+    'rejects malformed sizing behavior %s',
+    (value) => {
+      expect(parseSize(value, 100)).toEqual({ value: 100, sizing: 'FIXED' })
+    }
+  )
 })

--- a/tests/engine/pen/layout.test.ts
+++ b/tests/engine/pen/layout.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test'
+
+import { computeAllLayouts } from '@open-pencil/core/layout'
+import { parsePenFile, parseSize, type PenDocument, type PenNode } from '@open-pencil/pen'
+
+function parseLayoutDocument(children: PenNode[]) {
+  const document: PenDocument = { version: '2.17', children }
+  const graph = parsePenFile(JSON.stringify(document))
+  computeAllLayouts(graph)
+  return graph
+}
+
+function fixedChild(id: string): PenNode {
+  return { id, type: 'frame', width: 620, height: 420 }
+}
+
+describe('parsePenFile — Pen layout defaults (#564)', () => {
+  test('treats an omitted frame layout as horizontal', () => {
+    const graph = parseLayoutDocument([
+      {
+        id: 'screen',
+        type: 'frame',
+        width: 1440,
+        layout: 'vertical',
+        children: [
+          {
+            id: 'section',
+            type: 'frame',
+            width: 'fill_container',
+            gap: 56,
+            padding: [72, 80],
+            alignItems: 'center',
+            children: [
+              fixedChild('fixed'),
+              {
+                id: 'fill',
+                type: 'frame',
+                width: 'fill_container',
+                height: 420
+              }
+            ]
+          }
+        ]
+      }
+    ])
+
+    expect(graph.getNode('section')).toMatchObject({
+      layoutMode: 'HORIZONTAL',
+      width: 1440,
+      height: 564,
+      paddingTop: 72,
+      paddingRight: 80,
+      paddingBottom: 72,
+      paddingLeft: 80
+    })
+    expect(graph.getNode('fixed')).toMatchObject({ x: 80, y: 72, width: 620, height: 420 })
+    expect(graph.getNode('fill')).toMatchObject({ x: 756, y: 72, width: 604, height: 420 })
+  })
+
+  test.each(['fit_content', 'fit_content(100)'])('maps %s to HUG sizing', (height) => {
+    const graph = parseLayoutDocument([
+      {
+        id: 'section',
+        type: 'frame',
+        width: 1440,
+        height,
+        layout: 'horizontal',
+        padding: [72, 80],
+        children: [fixedChild('fixed')]
+      }
+    ])
+
+    expect(graph.getNode('section')).toMatchObject({
+      counterAxisSizing: 'HUG',
+      height: 564
+    })
+  })
+
+  test('keeps explicit freeform frames out of auto-layout', () => {
+    const graph = parseLayoutDocument([
+      {
+        id: 'freeform',
+        type: 'frame',
+        layout: 'none',
+        children: [fixedChild('fixed')]
+      }
+    ])
+
+    expect(graph.getNode('freeform')?.layoutMode).toBe('NONE')
+  })
+})
+
+describe('parseSize — Pen sizing fallbacks (#564)', () => {
+  test('preserves parameterized fill-container fallback values', () => {
+    expect(parseSize('fill_container(900)', 100)).toEqual({ value: 900, sizing: 'FILL' })
+  })
+})

--- a/tests/engine/pen/var-padding.test.ts
+++ b/tests/engine/pen/var-padding.test.ts
@@ -120,6 +120,18 @@ describe('applyPadding — variable resolution (#201)', () => {
   })
 })
 
+describe('applyPadding — Pen shorthand (#564)', () => {
+  test('expands two values as vertical and horizontal pairs', () => {
+    const node = makeNode()
+    applyPadding(node, [72, 80])
+
+    expect(node.paddingTop).toBe(72)
+    expect(node.paddingRight).toBe(80)
+    expect(node.paddingBottom).toBe(72)
+    expect(node.paddingLeft).toBe(80)
+  })
+})
+
 describe('isVarRef', () => {
   test.each(['$merk-blauw', '$font-tekst', '$color.background', '$x'])(
     'recognizes %s as a variable reference',

--- a/tests/fixtures/pen-layout-defaults.pen
+++ b/tests/fixtures/pen-layout-defaults.pen
@@ -1,0 +1,41 @@
+{
+  "version": "2.17",
+  "children": [
+    {
+      "type": "frame",
+      "id": "screen",
+      "name": "Screen",
+      "width": 1440,
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "section",
+          "name": "Omitted horizontal layout",
+          "width": "fill_container",
+          "gap": 56,
+          "padding": [72, 80],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "fixed-child",
+              "name": "Fixed child",
+              "width": 620,
+              "height": 420,
+              "fill": "#3355AA"
+            },
+            {
+              "type": "frame",
+              "id": "fill-child",
+              "name": "Fill child",
+              "width": "fill_container",
+              "height": 420,
+              "fill": "#AA3355"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Summary

Fixes #564.

Pen.app omits default-valued frame properties when saving. The importer currently treats a missing frame `layout` as freeform, parses explicit `fit_content` sizing as fixed, and expands two-value padding incorrectly. Together these differences collapse imported auto-layout frames to the 100px fallback and leave their children at the origin.

Align the importer with the documented Pen defaults and shorthand semantics so the exact A/B case supplied in the issue imports with the same geometry as Pen.app.

### What changed

- Default an omitted frame `layout` to horizontal while preserving explicit vertical and freeform layouts.
- Parse `fit_content`, `hug_content`, and parameterized fit/fill sizing forms without losing their sizing mode or numeric fallback.
- Expand two-value padding as vertical and horizontal pairs.
- Add engine regressions and a browser file-open fixture that verifies the expected `1440 × 564` parent and child positions.
- Add an Unreleased changelog entry.

### AI assistance

Models: GPT-5 (OpenAI Codex).

AI assisted with investigation, implementation, tests, validation, and this PR description.

### Validation

Tested locally on macOS with Bun 1.4.0.

- [x] `bun run check` — passed, including package builds, type checks, architecture checks, tooling tests, secret scanning, and zero duplicate clones. One existing max-lines warning remains outside this change.
- [x] Tests added or updated.
- [x] `CHANGELOG.md` updated.
- [x] `bun run format` and `git diff --check`.
- [x] `bun test tests/engine/pen` — 19 passed, 0 failed.
- [x] `bun run test -- tests/e2e/canvas/pen-layout.spec.ts` — passed.
- [x] `bun run --filter @open-pencil/pen smoke:dist` — passed.

The wider suites are not green locally, and no unrelated baseline changes are included:

- `bun run test:unit`: 3,048 passed, 1 skipped, 16 failed. None of the failures involve `.pen`; they are in collaboration synchronization, AI catalog state, MCP routing, font/text measurement, and existing FIG round-trip checks. The four collaboration failures also reproduce when that file is run alone.
- The standard `bun run test` currently stops during collection because `real-llm.spec.ts` checks `OPENROUTER_API_KEY` at module load even though the command excludes the `@real-llm` tag. Running the browser suite with that file omitted reached 67 passes before being stopped after unrelated snapshot and Tauri-mock failures; the new `.pen` browser regression passed in that run as well.

No snapshots or unrelated product files are changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `.pen` imports with horizontal frame layouts when no layout mode is specified.
  * Added support for `fit_content`, `hug_content`, and `fill_container` sizing options, including fallback values.
  * Added support for two-value padding shorthand, applying values vertically and horizontally.
  * Improved sizing behavior for content-free elements using explicit fallback dimensions.

* **Documentation**
  * Documented updated `.pen` import behavior in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->