### PR TITLE
test: fix heavy unit-test measurement and round-trip checks

### DIFF
--- a/tests/engine/io/fig/roundtrip/helpers.ts
+++ b/tests/engine/io/fig/roundtrip/helpers.ts
@@ -97,7 +97,11 @@ function sameNodeReferences(
     a.length === b.length &&
     a.every((value, index) => {
       const other = b[index]
-      return other !== undefined && sameNodeReference(ctx, value, other)
+      return (
+        other !== undefined &&
+        (sameNodeReference(ctx, value, other) ||
+          (!ctx.aGraph.getNode(value) && !ctx.bGraph.getNode(other) && value === other))
+      )
     })
   )
 }
@@ -400,6 +404,7 @@ export const RAW_VERIFIERS = new Map<string, Verifier>([
       return true
     }
   ],
+  ['textAlignHorizontal', defaultEqual('LEFT')],
   ['borderRightWeight', defaultEqual(0)],
   ['borderLeftWeight', defaultEqual(0)],
   ['borderTopWeight', defaultEqual(0)],

--- a/tests/engine/io/fig/roundtrip/verifiers.test.ts
+++ b/tests/engine/io/fig/roundtrip/verifiers.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from 'bun:test'
+
+import { SceneGraph } from '@open-pencil/scene-graph'
+
+import { RAW_VERIFIERS, SCENE_VERIFIERS, type VerifierContext } from './helpers'
+
+function context(a: unknown, b: unknown, generation = 0): VerifierContext {
+  return {
+    a,
+    b,
+    generation,
+    key: '',
+    path: '',
+    label: 'verifier regression',
+    aGraph: new SceneGraph(),
+    bGraph: new SceneGraph(),
+    aNodes: new Map(),
+    bNodes: new Map(),
+    aNodePaths: new Map(),
+    bNodePaths: new Map(),
+    aComponentPropertyDefinitions: new Map(),
+    bComponentPropertyDefinitions: new Map(),
+    errors: [],
+    fixture: {
+      file: '',
+      fileSize: 0,
+      nodeCount: 0,
+      nodeTypes: {},
+      schemaSize: 0,
+      thumbnailSize: 0,
+      thumbnailWidth: 0,
+      thumbnailHeight: 0,
+      imageCount: 0,
+      figKiwiVersion: 0,
+      g1ExportSize: 0,
+      g2ExportSize: 0
+    }
+  }
+}
+
+test('alignment normalization accepts only default LEFT on the first round trip', () => {
+  const verify = RAW_VERIFIERS.get('textAlignHorizontal')
+  expect(verify).toBeDefined()
+  expect(verify?.(context(undefined, 'LEFT'))).toBe(true)
+  expect(verify?.(context(undefined, 'RIGHT'))).toBe(false)
+  expect(verify?.(context(undefined, 'LEFT', 1))).toBe(false)
+  expect(verify?.(context('LEFT', 'LEFT', 1))).toBe(true)
+})
+
+test('preferred component keys must remain identical while local IDs follow node paths', () => {
+  const definition = {
+    id: 'property',
+    name: 'Avatar',
+    type: 'INSTANCE_SWAP',
+    defaultValue: 'old',
+    preferredValues: ['external-key']
+  }
+  const other = { ...definition, defaultValue: 'new', preferredValues: ['external-key'] }
+  const ctx = context([definition], [other])
+  ctx.aNodePaths = new Map([['old', '0/0']])
+  ctx.bNodePaths = new Map([['new', '0/0']])
+  const verify = SCENE_VERIFIERS.get('componentPropertyDefinitions')
+  expect(verify).toBeDefined()
+  expect(verify?.(ctx)).toBe(true)
+  other.preferredValues = ['different-key']
+  expect(verify?.(ctx)).toBe(false)
+  definition.preferredValues = ['old']
+  other.preferredValues = ['new']
+  expect(verify?.(ctx)).toBe(true)
+  ctx.bNodePaths = new Map([['new', '0/1']])
+  expect(verify?.(ctx)).toBe(false)
+})

--- a/tests/engine/layout/auto-layout/text/measurement.test.ts
+++ b/tests/engine/layout/auto-layout/text/measurement.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
 import { computeAllLayouts, SceneGraph, setTextMeasurer } from '@open-pencil/core'
-
-import { createEditorStore } from '@/app/editor/session'
+import { createEditor } from '@open-pencil/core/editor'
 
 import { getNodeOrThrow } from '#tests/helpers/assert'
 import { autoFrame, loadFixtureGraph, pageId, rect } from '#tests/helpers/layout'
@@ -132,7 +131,7 @@ describe('text measurement', () => {
     { timeout: HEAVY_TEST_TIMEOUT_MS },
     async () => {
       const graph = await loadFixtureGraph('gold-preview.fig')
-      const store = createEditorStore(graph)
+      const store = createEditor({ graph, skipInitialGraphSetup: true })
       const title = [...store.graph.getAllNodes()].find(
         (node) => node.type === 'TEXT' && node.text === "World's largest"
       )


### PR DESCRIPTION
### Summary

Fix the four remaining heavy unit-test failures investigated after #653. This changes tests only; no production behavior, fixtures, snapshots, or test exclusions change.

### What changed

- Exercise imported-text measurement through the core editor. The app session waits for a rendered-frame acknowledgment that a headless layout test cannot provide.
- Compare unchanged external preferred-component keys as keys rather than requiring them to resolve to local graph nodes. Local node references continue to compare by graph path.
- Accept absent/default `LEFT` text alignment on the first FIG round trip using the existing default-equivalence policy. Second-round-trip comparison remains exact.
- Add negative verifier regressions for changed external keys, mismatched local paths, non-default alignment, and second-generation drift.

### AI assistance

Models: OpenAI coding assistant; exact model identifier unavailable.

### Validation

- [x] `bun run check` passes.
- [x] Targeted measurement, exhaustive round-trip, and verifier tests: 35 passed.
- [x] Complete `bun run test:unit`: 3,079 passed, 1 platform-specific skip, 0 failed.
- [x] Changed files formatted; `git diff --check` passes.
- [x] CHANGELOG.md not needed: test-only corrections.

Browser E2E and Figma application round-trip validation were not rerun: production import/export and rendering code are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded regression coverage for document round-tripping, including text alignment defaults and component property comparisons.
  * Improved validation of unchanged values and references during import/export checks.
  * Updated layout measurement tests to use the current editor initialization flow, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->