### PR TITLE
fix(ui): keep button labels on one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### Fixed
 
+- Keep button labels on one line when controls are constrained by surrounding layouts.
 - Resolve `$name` references in imported `.pen` fills, stroke fills, font families, dimensions, and spacing without requiring a `--` prefix. (#563)
 - Prevent the stock photo tool from replacing text, lines, structural layers, or containers with content while supporting closed shape geometry.
 - Preserve explicit text alignment metadata on imported Figma vectors across save and reload.

--- a/src/app.css
+++ b/src/app.css
@@ -129,6 +129,12 @@ body {
   -webkit-user-select: none;
 }
 
+@layer base {
+  button {
+    white-space: nowrap;
+  }
+}
+
 input[type='number'] {
   appearance: textfield;
   -moz-appearance: textfield;

--- a/tests/e2e/ui/theme.spec.ts
+++ b/tests/e2e/ui/theme.spec.ts
@@ -43,3 +43,17 @@ test('rulers follow the active theme', async () => {
   })
   await page.waitForFunction(() => document.documentElement.dataset.theme === 'dark')
 })
+
+test('button labels stay on one line when space is constrained', async () => {
+  const whiteSpace = await editor.page.evaluate(() => {
+    const button = document.createElement('button')
+    button.textContent = '两字'
+    button.style.width = '1px'
+    document.body.append(button)
+    const value = getComputedStyle(button).whiteSpace
+    button.remove()
+    return value
+  })
+
+  expect(whiteSpace).toBe('nowrap')
+})


### PR DESCRIPTION
## Summary

- prevent button labels from wrapping when surrounding layouts constrain their width
- keep the default in Tailwind’s base layer so an explicit whitespace utility can override it
- cover constrained CJK labels with a browser regression test and document the fix

## Testing

- `bun run format`
- `bun run build:packages`
- system Chrome computed-style assertion (`nowrap` by default, `normal` with an explicit override)
- `bun run check` (all completed checks passed; `check:audit` was blocked by the configured npm mirror returning 404, and `test:tools` was blocked by oxlint fixture subprocesses exiting without JSON)
- `bun run test:dupes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Button labels now remain on a single line when controls have limited horizontal space.

* **Tests**
  * Added coverage to verify button text does not wrap under constrained layouts.

* **Documentation**
  * Updated the unreleased changelog with this fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->