### PR TITLE
fix: load fonts with request in desktop app cause OOMs (replaced with fetch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 ### Fixed
 
+- load fonts with request in desktop app cause OOMs (replaced with fetch)
+
 - Preserve edited instance text, including cleared labels, when saving and reopening `.fig` files.
 - Honor `.pen` frame layout defaults and sizing and padding shorthands so imported auto-layout frames keep their computed dimensions and child positions. (#564)
 - Avoid macOS Keychain prompts during credential status checks and pause repeated credential access after failures until explicitly retried from Settings.

--- a/src/app/tauri/http.ts
+++ b/src/app/tauri/http.ts
@@ -1,4 +1,3 @@
-import type { FetchFunction } from '@/app/http/types'
 
 export interface ProxyHttpHeader {
   name: string
@@ -74,9 +73,6 @@ export interface TauriFetchOptions {
   maxResponseBytes?: number
 }
 
-export function createTauriFetch(options: TauriFetchOptions = {}): FetchFunction {
-  return (input, init) => tauriFetch(input, init, options.maxResponseBytes, options.timeoutMs)
-}
 
 export async function tauriFetch(
   input: RequestInfo | URL,
@@ -84,15 +80,29 @@ export async function tauriFetch(
   maxResponseBytes?: number,
   timeoutMs?: number
 ): Promise<Response> {
+  const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+
+  if (url.startsWith('http://ipc.localhost') || url.startsWith('https://ipc.localhost') || url.startsWith('ipc://')) {
+    return fetch(input as RequestInfo, init);
+  }
+
   const request = new Request(input, init)
   request.signal.throwIfAborted()
   const { invoke } = await import('@tauri-apps/api/core')
   request.signal.throwIfAborted()
+
+  let bodyData: Uint8Array | undefined = undefined
+  if (request.body != null) {
+    const buffer = await request.arrayBuffer()
+    request.signal.throwIfAborted()
+    bodyData = new Uint8Array(buffer)
+  }
+
   const payload: ProxyHttpRequest = {
     url: request.url,
     method: request.method,
     headers: headersToProxyHeaders(request.headers),
-    body: request.body == null ? undefined : [...new Uint8Array(await request.arrayBuffer())],
+    body: bodyData ? Array.from(bodyData) : undefined,
     max_response_bytes: maxResponseBytes,
     follow_redirects: request.redirect === 'follow',
     timeout_ms: timeoutMs

--- a/tests/engine/tauri/http.test.ts
+++ b/tests/engine/tauri/http.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 
 import {
-  createTauriFetch,
   tauriFetch,
   type ProxyHttpRequest,
   type ProxyHttpResponse
@@ -54,12 +53,6 @@ describe('tauriFetch', () => {
         headers: [{ name: 'x-open-pencil', value: 'ok' }],
         body: [...new TextEncoder().encode('OK')]
       }
-    })
-
-    const response = await createTauriFetch({ timeoutMs: 15_000 })('https://example.test/check', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: '{"ok":true}'
     })
 
     if (!captured) throw new Error('Expected proxy_http_request to be invoked')


### PR DESCRIPTION
### Summary

loading fonts with fetch instead of request because it cause memory leak leading webview failed as video show and add if condition for checking if buffer aborted before converting buffer to unit8array
Related to #674; the larger-font-library enumeration case remains open. 
### What changed

- load fonts with fetch instead of request
- checking buffer before converting it to unit8array
- remove `createTauriFetch` there is no use for it just in test file
### AI assistance

deepwiki used for tracing functions and understanding the flow of data

Models: deepwiki, GLM5.3

|before|after|
|----------|----------|
| https://github.com/user-attachments/assets/ad47bf82-7121-4768-813e-9fe2a3dffae7 | https://github.com/user-attachments/assets/768cc993-3666-406a-8b69-8a5fcbf7c1c7 |

### Validation

- [x] `bun run check`
- [x] Tests updated because: remove `createTauriFetch` test unit
- [x] CHANGELOG.md updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Fixed recursive desktop proxy requests that could occur when font downloads intercepted internal app traffic.
- Improved routing for internal desktop requests to use the appropriate native network path.
- Improved cancellation handling during desktop network operations.

## Documentation

- Added an unreleased changelog entry documenting the desktop font-loading fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->